### PR TITLE
Feature - add secret name mutation to HashiCorp Vault secret store builder extensions

### DIFF
--- a/docs/preview/features/secret-store/provider/hashicorp-vault.md
+++ b/docs/preview/features/secret-store/provider/hashicorp-vault.md
@@ -55,6 +55,10 @@ public class Program
                         // Mount point of KeyValue secret engine (default: kv-v2).
                         builder.AddHashiCorpVaultWithUserPass(..., keyValueMountPoint: "secret");
 
+                        // Adding the HashiCorp Vault secret provider with UserPass authentication, using `-` instead of `:` when looking up secrets.
+                        // Example - When looking up `Foo:Bar` it will be changed to `Foo-Bar`.
+                        builder.AddHashiCorpVaultWithUserPass(..., mutateSecretName: secretName => secretName.Replace(":", "-"));
+
                         // Kubernetes authentication built-in overload:
                         // --------------------------------------------
                         builder.AddHashiCorpVaultWithKubernetes(
@@ -77,6 +81,10 @@ public class Program
                         // Mount point of KeyValue secret engine (default: kv-v2).
                         builder.AddHashiCorpVaultWithKubernetes(..., keyValueMountPoint: "secret");
 
+                        // Adding the HashiCorp Vault secret provider with Kubernetes authentication, using `-` instead of `:` when looking up secrets.
+                        // Example - When looking up `Foo:Bar` it will be changed to `Foo-Bar`.
+                        builder.AddHashiCorpVaultWithKubernetes(..., mutateSecretName: secretName => secretName.Replace(":", "-"));
+
                         // Custom settings overload for when using the [VaultSharp](https://github.com/rajanadar/VaultSharp) settings directly:
                         // --------------------------------------------------------------------------------------------------------------------
                         var tokenAuthentication = new TokenAuthMethodInfo("token");
@@ -91,6 +99,10 @@ public class Program
 
                         // Mount point of KeyValue secret engine (default: kv-v2).
                         builder.AddHashiCorpVault(..., keyValueMountPoint: "secret");
+
+                        // Adding the HashiCorp Vault secret provider, using `-` instead of `:` when looking up secrets.
+                        // Example - When looking up `Foo:Bar` it will be changed to `Foo-Bar`.
+                        builder.AddHashiCorpVault(..., mutateSecretName: secretName => secretName.Replace(":", "-"));
                     })
                     .ConfigureWebHostDefaults(webBuilder => webBuilder.UseStartup<Startup>());
     }

--- a/docs/preview/features/secret-store/provider/key-vault.md
+++ b/docs/preview/features/secret-store/provider/key-vault.md
@@ -49,7 +49,7 @@ public class Program
                         var cacheConfiguration = new CacheConfiguration(TimeSpan.FromMinutes(1));
                         builder.AddAzureKeyVaultWithManagedServiceIdentity(keyVaultUri, cacheConfiguration);
 
-                        // Adding the Azure Key Vault secret provider, using `.` instead of `:` when looking up secrets.
+                        // Adding the Azure Key Vault secret provider, using `-` instead of `:` when looking up secrets.
                         // Example - When looking up `ServicePrincipal:ClientKey` it will be changed to `ServicePrincipal-ClientKey`.
                         builder.AddAzureKeyVaultWithManagedServiceIdentity(keyVaultUri, mutateSecretName: secretName => secretName.Replace(":", "-"));
                     })

--- a/src/Arcus.Security.Providers.HashiCorp/Extensions/SecretStoreBuilderExtensions.cs
+++ b/src/Arcus.Security.Providers.HashiCorp/Extensions/SecretStoreBuilderExtensions.cs
@@ -31,6 +31,7 @@ namespace Arcus.Security.Providers.HashiCorp.Extensions
         /// <param name="keyValueVersion">The client API version to use when interacting with the KeyValue secret engine.</param>
         /// <param name="keyValueMountPoint">The point where HashiCorp Vault KeyValue secret engine is mounted (default: kv-v2).</param>
         /// <param name="userPassMountPoint">The point where the HashiCorp Vault UserPass authentication is mounted (default: userpass).</param>
+        /// <param name="mutateSecretName">The function to mutate the secret name before looking it up.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="builder"/> or <paramref name="secretPath"/> is <c>null</c>.</exception>
         /// <exception cref="ArgumentException">
         ///     Thrown when the <paramref name="vaultServerUriWithPort"/> is blank or doesn't represent a valid URI,
