### PR TITLE
Feature - add guards against Azure Key Vault component formats

### DIFF
--- a/src/Arcus.Security.Providers.AzureKeyVault/Configuration/KeyVaultConfiguration.cs
+++ b/src/Arcus.Security.Providers.AzureKeyVault/Configuration/KeyVaultConfiguration.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Text.RegularExpressions;
 using GuardNet;
 
 namespace Arcus.Security.Providers.AzureKeyVault.Configuration
@@ -8,6 +9,10 @@ namespace Arcus.Security.Providers.AzureKeyVault.Configuration
     /// </summary>
     public class KeyVaultConfiguration : IKeyVaultConfiguration
     {
+        private const string VaultUriPattern = "^https:\\/\\/[0-9a-zA-Z\\-]{3,24}\\.vault.azure.net(\\/)?$";
+
+        private readonly Regex _vaultUriRegex = new Regex(VaultUriPattern, RegexOptions.Compiled);
+
         /// <summary>
         ///     The Uri of the Azure Key Vault you want to connect to.
         /// </summary>
@@ -26,6 +31,9 @@ namespace Arcus.Security.Providers.AzureKeyVault.Configuration
             Guard.For<UriFormatException>(
                 () => vaultUri.Scheme != Uri.UriSchemeHttps,
                 "Requires the vault URI to have a 'https' scheme");
+            Guard.For<UriFormatException>(
+                () => !_vaultUriRegex.IsMatch(vaultUri.ToString()),
+                "Requires the Azure Key Vault host to be in the right format, see https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#objects-identifiers-and-versioning");
 
             VaultUri = vaultUri;
         }

--- a/src/Arcus.Security.Tests.Integration/KeyVault/KeyVaultSecretProviderTests.cs
+++ b/src/Arcus.Security.Tests.Integration/KeyVault/KeyVaultSecretProviderTests.cs
@@ -52,7 +52,7 @@ namespace Arcus.Security.Tests.Integration.KeyVault
             string applicationId = Configuration.GetValue<string>("Arcus:ServicePrincipal:ApplicationId");
             var clientKey = Configuration.GetValue<string>("Arcus:ServicePrincipal:AccessKey");
             var keyVaultUri = Configuration.GetValue<string>("Arcus:KeyVault:Uri");
