### PR TITLE
Use fluent approach in example when adding KeyVault ConfigProvider

### DIFF
--- a/docs/features/key-vault/extensions/iconfiguration-integration.md
+++ b/docs/features/key-vault/extensions/iconfiguration-integration.md
@@ -43,7 +43,7 @@ IKeyVaultConfiguration vaultConfiguration = new KeyVaultConfiguration(keyVaultUr
 ISecretProvider yourSecretProvider = new KeyVaultSecretProvider(vaultAuthentication, vaultConfiguration);
 
 var config = new ConfigurationBuilder()
-    .AddAzureKeyVault(new CachedSecretProvider(yourSecretProvider))
+    .AddAzureKeyVault(yourSecretProvider.WithCaching())
     .Build();
 
 var host = new WebHostBuilder()


### PR DESCRIPTION
To make it more obvious that there exists a more fluent way to use the caching capabilities, I've modified the documentation on how to integrate the arcus KeyVault Provider with the ASP.NET configuration.