@@ -48,7 +49,8 @@ namespace Arcus.Security.Providers.HashiCorp.Extensions
             string secretPath,
             VaultKeyValueSecretEngineVersion keyValueVersion = VaultKeyValueSecretEngineVersion.V2,
             string keyValueMountPoint = SecretsEngineDefaultPaths.KeyValueV2,
-            string userPassMountPoint = AuthMethodDefaultPaths.UserPass)
+            string userPassMountPoint = AuthMethodDefaultPaths.UserPass,
+            Func<string, string> mutateSecretName = null)
         {
             Guard.NotNull(builder, nameof(builder), "Requires a secret store builder to add the HashiCorp Vault secret provider");
             Guard.NotNullOrWhitespace(vaultServerUriWithPort, nameof(vaultServerUriWithPort));
@@ -61,7 +63,7 @@ namespace Arcus.Security.Providers.HashiCorp.Extensions
             IAuthMethodInfo authenticationMethod = new UserPassAuthMethodInfo(userPassMountPoint, username, password);
             var settings = new VaultClientSettings(vaultServerUriWithPort, authenticationMethod);
 
-            return AddHashiCorpVault(builder, settings, secretPath, keyValueVersion, keyValueMountPoint);
+            return AddHashiCorpVault(builder, settings, secretPath, keyValueVersion, keyValueMountPoint, mutateSecretName);
         }
 
         /// <summary>
@@ -84,6 +86,7 @@ namespace Arcus.Security.Providers.HashiCorp.Extensions
         /// <param name="keyValueVersion">The client API version to use when interacting with the KeyValue secret engine.</param>
         /// <param name="keyValueMountPoint">The point where HashiCorp Vault KeyVault secret engine is mounted.</param>
         /// <param name="kubernetesMountPoint">The point where the HashiCorp Vault Kubernetes authentication is mounted.</param>
+        /// <param name="mutateSecretName">The function to mutate the secret name before looking it up.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="builder"/>.</exception>
         /// <exception cref="ArgumentException">
         ///     Thrown when the <paramref name="vaultServerUriWithPort"/> is blank or doesn't represent a valid URI,
@@ -101,7 +104,8 @@ namespace Arcus.Security.Providers.HashiCorp.Extensions
             string secretPath,
             VaultKeyValueSecretEngineVersion keyValueVersion = VaultKeyValueSecretEngineVersion.V2,
             string keyValueMountPoint = SecretsEngineDefaultPaths.KeyValueV2,
-            string kubernetesMountPoint = AuthMethodDefaultPaths.Kubernetes)
+            string kubernetesMountPoint = AuthMethodDefaultPaths.Kubernetes,
+            Func<string, string> mutateSecretName = null)
         {
             Guard.NotNull(builder, nameof(builder), "Requires a secret store builder to add the HashiCorp Vault secret provider");
             Guard.NotNullOrWhitespace(vaultServerUriWithPort, nameof(vaultServerUriWithPort), "Requires a valid HashiCorp Vault URI with HTTP port to connect to the running HashiCorp Vault");
@@ -115,7 +119,7 @@ namespace Arcus.Security.Providers.HashiCorp.Extensions
             IAuthMethodInfo authenticationMethod = new KubernetesAuthMethodInfo(kubernetesMountPoint, roleName, jsonWebToken);
             var settings = new VaultClientSettings(vaultServerUriWithPort, authenticationMethod);
 
-            return AddHashiCorpVault(builder, settings, secretPath, keyValueVersion, keyValueMountPoint);
+            return AddHashiCorpVault(builder, settings, secretPath, keyValueVersion, keyValueMountPoint, mutateSecretName);
         }
 
         /// <summary>
@@ -131,6 +135,7 @@ namespace Arcus.Security.Providers.HashiCorp.Extensions
         /// <param name="secretPath">The secret path where the secret provider should look for secrets.</param>
         /// <param name="keyValueVersion">The client API version to use when interacting with the KeyValue secret engine.</param>
         /// <param name="keyValueMountPoint">The point where HashiCorp Vault KeyVault secret engine is mounted.</param>
+        /// <param name="mutateSecretName">The function to mutate the secret name before looking it up.</param>
         /// <exception cref="ArgumentNullException">
         ///     Thrown when the <paramref name="builder"/>, <paramref name="settings"/> or <paramref name="secretPath"/> is <c>null</c>.
         /// </exception>
