### PR TITLE
FEAT: certificate based authenticate Key Vault client

### DIFF
--- a/docs/auth/azure-key-vault.md
+++ b/docs/auth/azure-key-vault.md
@@ -30,4 +30,16 @@ var vaultConfiguration = new KeyVaultConfiguration(keyVaultUri);
 var keyVaultSecretProvider = new KeyVaultSecretProvider(vaultAuthenticator, vaultConfiguration);
 ```
 
+### Certificate Based
+Authentication via client ID and certificate is supported with the `CertifidateBasedAuthentication`.
+
+```csharp
+var clientId = Configuration.GetValue<string>("Arcus:ServicePrincipal:ClientId");
+X509Certificate2 certificate = ...
+
+var vaultAuthenticator = new CertificateBasedAuthentication(clientId, certificate);
+var vaultConfiguration = new KeyVaultConfiguration(keyVaultUri);
+var keyVaultSecretProvider = new KeyVaultSecretProvider(vaultAuthenticator, vaultConfiguration);
+```
+
 [&larr; back](/)

--- a/docs/auth/azure-key-vault.md
+++ b/docs/auth/azure-key-vault.md
@@ -30,7 +30,7 @@ var vaultConfiguration = new KeyVaultConfiguration(keyVaultUri);
 var keyVaultSecretProvider = new KeyVaultSecretProvider(vaultAuthenticator, vaultConfiguration);
 ```
 
