### PR TITLE
Feature - add secret providers to secret store w/ dependent services

### DIFF
--- a/docs/preview/features/secret-store/create-new-secret-provider.md
+++ b/docs/preview/features/secret-store/create-new-secret-provider.md
@@ -98,6 +98,26 @@ This section describes how a new secret store source can be added to the pipelin
    }
    ```
 
+### Adding dependency services to your secret provider
+
+When your secret provider requires additional services, configured in the dependency container, you can choose to pick an method overload that provides access to the `IServiceProvider`:
+
+The example below shows how an `ILogger` instance is passed to the secret provider.
+
+```csharp
+public static class SecretStoreBuilderExtensions
+{
+    public static SecretStoreBuilder AddRegistry(this SecretStoreBuilder builder)
+    {
+        return builder.AddProvider((IServiceProvider serviceProvider) =>
+        {
+            var logger = serviceProvider.GetRequiredService<ILogger<RegistrySecretProvider>>();
+            return new RegistrySecretProvider(logger);
+        });
+    }
+}
+```
+
 ### Adding caching to your secret provider
 
 When your secret provider requires caching, you can wrap the provider in a `CachedSecretProvider` at registration:

--- a/docs/preview/features/secret-store/index.md
+++ b/docs/preview/features/secret-store/index.md
@@ -21,7 +21,7 @@ Several built in secret providers available in the package.
 And several additional providers in seperate packages.
 
 * [Azure Key Vault](./../../features/secret-store/provider/key-vault)
-* [HashiCorp](./../../features/secret-store/hashicorp-vault)
+* [HashiCorp](./../../features/secret-store//provider/hashicorp-vault)
 * [User Secrets](./../../features/secret-store/provider/user-secrets)
 
 If you require an additional secret providers that aren't available here, please [this document](./../../features/secret-store/create-new-secret-provider) that describes how you can create your own secret provider.

--- a/src/Arcus.Security.Core/SecretStoreSource.cs
+++ b/src/Arcus.Security.Core/SecretStoreSource.cs
@@ -27,6 +27,8 @@ namespace Arcus.Security.Core
             Func<IServiceProvider, ISecretProvider> createSecretProvider, 
             Func<string, string> mutateSecretName = null)
         {
+            Guard.NotNull(createSecretProvider, nameof(createSecretProvider), "Requires a function to create an secret provider instance to register it in the secret store");
+            
             _createSecretProvider = createSecretProvider;
 
             MutateSecretName = mutateSecretName;

--- a/src/Arcus.Security.Core/SecretStoreSource.cs
+++ b/src/Arcus.Security.Core/SecretStoreSource.cs
@@ -54,7 +54,6 @@ namespace Arcus.Security.Core
             MutateSecretName = mutateSecretName;
         }
 
-
         /// <summary>
         /// Gets the provider for this secret store.
         /// </summary>

--- a/src/Arcus.Security.Tests.Unit/Core/IHostBuilderExtensionsTests.cs
+++ b/src/Arcus.Security.Tests.Unit/Core/IHostBuilderExtensionsTests.cs
@@ -22,7 +22,8 @@ namespace Arcus.Security.Tests.Unit.Core
             builder.ConfigureSecretStore((config, stores) => stores.AddProvider(serviceProvider => null));
 
             // Assert
-            Assert.Throws<InvalidOperationException>(() => builder.Build());
+            IHost host = builder.Build();
+            Assert.Throws<InvalidOperationException>(() => host.Services.GetService<ISecretProvider>());
         }
 
         [Fact]
@@ -38,7 +39,8 @@ namespace Arcus.Security.Tests.Unit.Core
             });
 
             // Assert
-            Assert.Throws<TestClassException>(() => builder.Build());
+            IHost host = builder.Build();
+            Assert.Throws<TestClassException>(() => host.Services.GetService<ISecretProvider>());
         }
 
         [Fact]

--- a/src/Arcus.Security.Tests.Unit/Core/IHostBuilderExtensionsTests.cs
+++ b/src/Arcus.Security.Tests.Unit/Core/IHostBuilderExtensionsTests.cs
@@ -6,11 +6,41 @@ using Arcus.Security.Tests.Unit.Core.Stubs;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Xunit;
+using Xunit.Sdk;
 
 namespace Arcus.Security.Tests.Unit.Core
 {
     public class IHostBuilderExtensionsTests
     {
+        [Fact]
+        public void ConfigureSecretStore_WithoutFoundLazySecretProvider_ThrowsException()
+        {
+            // Arrange
+            var builder = new HostBuilder();
+
+            // Act
+            builder.ConfigureSecretStore((config, stores) => stores.AddProvider(serviceProvider => null));
+
+            // Assert
+            Assert.Throws<InvalidOperationException>(() => builder.Build());
+        }
+
+        [Fact]
+        public void ConfigureSecretStore_WithFailedLazySecretProviderCreation_ThrowsException()
+        {
+            // Arrange
+            var builder = new HostBuilder();
+
+            // Act
+            builder.ConfigureSecretStore((config, stores) =>
+            {
+                stores.AddProvider(serviceProvider => throw new TestClassException("Some failure"));
+            });
+
+            // Assert
+            Assert.Throws<TestClassException>(() => builder.Build());
+        }
+
         [Fact]
         public async Task ConfigureSecretStore_WithoutSecretProviders_ThrowsException()
         {
@@ -58,6 +88,26 @@ namespace Arcus.Security.Tests.Unit.Core
             IHost host = builder.Build();
             var provider = host.Services.GetRequiredService<ICachedSecretProvider>();
             await Assert.ThrowsAsync<SecretNotFoundException>(() => provider.InvalidateSecretAsync(secretKey));
+        }
+
+        [Fact]
+        public async Task ConfigureSecretStore_WithFoundLazyCachedSecretProvider_UsesLazyRegisteredSecretProvider()
+        {
+            // Arrange
+            string expected = $"secret-{Guid.NewGuid()}";
+            var stubProvider = new TestSecretProviderStub(expected);
+
+            var builder = new HostBuilder();
+
+            // Act
+            builder.ConfigureSecretStore((config, stores) => stores.AddProvider(serviceProvider => stubProvider));
+
+            // Assert
+            IHost host = builder.Build();
+            var provider = host.Services.GetRequiredService<ICachedSecretProvider>();
+            string actual = await provider.GetRawSecretAsync("ignored-key");
+            Assert.Equal(expected, actual);
+            Assert.Equal(1, stubProvider.CallsMadeSinceCreation);
         }
 
         [Fact]
@@ -114,6 +164,39 @@ namespace Arcus.Security.Tests.Unit.Core
         }
 
         [Fact]
+        public async Task ConfigureSecretStore_AddMultipleLazySecretProviders_UsesAllSecretProviders()
+        {
+            // Arrange
+            string secretKey1 = "MySecret1";
+            string secretValue1 = $"secret-{Guid.NewGuid()}";
+            var stubProvider1 = new InMemorySecretProvider((secretKey1, secretValue1));
+
+            string secretKey2 = "MySecret2";
+            string secretValue2 = $"secret-{Guid.NewGuid()}";
+            var stubProvider2 = new InMemorySecretProvider((secretKey2, secretValue2));
+
+            string secretKey3 = "MySecret3";
+            string secretValue3 = $"secret-{Guid.NewGuid()}";
+            var stubProvider3 = new InMemorySecretProvider((secretKey3, secretValue3));
+
+            var builder = new HostBuilder();
+
+            // Act
+            builder.ConfigureSecretStore((context, config, stores) =>
+            {
+                stores.AddProvider(stubProvider1);
+                stores.AddProvider(serviceProvider => stubProvider2);
+            }).ConfigureSecretStore((config, stores) => stores.AddProvider(serviceProvider => stubProvider3));
+
+            // Assert
+            IHost host = builder.Build();
+            var provider = host.Services.GetRequiredService<ISecretProvider>();
+            Assert.Equal(secretValue1, await provider.GetRawSecretAsync(secretKey1));
+            Assert.Equal(secretValue2, await provider.GetRawSecretAsync(secretKey2));
+            Assert.Equal(secretValue3, await provider.GetRawSecretAsync(secretKey3));
+        }
+
+        [Fact]
         public async Task ConfigureSecretStore_WithoutCachingProviderWithMutation_DoesntFindCachedProvider()
         {
             // Arrange
@@ -151,6 +234,48 @@ namespace Arcus.Security.Tests.Unit.Core
             IHost host = builder.Build();
             var cachedSecretProvider = host.Services.GetRequiredService<ICachedSecretProvider>();
             Secret secret = await cachedSecretProvider.GetSecretAsync("KeyVault.Secret", ignoreCache: false);
+            Assert.Equal(expected, secret.Value);
+        }
+
+        [Fact]
+        public async Task ConfigureSecretStore_WithLazySecretProviderWithMutation_DoesntFindCachedProvider()
+        {
+            // Arrange
+            var stubProvider = new InMemorySecretProvider(("Arcus.KeyVault.Secret", Guid.NewGuid().ToString()));
+            var builder = new HostBuilder();
+
+            // Act
+            builder.ConfigureSecretStore((config, stores) =>
+            {
+                stores.AddProvider(serviceProvider => stubProvider, secretName => "Arcus." + secretName);
+            });
+
+            // Assert
+            IHost host = builder.Build();
+            var cachedSecretProvider = host.Services.GetRequiredService<ICachedSecretProvider>();
+            await Assert.ThrowsAsync<SecretNotFoundException>(
+                () => cachedSecretProvider.GetSecretAsync("KeyVault.Secret", ignoreCache: false));
+        }
+
+        [Fact]
+        public async Task ConfigureSecretStore_WithLazyCachedSecretProvider_FindsInvalidateSecret()
+        {
+            // Arrange
+            var secretKey = "Arcus.KeyVault.Secret";
+            var expected = Guid.NewGuid().ToString();
+            var stubProvider = new InMemoryCachedSecretProvider((secretKey, expected));
+            var builder = new HostBuilder();
+
+            // Act
+            builder.ConfigureSecretStore((config, stores) =>
+            {
+                stores.AddProvider(serviceProvider => stubProvider);
+            });
+
+            // Assert
+            IHost host = builder.Build();
+            var cachedSecretProvider = host.Services.GetRequiredService<ICachedSecretProvider>();
+            Secret secret = await cachedSecretProvider.GetSecretAsync(secretKey, ignoreCache: false);
             Assert.Equal(expected, secret.Value);
         }
     }

--- a/src/Arcus.Security.Tests.Unit/Core/SecretStoreBuilderTests.cs
+++ b/src/Arcus.Security.Tests.Unit/Core/SecretStoreBuilderTests.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Xunit;
+
+namespace Arcus.Security.Tests.Unit.Core
+{
+    public class SecretStoreBuilderTests
+    {
+        [Fact]
+        public void AddProvider_WithoutSecretProvider_Throws()
+        {
+            // Arrange
+            var services = new ServiceCollection();
+            var builder = new SecretStoreBuilder(services);
+
+            // Act / Assert
+            Assert.ThrowsAny<ArgumentException>(() => builder.AddProvider(secretProvider: null));
+        }
+
+        [Fact]
+        public void AddProviderFunction_WithoutFunction_Throws()
+        {
+            // Arrange
+            var services = new ServiceCollection();
+            var builder = new SecretStoreBuilder(services);
+
+            // Act / Assert
+            Assert.ThrowsAny<ArgumentException>(() => builder.AddProvider(createSecretProvider: null));
+        }
+    }
+}


### PR DESCRIPTION
Provides an `SecretStoreBuilder.AddProvider` method overload that takes in the `IServiceProvider` so additional dependent services can be included when creating an `ISecretProvider`.
A good example is logging. With this change, we can now provide an `ILogger` instance to each `ISecretProvider` and consumers can also benefit from this when implementing their own provider.

- Added method overload
- Updated the `SecretStoreSource` to accompany this change (with backwards compatibility in mind, so chosen for a mutable approach)
- Updated secret store builder registration so the `IServiceProvider` gets send allong the needed registrations
- Added unit tests that also verify if caching and secret name mutation is combinable with this approach (which it does 😃 ). 
- Updated (preview) feature docs on creating your own secret provider