@@ -145,7 +150,8 @@ namespace Arcus.Security.Providers.HashiCorp.Extensions
             VaultClientSettings settings,
             string secretPath,
             VaultKeyValueSecretEngineVersion keyValueVersion = VaultKeyValueSecretEngineVersion.V2,
-            string keyValueMountPoint = SecretsEngineDefaultPaths.KeyValueV2)
+            string keyValueMountPoint = SecretsEngineDefaultPaths.KeyValueV2,
+            Func<string, string> mutateSecretName = null)
         {
             Guard.NotNull(builder, nameof(builder), "Requires a secret store builder to add the HashiCorp Vault secret provider");
             Guard.NotNull(settings, nameof(settings), "Requires HashiCorp Vault settings to correctly connect to the running HashiCorp Vault");
@@ -157,7 +163,7 @@ namespace Arcus.Security.Providers.HashiCorp.Extensions
             Guard.NotNullOrWhitespace(keyValueMountPoint, nameof(keyValueMountPoint), "Requires a point where the KeyVault secret engine is mounted");
 
             var provider = new HashiCorpSecretProvider(settings, keyValueVersion, keyValueMountPoint, secretPath);
-            return builder.AddProvider(provider);
+            return builder.AddProvider(provider, mutateSecretName);
         }
     }
 }

--- a/src/Arcus.Security.Providers.HashiCorp/HashiCorpSecretProvider.cs
+++ b/src/Arcus.Security.Providers.HashiCorp/HashiCorpSecretProvider.cs
@@ -109,7 +109,7 @@ namespace Arcus.Security.Providers.HashiCorp
                     return secretV2.Data;
                 
                 default:
-                    throw new ArgumentOutOfRangeException(nameof(_secretEngineVersion), _secretEngineVersion, "Unknown client API version");
+                    throw new ArgumentOutOfRangeException(nameof(_secretEngineVersion), _secretEngineVersion, "Unknown HashiCorp Vault KeyValue secret engine version");
             }
         }
     }

--- a/src/Arcus.Security.Tests.Integration/HashiCorp/HashiCorpSecretProviderTests.cs
+++ b/src/Arcus.Security.Tests.Integration/HashiCorp/HashiCorpSecretProviderTests.cs
@@ -1,9 +1,13 @@
 ﻿using System.Collections.Generic;
 using System.Threading.Tasks;
+using Arcus.Security.Core;
 using Arcus.Security.Providers.HashiCorp;
+using Arcus.Security.Providers.HashiCorp.Extensions;
 using Arcus.Security.Tests.Integration.Fixture;
 using Arcus.Security.Tests.Integration.HashiCorp.Hosting;
 using Arcus.Testing.Logging;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Vault.Endpoints.Sys;
 using VaultSharp;
@@ -41,13 +45,8 @@ namespace Arcus.Security.Tests.Integration.HashiCorp
             string userName = "arcus";
             string password = "123";
 
