### PR TITLE
FIX: remove manual variable in MyGet release

### DIFF
--- a/build/myget-release.yml
+++ b/build/myget-release.yml
@@ -11,6 +11,7 @@ variables:
     value: '2.2.105'
   - name: 'Project'
     value: 'Arcus.Security'
+  # 'Package.Version.ManualTrigger' is added as queue-time variable on build in Azure DevOps
 
 stages:
   - stage: Build

--- a/build/myget-release.yml
+++ b/build/myget-release.yml
@@ -11,8 +11,6 @@ variables:
     value: '2.2.105'
   - name: 'Project'
     value: 'Arcus.Security'
-  - name: 'Package.Version.ManualTrigger'
-    value: preview
 
 stages:
   - stage: Build


### PR DESCRIPTION
When we remove this variable in the variables block in the YAML file, we can set the variable at queue-time.

Relates to #63 