### PR TITLE
Fixup - UserSecrets should return `null` secret value

### DIFF
--- a/src/Arcus.Security.Providers.UserSecrets/UserSecretsSecretProvider.cs
+++ b/src/Arcus.Security.Providers.UserSecrets/UserSecretsSecretProvider.cs
@@ -37,7 +37,7 @@ namespace Arcus.Security.Providers.UserSecrets
                 return Task.FromResult(value);
             }
 
-            return null;
+            return Task.FromResult<string>(null);
         }
 
         /// <summary>


### PR DESCRIPTION
The User Secrets secret provider should return `null` as secret value and not `null` as `Task`.
FYI: this has not impact when this is used in the secret store approach bc we test for this, but if the provider is used directly, it may cause problems.