-            const string policyName = "my-policy";
-
-            using (var server = await HashiCorpVaultTestServer.StartServerAsync(_config, _logger))
+            using (HashiCorpVaultTestServer server = await StartServerWithUserPassAsync(userName, password, DefaultDevMountPoint))
             {
-                await server.AddPolicyAsync(policyName, DefaultDevMountPoint, new[] { "read" });
-                await server.EnableAuthenticationTypeAsync(AuthMethodDefaultPaths.UserPass, "Authenticating with username and password");
-                await server.AddUserPassUserAsync(userName, password, policyName);
                 await server.KeyValueV2.WriteSecretAsync(
                     mountPoint: DefaultDevMountPoint,
                     path: secretPath,
@@ -66,6 +65,172 @@ namespace Arcus.Security.Tests.Integration.HashiCorp
         }
 
         [Fact]
+        public async Task AuthenticateWithUserPassKeyValueV2_GetNotFoundSecret_Fails()
+        {
+            // Arrange
+            string secretPath = "mysecret";
+            string secretName = "my-value";
+            string expected = "s3cr3t";
+
+            string userName = "arcus";
+            string password = "123";
+
+            using (HashiCorpVaultTestServer server = await StartServerWithUserPassAsync(userName, password, DefaultDevMountPoint))
+            {
+                await server.KeyValueV2.WriteSecretAsync(
+                    mountPoint: DefaultDevMountPoint,
+                    path: secretPath,
+                    data: new Dictionary<string, object> { ["unknown-prefix-" + secretName] = expected });
+
+                var authentication = new UserPassAuthMethodInfo(userName, password);
+                var settings = new VaultClientSettings(server.ListenAddress.ToString(), authentication);
+                var provider = new HashiCorpSecretProvider(settings, VaultKeyValueSecretEngineVersion.V2, DefaultDevMountPoint, secretPath);
+
+                // Act
+                string actual = await provider.GetRawSecretAsync(secretName);
+
+                // Assert
+                Assert.Null(actual);
+            }
+        }
+
+        [Fact]
+        public async Task AddHashiCorpVaultWithUserPass_WithMutationToRemovePrefix_Succeeds()
+        {
+            // Arrange
+            string secretPath = "secretpath";
+            string secretKey = "my-value", expected = "s3cr3t";
+            string userName = "arcus", password = "123";
+
+            var builder = new HostBuilder();
+
+            using (HashiCorpVaultTestServer server = await StartServerWithUserPassAsync(userName, password, DefaultDevMountPoint))
+            {
+                await server.KeyValueV2.WriteSecretAsync(
+                    mountPoint: DefaultDevMountPoint,
+                    path: secretPath,
+                    data: new Dictionary<string, object> { [secretKey] = expected });
+
+                // Act
+                builder.ConfigureSecretStore((config, stores) =>
+                {
+                    stores.AddHashiCorpVaultWithUserPass(
+                        server.ListenAddress.ToString(), userName, password, secretPath, keyValueMountPoint: DefaultDevMountPoint, 
+                        mutateSecretName: secretName => secretName.Remove(0, 5));
+                });
+
+                // Assert
+                IHost host = builder.Build();
+                var provider = host.Services.GetRequiredService<ISecretProvider>();
+                string actual = await provider.GetRawSecretAsync("Test-" + secretKey);
+
+                Assert.Equal(expected, actual);
+            }
+        }
+
+        [Fact]
+        public async Task AddHashiCorpVaultWithUserPass_WithWrongMutation_Fails()
+        {
+            // Arrange
+            string secretPath = "secretpath";
+            string secretKey = "my-value", expected = "s3cr3t";
+            string userName = "arcus", password = "123";
+
+            var builder = new HostBuilder();
+
+            using (HashiCorpVaultTestServer server = await StartServerWithUserPassAsync(userName, password, DefaultDevMountPoint))
+            {
+                await server.KeyValueV2.WriteSecretAsync(
+                    mountPoint: DefaultDevMountPoint,
+                    path: secretPath,
+                    data: new Dictionary<string, object> { [secretKey] = expected });
+
+                // Act
+                builder.ConfigureSecretStore((config, stores) =>
+                {
+                    stores.AddHashiCorpVaultWithUserPass(
+                        server.ListenAddress.ToString(), userName, password, secretPath, keyValueMountPoint: DefaultDevMountPoint,
+                        mutateSecretName: secretName => "Test-" + secretName);
+                });
+
+                // Assert
+                IHost host = builder.Build();
+                var provider = host.Services.GetRequiredService<ISecretProvider>();
+                await Assert.ThrowsAsync<SecretNotFoundException>(() => provider.GetRawSecretAsync(secretKey));
+            }
+        }
+
+        [Fact]
+        public async Task AddHashiCorpVault_WithMutationToRemovePrefix_Succeeds()
+        {
+            // Arrange
+            string secretPath = "secretpath";
+            string secretKey = "my-value", expected = "s3cr3t";
+            string userName = "arcus", password = "123";
+
+            var builder = new HostBuilder();
+
+            using (HashiCorpVaultTestServer server = await StartServerWithUserPassAsync(userName, password, DefaultDevMountPoint))
+            {
+                await server.KeyValueV2.WriteSecretAsync(
+                    mountPoint: DefaultDevMountPoint,
+                    path: secretPath,
+                    data: new Dictionary<string, object> { [secretKey] = expected });
+
+                var authentication = new UserPassAuthMethodInfo(userName, password);
+                var settings = new VaultClientSettings(server.ListenAddress.ToString(), authentication);
+
+                // Act
+                builder.ConfigureSecretStore((config, stores) =>
+                {
+                    stores.AddHashiCorpVault(settings, secretPath, keyValueMountPoint: DefaultDevMountPoint, 
+                        mutateSecretName: secretName => secretName.Remove(0, 5));
+                });
+
+                // Assert
+                IHost host = builder.Build();
+                var provider = host.Services.GetRequiredService<ISecretProvider>();
+                string actual = await provider.GetRawSecretAsync("Test-" + secretKey);
+
+                Assert.Equal(expected, actual);
+            }
+        }
+
+        [Fact]
+        public async Task AddHashiCorpVault_WithWrongMutation_Fails()
+        {
+            // Arrange
+            string secretPath = "secretpath";
+            string secretKey = "my-value", expected = "s3cr3t";
+            string userName = "arcus", password = "123";
+
+            var builder = new HostBuilder();
+
+            using (HashiCorpVaultTestServer server = await StartServerWithUserPassAsync(userName, password, DefaultDevMountPoint))
+            {
+                await server.KeyValueV2.WriteSecretAsync(
+                    mountPoint: DefaultDevMountPoint,
+                    path: secretPath,
+                    data: new Dictionary<string, object> { [secretKey] = expected });
+
+                var authentication = new UserPassAuthMethodInfo(userName, password);
+                var settings = new VaultClientSettings(server.ListenAddress.ToString(), authentication);
+
+                // Act
+                builder.ConfigureSecretStore((config, stores) =>
+                {
+                    stores.AddHashiCorpVault(settings, secretPath, keyValueMountPoint: DefaultDevMountPoint,
+                                             mutateSecretName: secretName => "Test-" + secretName);
+                });
+
+                // Assert
+                IHost host = builder.Build();
+                var provider = host.Services.GetRequiredService<ISecretProvider>();
+                await Assert.ThrowsAsync<SecretNotFoundException>(() => provider.GetRawSecretAsync(secretKey));
+            }
+        }
+
+        [Fact]
         public async Task AuthenticateWithUserPassKeyValueV1_GetSecret_Succeeds()
         {
             // Arrange
@@ -76,16 +241,12 @@ namespace Arcus.Security.Tests.Integration.HashiCorp
             string userName = "arcus";
             string password = "123";
 
-            const string policyName = "my-policy";
             const string mountPoint = "secret-v1";
             const VaultKeyValueSecretEngineVersion keyValueVersion = VaultKeyValueSecretEngineVersion.V1;
 
-            using (var server = await HashiCorpVaultTestServer.StartServerAsync(_config, _logger))
+            using (HashiCorpVaultTestServer server = await StartServerWithUserPassAsync(userName, password, mountPoint))
             {
                 await server.MountKeyValueAsync(mountPoint, keyValueVersion);
-                await server.AddPolicyAsync(policyName, mountPoint, new[] { "read" });
-                await server.EnableAuthenticationTypeAsync(AuthMethodDefaultPaths.UserPass, "Authenticating with username and password");
-                await server.AddUserPassUserAsync(userName, password, policyName);
                 await server.KeyValueV1.WriteSecretAsync(
                     mountPoint: mountPoint,
                     path: secretPath,
@@ -101,6 +262,52 @@ namespace Arcus.Security.Tests.Integration.HashiCorp
                 // Assert
                 Assert.Equal(expected, actual);
             }
+        }
+
+        [Fact]
+        public async Task AuthenticateWithUserPassKeyValueV1_GetNotFoundSecret_Fails()
+        {
+            // Arrange
+            string secretPath = "mysecret";
+            string secretName = "my-value";
+            string expected = "s3cr3t";
+
+            string userName = "arcus";
+            string password = "123";
+
+            const string mountPoint = "secret-v1";
+            const VaultKeyValueSecretEngineVersion keyValueVersion = VaultKeyValueSecretEngineVersion.V1;
+
+            using (HashiCorpVaultTestServer server = await StartServerWithUserPassAsync(userName, password, mountPoint))
+            {
+                await server.MountKeyValueAsync(mountPoint, keyValueVersion);
+                await server.KeyValueV1.WriteSecretAsync(
+                    mountPoint: mountPoint,
+                    path: secretPath,
+                    values: new Dictionary<string, object> { ["unknown-prefix-" + secretName] = expected });
+
+                var authentication = new UserPassAuthMethodInfo(userName, password);
+                var settings = new VaultClientSettings(server.ListenAddress.ToString(), authentication);
+                var provider = new HashiCorpSecretProvider(settings, keyValueVersion, mountPoint, secretPath);
+
+                // Act
+                string actual = await provider.GetRawSecretAsync(secretName);
+
+                // Assert
+                Assert.Null(actual);
+            }
+        }
+
+        private async Task<HashiCorpVaultTestServer> StartServerWithUserPassAsync(string userName, string password, string availableSecretMountPoint)
+        {
+            const string policyName = "my-policy";
+
+            var server = await HashiCorpVaultTestServer.StartServerAsync(_config, _logger);
+            await server.AddPolicyAsync(policyName, availableSecretMountPoint, new[] { "read" });
+            await server.EnableAuthenticationTypeAsync(AuthMethodDefaultPaths.UserPass, "Authenticating with username and password");
+            await server.AddUserPassUserAsync(userName, password, policyName);
+
+            return server;
         }
     }
 }