-### Certificate Based
+### Certificate
 Authentication via client ID and certificate is supported with the `CertifidateBasedAuthentication`.
 
 ```csharp

--- a/src/Arcus.Security.Providers.AzureKeyVault/Authentication/CertificateBasedAuthentication.cs
+++ b/src/Arcus.Security.Providers.AzureKeyVault/Authentication/CertificateBasedAuthentication.cs
@@ -13,20 +13,20 @@ namespace Arcus.Security.Providers.AzureKeyVault.Authentication
     /// </summary>
     public class CertificateBasedAuthentication : IKeyVaultAuthentication
     {
-        private readonly string _applicationId;
+        private readonly string _clientId;
         private readonly X509Certificate2 _certificate;
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="CertificateBasedAuthentication"/> class.
+        ///     Initializes a new instance of the <see cref="CertificateBasedAuthentication"/> class.
         /// </summary>
-        /// <param name="applicationId">The identifier of the application requesting the authentication token.</param>
+        /// <param name="clientId">The identifier of the application requesting the authentication token.</param>
         /// <param name="certificate">The certificate that is used as credential.</param>
-        public CertificateBasedAuthentication(string applicationId, X509Certificate2 certificate)
+        public CertificateBasedAuthentication(string clientId, X509Certificate2 certificate)
         {
-            Guard.NotNull(applicationId, nameof(applicationId));
+            Guard.NotNull(clientId, nameof(clientId));
             Guard.NotNull(certificate, nameof(certificate));
 
-            _applicationId = applicationId;
+            _clientId = clientId;
             _certificate = certificate;
         }
 
@@ -43,7 +43,7 @@ namespace Arcus.Security.Providers.AzureKeyVault.Authentication
         private async Task<string> AuthenticationCallback(string authority, string resource, string scope)
         {
             var authenticationContext = new AuthenticationContext(authority);
-            var clientAssertionCertificate = new ClientAssertionCertificate(_applicationId, _certificate);
+            var clientAssertionCertificate = new ClientAssertionCertificate(_clientId, _certificate);
 
             AuthenticationResult result = await authenticationContext.AcquireTokenAsync(resource, clientAssertionCertificate);
             return result.AccessToken;

--- a/src/Arcus.Security.Providers.AzureKeyVault/Authentication/CertificateBasedAuthentication.cs
+++ b/src/Arcus.Security.Providers.AzureKeyVault/Authentication/CertificateBasedAuthentication.cs
@@ -36,16 +36,17 @@ namespace Arcus.Security.Providers.AzureKeyVault.Authentication
         /// <returns>A <see cref="IKeyVaultClient" /> client to use for interaction with the vault</returns>
         public Task<IKeyVaultClient> Authenticate()
         {
-            IKeyVaultClient client = new KeyVaultClient((async (authority, resource, scope) =>
-            {
-                var authenticationContext = new AuthenticationContext(authority);
-                var clientAssertionCertificate = new ClientAssertionCertificate(_applicationId, _certificate);
-                
-                AuthenticationResult result = await authenticationContext.AcquireTokenAsync(resource, clientAssertionCertificate);
-                return result.AccessToken;
-            }));
-
+            IKeyVaultClient client = new KeyVaultClient(AuthenticationCallback);
             return Task.FromResult(client);
+        }
+
+        private async Task<string> AuthenticationCallback(string authority, string resource, string scope)
+        {
+            var authenticationContext = new AuthenticationContext(authority);
+            var clientAssertionCertificate = new ClientAssertionCertificate(_applicationId, _certificate);
+
+            AuthenticationResult result = await authenticationContext.AcquireTokenAsync(resource, clientAssertionCertificate);
+            return result.AccessToken;
         }
     }
 }

--- a/src/Arcus.Security.Providers.AzureKeyVault/Authentication/CertificateBasedAuthentication.cs
+++ b/src/Arcus.Security.Providers.AzureKeyVault/Authentication/CertificateBasedAuthentication.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using System.Security.Cryptography.X509Certificates;
+using System.Threading.Tasks;
+using Arcus.Security.Providers.AzureKeyVault.Authentication.Interfaces;
+using GuardNet;
+using Microsoft.Azure.KeyVault;
+using Microsoft.IdentityModel.Clients.ActiveDirectory;
+
+namespace Arcus.Security.Providers.AzureKeyVault.Authentication
+{
+    /// <summary>
+    ///     Azure Key Vault <see cref="IKeyVaultAuthentication"/> by using client ID and certificate to authenticate the <see cref="IKeyVaultClient"/>.
+    /// </summary>
+    public class CertificateBasedAuthentication : IKeyVaultAuthentication
+    {
+        private readonly string _applicationId;
+        private readonly X509Certificate2 _certificate;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CertificateBasedAuthentication"/> class.
+        /// </summary>
+        /// <param name="applicationId">The identifier of the application requesting the authentication token.</param>
+        /// <param name="certificate">The certificate that is used as credential.</param>
+        public CertificateBasedAuthentication(string applicationId, X509Certificate2 certificate)
+        {
+            Guard.NotNull(applicationId, nameof(applicationId));
+            Guard.NotNull(certificate, nameof(certificate));
+
+            _applicationId = applicationId;
+            _certificate = certificate;
+        }
+
+        /// <summary>
+        ///     Authenticates with Azure Key Vault
+        /// </summary>
+        /// <returns>A <see cref="IKeyVaultClient" /> client to use for interaction with the vault</returns>
+        public Task<IKeyVaultClient> Authenticate()
+        {
+            IKeyVaultClient client = new KeyVaultClient((async (authority, resource, scope) =>
+            {
+                var authenticationContext = new AuthenticationContext(authority);
+                var clientAssertionCertificate = new ClientAssertionCertificate(_applicationId, _certificate);
+                
+                AuthenticationResult result = await authenticationContext.AcquireTokenAsync(resource, clientAssertionCertificate);
+                return result.AccessToken;
+            }));
+
+            return Task.FromResult(client);
+        }
+    }
+}

--- a/src/Arcus.Security.Tests.Unit/KeyVault/Authentication/CertificateBasedAuthenticationTests.cs
+++ b/src/Arcus.Security.Tests.Unit/KeyVault/Authentication/CertificateBasedAuthenticationTests.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Security.Cryptography.X509Certificates;
+using Arcus.Security.Providers.AzureKeyVault.Authentication;
+using Xunit;
+
+namespace Arcus.Security.Tests.Unit.KeyVault.Authentication
+{
+    public class CertificateBasedAuthenticationTests
+    {
+        [Fact]
+        public void Authentication_Without_ClientId_Fails_With_ArgumentNullException()
+        {
+            // Act / Assert
+            Assert.Throws<ArgumentNullException>(
+                () => new CertificateBasedAuthentication(applicationId: null, certificate: new X509Certificate2(rawData: new byte[0])))
+        }
+
+        [Fact]
+        public void Authentication_Without_Certificate_Fails_With_ArgumentNullException()
+        {
+            // Act / Assert
+            Assert.Throws<ArgumentNullException>(
+                () => new CertificateBasedAuthentication(applicationId: $"app-{Guid.NewGuid()}", certificate: null));
+        }
+
+        [Fact]
+        public void Authentication_With_ClientId_And_Certificate_Succeeds()
+        {
+            // Act
+            var authentication = new CertificateBasedAuthentication(
+                applicationId: $"app-{Guid.NewGuid()}", 
+                certificate: new X509Certificate2(rawData: new byte[0]));
+
+            // Assert
+            Assert.NotNull(authentication);
+        }
+    }
+}

--- a/src/Arcus.Security.Tests.Unit/KeyVault/Authentication/CertificateBasedAuthenticationTests.cs
+++ b/src/Arcus.Security.Tests.Unit/KeyVault/Authentication/CertificateBasedAuthenticationTests.cs
@@ -12,7 +12,7 @@ namespace Arcus.Security.Tests.Unit.KeyVault.Authentication
         {
             // Act / Assert
             Assert.Throws<ArgumentNullException>(
-                () => new CertificateBasedAuthentication(applicationId: null, certificate: new X509Certificate2(rawData: new byte[0])));
+                () => new CertificateBasedAuthentication(clientId: null, certificate: new X509Certificate2(rawData: new byte[0])));
         }
 
         [Fact]
@@ -20,7 +20,7 @@ namespace Arcus.Security.Tests.Unit.KeyVault.Authentication
         {
             // Act / Assert
             Assert.Throws<ArgumentNullException>(
-                () => new CertificateBasedAuthentication(applicationId: $"app-{Guid.NewGuid()}", certificate: null));
+                () => new CertificateBasedAuthentication(clientId: $"app-{Guid.NewGuid()}", certificate: null));
         }
 
         [Fact]
@@ -28,7 +28,7 @@ namespace Arcus.Security.Tests.Unit.KeyVault.Authentication
         {
             // Act
             var authentication = new CertificateBasedAuthentication(
-                applicationId: $"app-{Guid.NewGuid()}", 
+                clientId: $"app-{Guid.NewGuid()}", 
                 certificate: new X509Certificate2(rawData: new byte[0]));
 
             // Assert

--- a/src/Arcus.Security.Tests.Unit/KeyVault/Authentication/CertificateBasedAuthenticationTests.cs
+++ b/src/Arcus.Security.Tests.Unit/KeyVault/Authentication/CertificateBasedAuthenticationTests.cs
@@ -12,7 +12,7 @@ namespace Arcus.Security.Tests.Unit.KeyVault.Authentication
         {
             // Act / Assert
             Assert.Throws<ArgumentNullException>(
-                () => new CertificateBasedAuthentication(applicationId: null, certificate: new X509Certificate2(rawData: new byte[0])))
+                () => new CertificateBasedAuthentication(applicationId: null, certificate: new X509Certificate2(rawData: new byte[0])));
         }
 
         [Fact]


### PR DESCRIPTION
Besides client-id/client-secret; we should also provide a way to
authenticate the Key Vault client with client-id/certificate.

 #10