-            var notExistingKeyName = $"secret-{Guid.NewGuid().ToString("N").Substring(0, 120)}";
+            var notExistingKeyName = $"secret-{Guid.NewGuid():N}";
 
             var keyVaultSecretProvider = new KeyVaultSecretProvider(
                 authentication: new ServicePrincipalAuthentication(applicationId, clientKey), 
@@ -92,7 +92,7 @@ namespace Arcus.Security.Tests.Integration.KeyVault
             // Arrange
             var keyVaultUri = Configuration.GetValue<string>("Arcus:KeyVault:Uri");
             var connectionString = Configuration.GetValue<string>("Arcus:MSI:AzureServicesAuth:ConnectionString");
-            var notExistingKeyName = $"secret-{Guid.NewGuid().ToString("N").Substring(0, 120)}";
+            var notExistingKeyName = $"secret-{Guid.NewGuid():N}";
             var keyVaultSecretProvider = new KeyVaultSecretProvider(
                 authentication: new ManagedServiceIdentityAuthentication(connectionString: connectionString),
                 vaultConfiguration: new KeyVaultConfiguration(keyVaultUri));
@@ -134,7 +134,7 @@ namespace Arcus.Security.Tests.Integration.KeyVault
             // Arrange
             var keyVaultUri = Configuration.GetValue<string>("Arcus:KeyVault:Uri");
             var connectionString = Configuration.GetValue<string>("Arcus:MSI:AzureServicesAuth:ConnectionString");
-            var notExistingKeyName = $"secret-{Guid.NewGuid().ToString("N").Substring(0, 120)}";
+            var notExistingKeyName = $"secret-{Guid.NewGuid():N}";
             var keyVaultSecretProvider = new KeyVaultSecretProvider(
                 authentication: new ManagedServiceIdentityAuthentication(),
                 vaultConfiguration: new KeyVaultConfiguration(keyVaultUri));

--- a/src/Arcus.Security.Tests.Integration/KeyVault/KeyVaultSecretProviderTests.cs
+++ b/src/Arcus.Security.Tests.Integration/KeyVault/KeyVaultSecretProviderTests.cs
@@ -52,7 +52,7 @@ namespace Arcus.Security.Tests.Integration.KeyVault
             string applicationId = Configuration.GetValue<string>("Arcus:ServicePrincipal:ApplicationId");
             var clientKey = Configuration.GetValue<string>("Arcus:ServicePrincipal:AccessKey");
             var keyVaultUri = Configuration.GetValue<string>("Arcus:KeyVault:Uri");
-            var notExistingKeyName = Guid.NewGuid().ToString("N");
+            var notExistingKeyName = $"secret-{Guid.NewGuid().ToString("N").Substring(0, 120)}";
 
             var keyVaultSecretProvider = new KeyVaultSecretProvider(
                 authentication: new ServicePrincipalAuthentication(applicationId, clientKey), 
@@ -92,7 +92,7 @@ namespace Arcus.Security.Tests.Integration.KeyVault
             // Arrange
             var keyVaultUri = Configuration.GetValue<string>("Arcus:KeyVault:Uri");
             var connectionString = Configuration.GetValue<string>("Arcus:MSI:AzureServicesAuth:ConnectionString");
-            var notExistingKeyName = Guid.NewGuid().ToString("N");
+            var notExistingKeyName = $"secret-{Guid.NewGuid().ToString("N").Substring(0, 120)}";
             var keyVaultSecretProvider = new KeyVaultSecretProvider(
                 authentication: new ManagedServiceIdentityAuthentication(connectionString: connectionString),
                 vaultConfiguration: new KeyVaultConfiguration(keyVaultUri));
@@ -134,7 +134,7 @@ namespace Arcus.Security.Tests.Integration.KeyVault
             // Arrange
             var keyVaultUri = Configuration.GetValue<string>("Arcus:KeyVault:Uri");
             var connectionString = Configuration.GetValue<string>("Arcus:MSI:AzureServicesAuth:ConnectionString");
-            var notExistingKeyName = Guid.NewGuid().ToString("N");
+            var notExistingKeyName = $"secret-{Guid.NewGuid().ToString("N").Substring(0, 120)}";
             var keyVaultSecretProvider = new KeyVaultSecretProvider(
                 authentication: new ManagedServiceIdentityAuthentication(),
                 vaultConfiguration: new KeyVaultConfiguration(keyVaultUri));

--- a/src/Arcus.Security.Tests.Unit/KeyVault/Configuration/KeyVaultConfigurationTests.cs
+++ b/src/Arcus.Security.Tests.Unit/KeyVault/Configuration/KeyVaultConfigurationTests.cs
@@ -7,10 +7,17 @@ namespace Arcus.Security.Tests.Unit.KeyVault.Configuration
     public class KeyVaultConfigurationTests
     {
         [Fact]
+        public void Constructor_UriWithoutVaultSuffix_Fails()
+        {
+            Assert.ThrowsAny<UriFormatException>(
+                () => new KeyVaultConfiguration("https://something-without-azure-vault-suffix"));
+        }
+
+        [Fact]
         public void Constructor_ValidRawUri_Succeeds()
         {
             // Arrange
-            string vaultUri = $"https://{Guid.NewGuid():N}.vault.azure.net/";
+            string vaultUri = $"https://{Guid.NewGuid().ToString("N").Substring(0, 24)}.vault.azure.net/";
             var expectedVaultUri = new Uri(vaultUri);
 
             // Act
@@ -25,7 +32,7 @@ namespace Arcus.Security.Tests.Unit.KeyVault.Configuration
         public void Constructor_ValidUri_Succeeds()
         {
             // Arrange
-            var expectedVaultUri = new Uri($"https://{Guid.NewGuid():N}.vault.azure.net/");
+            var expectedVaultUri = new Uri($"https://{Guid.NewGuid().ToString("N").Substring(0, 24)}.vault.azure.net/");
 
             // Act
             var keyVaultConfiguration = new KeyVaultConfiguration(expectedVaultUri);


### PR DESCRIPTION
The Azure Key Vault name and secret names can be checked on their format before we send out HTTP requests and (maybe) get some obscure return exception message.
These guards help with that and is by itself an extra safety check for malicious input.

See https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#objects-identifiers-and-versioning