--- a/src/Arcus.Security.Tests.Integration/HashiCorp/HashiCorpSecretProviderTests.cs
+++ b/src/Arcus.Security.Tests.Integration/HashiCorp/HashiCorpSecretProviderTests.cs
@@ -101,7 +101,8 @@ namespace Arcus.Security.Tests.Integration.HashiCorp
             string secretPath = "secretpath";
             string secretKey = "my-value", expected = "s3cr3t";
             string userName = "arcus", password = "123";
-
+            const string secretNamePrefix = "Test-";
+            
             var builder = new HostBuilder();
 
             using (HashiCorpVaultTestServer server = await StartServerWithUserPassAsync(userName, password, DefaultDevMountPoint))
@@ -116,13 +117,13 @@ namespace Arcus.Security.Tests.Integration.HashiCorp
                 {
                     stores.AddHashiCorpVaultWithUserPass(
                         server.ListenAddress.ToString(), userName, password, secretPath, keyValueMountPoint: DefaultDevMountPoint, 
-                        mutateSecretName: secretName => secretName.Remove(0, 5));
+                        mutateSecretName: secretName => secretName.Remove(0, secretNamePrefix.Length));
                 });
 
                 // Assert
                 IHost host = builder.Build();
                 var provider = host.Services.GetRequiredService<ISecretProvider>();
