### PR TITLE
Use nuget/publish-preview-package.yml instead of old version

### DIFF
--- a/build/ci-build.yml
+++ b/build/ci-build.yml
@@ -120,4 +120,4 @@ stages:
             inputs:
               artifact: 'Build'
               path: '$(Build.SourcesDirectory)'
-          - template: build/nuget/publish-preview-package.yml@templates
+          - template: nuget/publish-preview-package.yml@templates


### PR DESCRIPTION
Use nuget/publish-preview-package.yml instead of build/nuget/publish-preview-package.yml

Relates to https://github.com/arcus-azure/azure-devops-templates/pull/12