### PR TITLE
Docs - add HashiCorp Vault link to index page

### DIFF
--- a/docs/preview/index.md
+++ b/docs/preview/index.md
@@ -24,6 +24,7 @@ PM > Install-Package Arcus.Security.Providers.AzureKeyVault
     - [Azure Key Vault](features/secret-store/provider/key-vault)
     - [Configuration](features/secret-store/provider/configuration)
     - [Environment variables](features/secret-store/provider/environment-variables)
+    - [HashiCorp Vault](features/secret-store/provider/hashicorp-vault)
     - [User Secrets](features/secret-store/provider/user-secrets)
   - [Creating your own secret provider](features/secret-store/create-new-secret-provider)
 - **Interacting with Secrets**


### PR DESCRIPTION
Provide link to root index page to the HashiCorp Vault secret provider.

Closes #159 