-                string actual = await provider.GetRawSecretAsync("Test-" + secretKey);
+                string actual = await provider.GetRawSecretAsync(secretNamePrefix + secretKey);
 
                 Assert.Equal(expected, actual);
             }
@@ -135,7 +136,7 @@ namespace Arcus.Security.Tests.Integration.HashiCorp
             string secretPath = "secretpath";
             string secretKey = "my-value", expected = "s3cr3t";
             string userName = "arcus", password = "123";
-
+            
             var builder = new HostBuilder();
 
             using (HashiCorpVaultTestServer server = await StartServerWithUserPassAsync(userName, password, DefaultDevMountPoint))
@@ -150,7 +151,7 @@ namespace Arcus.Security.Tests.Integration.HashiCorp
                 {
                     stores.AddHashiCorpVaultWithUserPass(
                         server.ListenAddress.ToString(), userName, password, secretPath, keyValueMountPoint: DefaultDevMountPoint,
-                        mutateSecretName: secretName => "Test-" + secretName);
+                        mutateSecretName: secretName =>  "Test-" + secretName);
                 });
 
                 // Assert
@@ -167,7 +168,8 @@ namespace Arcus.Security.Tests.Integration.HashiCorp
             string secretPath = "secretpath";
             string secretKey = "my-value", expected = "s3cr3t";
             string userName = "arcus", password = "123";
-
+            const string secretNamePrefix = "Test-";
+            
             var builder = new HostBuilder();
 
             using (HashiCorpVaultTestServer server = await StartServerWithUserPassAsync(userName, password, DefaultDevMountPoint))
@@ -184,13 +186,13 @@ namespace Arcus.Security.Tests.Integration.HashiCorp
                 builder.ConfigureSecretStore((config, stores) =>
                 {
                     stores.AddHashiCorpVault(settings, secretPath, keyValueMountPoint: DefaultDevMountPoint, 
-                        mutateSecretName: secretName => secretName.Remove(0, 5));
+                        mutateSecretName: secretName => secretName.Remove(0, secretNamePrefix.Length));
                 });
 
                 // Assert
                 IHost host = builder.Build();
                 var provider = host.Services.GetRequiredService<ISecretProvider>();
-                string actual = await provider.GetRawSecretAsync("Test-" + secretKey);
+                string actual = await provider.GetRawSecretAsync(secretNamePrefix + secretKey);
 
                 Assert.Equal(expected, actual);
             }


### PR DESCRIPTION
Add secret name mutation to all the HashiCorp Vault secret store builder so the secret name can be altered before it's send to the HashiCorp Vault.