### PR TITLE
Feature - provide support for using new Azure.Identity SDK in Azure Key Vault secret provider

### DIFF
--- a/src/Arcus.Security.Core/CompositeSecretProvider.cs
+++ b/src/Arcus.Security.Core/CompositeSecretProvider.cs
@@ -48,10 +48,16 @@ namespace Arcus.Security.Core
         /// Gets the cache-configuration for this instance.
         /// </summary>
         /// <remarks>
-        ///     Will always return <c>null</c> because several cached secret providers can be registered with different caching configuration,
+        ///     Will always throw an <see cref="NotSupportedException"/> because several cached secret providers can be registered with different caching configuration,
         ///     and there also could be none configured for caching.
         /// </remarks>
-        public ICacheConfiguration Configuration => null;
+        /// <exception cref="NotSupportedException">
+        ///     Thrown every time because the <see cref="CompositeSecretProvider"/> cannot determine the caching configuration from the different registered <see cref="ICachedSecretProvider"/>s.
+        /// </exception>
+        public ICacheConfiguration Configuration =>
+            throw new NotSupportedException(
+                "Getting the cache configuration directly from the secret store is not supported, "
+                + $"please use another way to access the configuration or implement your own '{nameof(ICachedSecretProvider)}' to use this within your secret provider");
 
         /// <summary>
         /// Retrieves the secret value, based on the given name

--- a/src/Arcus.Security.Providers.AzureKeyVault/Arcus.Security.Providers.AzureKeyVault.csproj
+++ b/src/Arcus.Security.Providers.AzureKeyVault/Arcus.Security.Providers.AzureKeyVault.csproj
@@ -19,6 +19,8 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Azure.Identity" Version="1.2.3" />
+    <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.1.0" />
     <PackageReference Include="Guard.Net" Version="1.2.0" />
     <PackageReference Include="Microsoft.Azure.KeyVault" Version="3.0.2" />
     <PackageReference Include="Microsoft.Azure.KeyVault.Core" Version="3.0.1" />

--- a/src/Arcus.Security.Providers.AzureKeyVault/Authentication/CertificateBasedAuthentication.cs
+++ b/src/Arcus.Security.Providers.AzureKeyVault/Authentication/CertificateBasedAuthentication.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading.Tasks;
+using Azure.Identity;
 using GuardNet;
 using Microsoft.Azure.KeyVault;
 using Microsoft.IdentityModel.Clients.ActiveDirectory;
@@ -10,6 +11,7 @@ namespace Arcus.Security.Providers.AzureKeyVault.Authentication
     /// <summary>
     ///     Azure Key Vault <see cref="IKeyVaultAuthentication"/> by using client ID and certificate to authenticate the <see cref="IKeyVaultClient"/>.
     /// </summary>
+    [Obsolete("Azure Key Vault authentication is moved to Azure Identity approach where the certificate authentication becomes: " + nameof(ClientCertificateCredential))]
     public class CertificateBasedAuthentication : IKeyVaultAuthentication
     {
         private readonly string _clientId;

--- a/src/Arcus.Security.Providers.AzureKeyVault/Authentication/IKeyVaultAuthentication.cs
+++ b/src/Arcus.Security.Providers.AzureKeyVault/Authentication/IKeyVaultAuthentication.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+﻿using System;
+using System.Threading.Tasks;
 using Microsoft.Azure.KeyVault;
 
 namespace Arcus.Security.Providers.AzureKeyVault.Authentication
@@ -6,6 +7,7 @@ namespace Arcus.Security.Providers.AzureKeyVault.Authentication
     /// <summary>
     ///     Authentication provider for Azure Key Vault
     /// </summary>
+    [Obsolete("Azure Key Vault authentication is moved to Azure Identity approach so this interface contract is not needed anymore")]
     public interface IKeyVaultAuthentication
     {
         /// <summary>

--- a/src/Arcus.Security.Providers.AzureKeyVault/Authentication/ManagedServiceIdentityAuthentication.cs
+++ b/src/Arcus.Security.Providers.AzureKeyVault/Authentication/ManagedServiceIdentityAuthentication.cs
@@ -1,4 +1,6 @@
-﻿using System.Threading.Tasks;
+﻿using System;
+using System.Threading.Tasks;
+using Azure.Identity;
 using Microsoft.Azure.KeyVault;
 using Microsoft.Azure.Services.AppAuthentication;
 
@@ -7,6 +9,7 @@ namespace Arcus.Security.Providers.AzureKeyVault.Authentication
     /// <summary>
     ///     Azure Key Vault authentication by using Azure Managed Service Identity
     /// </summary>
+    [Obsolete("Azure Key Vault authentication is moved to Azure Identity approach where the managed service identity authentication becomes: " + nameof(ManagedIdentityCredential))]
     public class ManagedServiceIdentityAuthentication : IKeyVaultAuthentication
     {
         private readonly string _connectionString;

--- a/src/Arcus.Security.Providers.AzureKeyVault/Authentication/ServicePrincipalAuthentication.cs
+++ b/src/Arcus.Security.Providers.AzureKeyVault/Authentication/ServicePrincipalAuthentication.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Threading.Tasks;
+using Azure.Identity;
 using GuardNet;
 using Microsoft.Azure.KeyVault;
 using Microsoft.IdentityModel.Clients.ActiveDirectory;
@@ -9,6 +10,7 @@ namespace Arcus.Security.Providers.AzureKeyVault.Authentication
     /// <summary>
     /// Representation of an <see cref="IKeyVaultAuthentication"/> that will generate a <see cref="IKeyVaultClient"/> implementation using a service principle.
     /// </summary>
+    [Obsolete("Azure Key Vault authentication is moved to Azure Identity approach where the service principal authentication becomes: " + nameof(ClientSecretCredential))]
     public class ServicePrincipalAuthentication : IKeyVaultAuthentication
     {
         private readonly string _clientId;

--- a/src/Arcus.Security.Providers.AzureKeyVault/Extensions/SecretStoreBuilderExtensions.cs
+++ b/src/Arcus.Security.Providers.AzureKeyVault/Extensions/SecretStoreBuilderExtensions.cs
@@ -33,6 +33,7 @@ namespace Microsoft.Extensions.Hosting
         /// <param name="mutateSecretName">The optional function to mutate the secret name before looking it up.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="builder"/> or <paramref name="certificate"/> is <c>null</c>.</exception>
         /// <exception cref="ArgumentException">Thrown when the <paramref name="rawVaultUri"/> or <paramref name="clientId"/> is blank.</exception>
+        [Obsolete("Use the " + nameof(AddAzureKeyVaultWithCertificate) + " overload with the tenant ID instead")]
         public static SecretStoreBuilder AddAzureKeyVaultWithCertificate(
             this SecretStoreBuilder builder,
             string rawVaultUri,
@@ -59,12 +60,48 @@ namespace Microsoft.Extensions.Hosting
         /// </summary>
         /// <param name="builder">The builder to create the secret store.</param>
         /// <param name="rawVaultUri">The Uri of the Azure Key Vault you want to connect to.</param>
+        /// <param name="tenantId">The Azure Active Directory tenant (directory) ID of the client or application.</param>
+        /// <param name="clientId">The identifier of the application requesting the authentication token.</param>
+        /// <param name="certificate">The certificate that is used as credential.</param>
+        /// <param name="allowCaching">The flag to indicate whether to include caching during secret retrieval in Azure key vault.</param>
+        /// <param name="mutateSecretName">The optional function to mutate the secret name before looking it up.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="builder"/> or <paramref name="certificate"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="rawVaultUri"/> or <paramref name="clientId"/> is blank.</exception>
+        public static SecretStoreBuilder AddAzureKeyVaultWithCertificate(
+            this SecretStoreBuilder builder,
+            string rawVaultUri,
+            string tenantId,
+            string clientId,
+            X509Certificate2 certificate,
+            bool allowCaching = false,
+            Func<string, string> mutateSecretName = null)
+        {
+            Guard.NotNull(builder, nameof(builder), "Requires a secret store builder to add the Azure Key Vault secret provider");
+            Guard.NotNullOrWhitespace(rawVaultUri, nameof(rawVaultUri), "Requires a non-blank URI of the Azure Key Vault instance to add the secret provider to the secret store");
+            Guard.NotNullOrWhitespace(tenantId, nameof(tenantId), "Requires a non-blank tenant ID of the directory where the client or application is located");
+            Guard.NotNullOrWhitespace(clientId, nameof(clientId), "Requires a non-blank client ID of the application requesting the authentication token that has read permissions on the Azure Key Vault to add a secret provider to the secret store");
+            Guard.NotNull(certificate, nameof(certificate), "Requires a certificate that is being used as credential on the Azure Key Vault to add the secret provider to the secret store");
+
+            return AddAzureKeyVault(
+                builder,
+                new ClientCertificateCredential(tenantId, clientId, certificate),
+                new KeyVaultConfiguration(rawVaultUri),
+                allowCaching,
+                mutateSecretName);
+        }
+
+        /// <summary>
+        /// Adds Azure Key Vault as a secret source which uses certificate authentication.
+        /// </summary>
+        /// <param name="builder">The builder to create the secret store.</param>
+        /// <param name="rawVaultUri">The Uri of the Azure Key Vault you want to connect to.</param>
         /// <param name="clientId">The identifier of the application requesting the authentication token.</param>
         /// <param name="certificate">The certificate that is used as credential.</param>
         /// <param name="cacheConfiguration">The configuration to control how the caching will be done.</param>
         /// <param name="mutateSecretName">The optional function to mutate the secret name before looking it up.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="builder"/> or <paramref name="certificate"/> is <c>null</c>.</exception>
         /// <exception cref="ArgumentException">Thrown when the <paramref name="rawVaultUri"/> or <paramref name="clientId"/> is blank.</exception>
+        [Obsolete("Use the " + nameof(AddAzureKeyVaultWithCertificate) + " overload with the tenant ID instead")]
         public static SecretStoreBuilder AddAzureKeyVaultWithCertificate(
             this SecretStoreBuilder builder,
             string rawVaultUri,
@@ -87,6 +124,41 @@ namespace Microsoft.Extensions.Hosting
         }
 
         /// <summary>
+        /// Adds Azure Key Vault as a secret source which uses certificate authentication.
+        /// </summary>
+        /// <param name="builder">The builder to create the secret store.</param>
+        /// <param name="rawVaultUri">The Uri of the Azure Key Vault you want to connect to.</param>
+        /// <param name="tenantId">The Azure Active Directory tenant (directory) ID of the client or application.</param>
+        /// <param name="clientId">The identifier of the application requesting the authentication token.</param>
+        /// <param name="certificate">The certificate that is used as credential.</param>
+        /// <param name="cacheConfiguration">The configuration to control how the caching will be done.</param>
+        /// <param name="mutateSecretName">The optional function to mutate the secret name before looking it up.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="builder"/> or <paramref name="certificate"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="rawVaultUri"/> or <paramref name="clientId"/> is blank.</exception>
+        public static SecretStoreBuilder AddAzureKeyVaultWithCertificate(
+            this SecretStoreBuilder builder,
+            string rawVaultUri,
+            string tenantId,
+            string clientId,
+            X509Certificate2 certificate,
+            ICacheConfiguration cacheConfiguration,
+            Func<string, string> mutateSecretName = null)
+        {
+            Guard.NotNull(builder, nameof(builder), "Requires a secret store builder to add the Azure Key Vault secret provider");
+            Guard.NotNullOrWhitespace(rawVaultUri, nameof(rawVaultUri), "Requires a non-blank URI of the Azure Key Vault instance to add the secret provider to the secret store");
+            Guard.NotNullOrWhitespace(tenantId, nameof(tenantId), "Requires a non-blank tenant ID of the directory where the client or application is located");
+            Guard.NotNullOrWhitespace(clientId, nameof(clientId), "Requires a non-blank client ID of the application requesting the authentication token that has read permissions on the Azure Key Vault to add a secret provider to the secret store");
+            Guard.NotNull(certificate, nameof(certificate), "Requires a certificate that is being used as credential on the Azure Key Vault to add the secret provider to the secret store");
+
+            return AddAzureKeyVault(
+                builder,
+                new ClientCertificateCredential(tenantId, clientId, certificate),
+                new KeyVaultConfiguration(rawVaultUri),
+                cacheConfiguration,
+                mutateSecretName);
+        }
+
+        /// <summary>
         /// Adds Azure Key Vault as a secret source which uses Managed Identity authentication.
         /// </summary>
         /// <param name="builder">The builder to create the secret store.</param>
@@ -97,6 +169,7 @@ namespace Microsoft.Extensions.Hosting
         /// <param name="mutateSecretName">The optional function to mutate the secret name before looking it up.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="builder"/> is <c>null</c>.</exception>
         /// <exception cref="ArgumentException">Thrown when the <paramref name="rawVaultUri"/> is blank.</exception>
+        [Obsolete("Use the " + nameof(AddAzureKeyVaultWithManagedIdentity) + " overload with the 'clientId' instead")]
         public static SecretStoreBuilder AddAzureKeyVaultWithManagedServiceIdentity(
             this SecretStoreBuilder builder,
             string rawVaultUri,
@@ -121,12 +194,43 @@ namespace Microsoft.Extensions.Hosting
         /// </summary>
         /// <param name="builder">The builder to create the secret store.</param>
         /// <param name="rawVaultUri">The Uri of the Azure Key Vault you want to connect to.</param>
+        /// <param name="clientId">
+        ///     The client id to authenticate for a user assigned managed identity.
+        ///     More information on user assigned managed identities can be found here: https://docs.microsoft.com/en-us/azure/active-directory/managed-identities-azure-resources/overview#how-a-user-assigned-managed-identity-works-with-an-azure-vm</param>
+        /// <param name="allowCaching">The flag to indicate whether to include caching during secret retrieval in Azure key vault.</param>
+        /// <param name="mutateSecretName">The optional function to mutate the secret name before looking it up.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="builder"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="rawVaultUri"/> is blank.</exception>
+        public static SecretStoreBuilder AddAzureKeyVaultWithManagedIdentity(
+            this SecretStoreBuilder builder,
+            string rawVaultUri,
+            string clientId = null,
+            bool allowCaching = false,
+            Func<string, string> mutateSecretName = null)
+        {
+            Guard.NotNull(builder, nameof(builder), "Requires a secret store builder to add the Azure Key Vault secret provider");
+            Guard.NotNullOrWhitespace(rawVaultUri, nameof(rawVaultUri), "Requires a non-blank URI of the Azure Key Vault instance to add the secret provider to the secret store");
+
+            return AddAzureKeyVault(
+                builder,
+                new ManagedIdentityCredential(clientId),
+                new KeyVaultConfiguration(rawVaultUri),
+                allowCaching,
+                mutateSecretName);
+        }
+
+        /// <summary>
+        /// Adds Azure Key Vault as a secret source which uses Managed Identity authentication.
+        /// </summary>
+        /// <param name="builder">The builder to create the secret store.</param>
+        /// <param name="rawVaultUri">The Uri of the Azure Key Vault you want to connect to.</param>
         /// <param name="cacheConfiguration">The configuration to control how the caching will be done.</param>
         /// <param name="connectionString">The connection string to use to authenticate, if applicable.</param>
         /// <param name="azureADInstance">The azure AD instance to use to authenticate, if applicable.</param>
         /// <param name="mutateSecretName">The optional function to mutate the secret name before looking it up.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="builder"/> is <c>null</c>.</exception>
         /// <exception cref="ArgumentException">Thrown when the <paramref name="rawVaultUri"/> is blank.</exception>
+        [Obsolete("Use the " + nameof(AddAzureKeyVaultWithManagedIdentity) + " overload with the 'clientId' instead")]
         public static SecretStoreBuilder AddAzureKeyVaultWithManagedServiceIdentity(
             this SecretStoreBuilder builder,
             string rawVaultUri,
@@ -147,6 +251,36 @@ namespace Microsoft.Extensions.Hosting
         }
 
         /// <summary>
+        /// Adds Azure Key Vault as a secret source which uses Managed Identity authentication.
+        /// </summary>
+        /// <param name="builder">The builder to create the secret store.</param>
+        /// <param name="rawVaultUri">The Uri of the Azure Key Vault you want to connect to.</param>
+        /// <param name="clientId">
+        ///     The client id to authenticate for a user assigned managed identity.
+        ///     More information on user assigned managed identities can be found here: https://docs.microsoft.com/en-us/azure/active-directory/managed-identities-azure-resources/overview#how-a-user-assigned-managed-identity-works-with-an-azure-vm</param>
+        /// <param name="cacheConfiguration">The configuration to control how the caching will be done.</param>
+        /// <param name="mutateSecretName">The optional function to mutate the secret name before looking it up.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="builder"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="rawVaultUri"/> is blank.</exception>
+        public static SecretStoreBuilder AddAzureKeyVaultWithManagedIdentity(
+            this SecretStoreBuilder builder,
+            string rawVaultUri,
+            ICacheConfiguration cacheConfiguration,
+            string clientId = null,
+            Func<string, string> mutateSecretName = null)
+        {
+            Guard.NotNull(builder, nameof(builder), "Requires a secret store builder to add the Azure Key Vault secret provider");
+            Guard.NotNullOrWhitespace(rawVaultUri, nameof(rawVaultUri), "Requires a non-blank URI of the Azure Key Vault instance to add the secret provider to the secret store");
+
+            return AddAzureKeyVault(
+                builder,
+                new ManagedIdentityCredential(clientId),
+                new KeyVaultConfiguration(rawVaultUri),
+                cacheConfiguration,
+                mutateSecretName);
+        }
+
+        /// <summary>
         /// Adds Azure Key Vault as a secret source which uses client secret authentication.
         /// </summary>
         /// <param name="builder">The builder to create the secret store.</param>
@@ -157,6 +291,7 @@ namespace Microsoft.Extensions.Hosting
         /// <param name="mutateSecretName">The optional function to mutate the secret name before looking it up.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="builder"/> is <c>null</c>.</exception>
         /// <exception cref="ArgumentException">Thrown when the <paramref name="rawVaultUri"/>, <paramref name="clientId"/>, or <paramref name="clientKey"/> is blank.</exception>
+        [Obsolete("Use the " + nameof(AddAzureKeyVaultWithServicePrincipal) + " overload with the 'tenantId' instead")]
         public static SecretStoreBuilder AddAzureKeyVaultWithServicePrincipal(
             this SecretStoreBuilder builder,
             string rawVaultUri,
@@ -183,12 +318,48 @@ namespace Microsoft.Extensions.Hosting
         /// </summary>
         /// <param name="builder">The builder to create the secret store.</param>
         /// <param name="rawVaultUri">The Uri of the Azure Key Vault you want to connect to.</param>
+        /// <param name="tenantId">The Azure Active Directory tenant (directory) Id of the service principal.</param>
+        /// <param name="clientId">The ClientId of the service principal, used to connect to Azure Key Vault</param>
+        /// <param name="clientKey">The Secret ClientKey of the service principal, used to connect to Azure Key Vault</param>
+        /// <param name="allowCaching">The flag to indicate whether to include caching during secret retrieval in Azure key vault.</param>
+        /// <param name="mutateSecretName">The optional function to mutate the secret name before looking it up.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="builder"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="rawVaultUri"/>, <paramref name="clientId"/>, or <paramref name="clientKey"/> is blank.</exception>
+        public static SecretStoreBuilder AddAzureKeyVaultWithServicePrincipal(
+            this SecretStoreBuilder builder,
+            string rawVaultUri,
+            string tenantId,
+            string clientId,
+            string clientKey,
+            bool allowCaching = false,
+            Func<string, string> mutateSecretName = null)
+        {
+            Guard.NotNull(builder, nameof(builder), "Requires a secret store builder to add the Azure Key Vault secret provider");
+            Guard.NotNullOrWhitespace(rawVaultUri, nameof(rawVaultUri), "Requires a non-blank URI of the Azure Key Vault instance to add the secret provider to the secret store");
+            Guard.NotNullOrWhitespace(tenantId, nameof(tenantId), "Requires a non-blank tenant ID of the directory where the Service Principal is located");
+            Guard.NotNullOrWhitespace(clientId, nameof(clientId), "Requires a non-blank client ID of the Service Principal that has permissions to read the secrets in the Azure Key Vault to add the secret provider to the secret store");
+            Guard.NotNullOrWhitespace(clientKey, nameof(clientKey), "Requires a non-blank client access key of the Service Principal that has permissions to read the secrets in the Azure Key Vault to add to the secret provider to the secret store");
+
+            return AddAzureKeyVault(
+                builder,
+                new ClientSecretCredential(tenantId, clientId, clientKey), 
+                new KeyVaultConfiguration(rawVaultUri),
+                allowCaching,
+                mutateSecretName);
+        }
+
+        /// <summary>
+        /// Adds Azure Key Vault as a secret source which uses client secret authentication.
+        /// </summary>
+        /// <param name="builder">The builder to create the secret store.</param>
+        /// <param name="rawVaultUri">The Uri of the Azure Key Vault you want to connect to.</param>
         /// <param name="clientId">The ClientId of the service principal, used to connect to Azure Key Vault</param>
         /// <param name="clientKey">The Secret ClientKey of the service principal, used to connect to Azure Key Vault</param>
         /// <param name="cacheConfiguration">The configuration to control how the caching will be done.</param>
         /// <param name="mutateSecretName">The optional function to mutate the secret name before looking it up.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="builder"/> is <c>null</c>.</exception>
         /// <exception cref="ArgumentException">Thrown when the <paramref name="rawVaultUri"/>, <paramref name="clientId"/>, or <paramref name="clientKey"/> is blank.</exception>
+        [Obsolete("Use the " + nameof(AddAzureKeyVaultWithServicePrincipal) + " overload with the 'tenantId' instead")]
         public static SecretStoreBuilder AddAzureKeyVaultWithServicePrincipal(
             this SecretStoreBuilder builder,
             string rawVaultUri,
@@ -211,6 +382,41 @@ namespace Microsoft.Extensions.Hosting
         }
 
         /// <summary>
+        /// Adds Azure Key Vault as a secret source which uses client secret authentication.
+        /// </summary>
+        /// <param name="builder">The builder to create the secret store.</param>
+        /// <param name="rawVaultUri">The Uri of the Azure Key Vault you want to connect to.</param>
+        /// <param name="tenantId">The Azure Active Directory tenant (directory) Id of the service principal.</param>
+        /// <param name="clientId">The ClientId of the service principal, used to connect to Azure Key Vault</param>
+        /// <param name="clientKey">The Secret ClientKey of the service principal, used to connect to Azure Key Vault</param>
+        /// <param name="cacheConfiguration">The configuration to control how the caching will be done.</param>
+        /// <param name="mutateSecretName">The optional function to mutate the secret name before looking it up.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="builder"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="rawVaultUri"/>, <paramref name="clientId"/>, or <paramref name="clientKey"/> is blank.</exception>
+        public static SecretStoreBuilder AddAzureKeyVaultWithServicePrincipal(
+            this SecretStoreBuilder builder,
+            string rawVaultUri,
+            string tenantId,
+            string clientId,
+            string clientKey,
+            ICacheConfiguration cacheConfiguration,
+            Func<string, string> mutateSecretName = null)
+        {
+            Guard.NotNull(builder, nameof(builder), "Requires a secret store builder to add the Azure Key Vault secret provider");
+            Guard.NotNullOrWhitespace(rawVaultUri, nameof(rawVaultUri), "Requires a non-blank URI of the Azure Key Vault instance to add the secret provider to the secret store");
+            Guard.NotNullOrWhitespace(tenantId, nameof(tenantId), "Requires a non-blank tenant ID of the directory where the Service Principal is located");
+            Guard.NotNullOrWhitespace(clientId, nameof(clientId), "Requires a non-blank client ID of the Service Principal that has permissions to read the secrets in the Azure Key Vault to add the secret provider to the secret store");
+            Guard.NotNullOrWhitespace(clientKey, nameof(clientKey), "Requires a non-blank client access key of the Service Principal that has permissions to read the secrets in the Azure Key Vault to add to the secret provider to the secret store");
+
+            return AddAzureKeyVault(
+                builder,
+                new ClientSecretCredential(tenantId, clientId, clientKey), 
+                new KeyVaultConfiguration(rawVaultUri),
+                cacheConfiguration,
+                mutateSecretName);
+        }
+
+        /// <summary>
         /// Adds Azure Key Vault as a secret source.
         /// </summary>
         /// <param name="builder">The builder to create the secret store.</param>
@@ -219,6 +425,7 @@ namespace Microsoft.Extensions.Hosting
         /// <param name="allowCaching">The flag to indicate whether to include caching during secret retrieval in Azure key vault.</param>
         /// <param name="mutateSecretName">The optional function to mutate the secret name before looking it up.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="builder"/>, <paramref name="authentication"/>, or <paramref name="configuration"/> is <c>null</c>.</exception>
+        [Obsolete("Use the " + nameof(AddAzureKeyVault) + " overload with the 'TokenCredential' instead")]
         public static SecretStoreBuilder AddAzureKeyVault(
             this SecretStoreBuilder builder,
             IKeyVaultAuthentication authentication,
@@ -243,6 +450,7 @@ namespace Microsoft.Extensions.Hosting
         /// <param name="cacheConfiguration">The configuration to control how the caching will be done.</param>
         /// <param name="mutateSecretName">The optional function to mutate the secret name before looking it up.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="builder"/>, <paramref name="authentication"/>, or <paramref name="configuration"/> is <c>null</c>.</exception>
+        [Obsolete("Use the " + nameof(AddAzureKeyVault) + " overload with the 'TokenCredential' instead")]
         public static SecretStoreBuilder AddAzureKeyVault(
             this SecretStoreBuilder builder,
             IKeyVaultAuthentication authentication,
@@ -288,6 +496,30 @@ namespace Microsoft.Extensions.Hosting
             Guard.NotNull(configuration, nameof(configuration), "Requires an Azure Key Vault configuration instance to add the secret provider to the secret store");
 
             return AddAzureKeyVault(builder, tokenCredential, configuration, cacheConfiguration: null, mutateSecretName: mutateSecretName);
+        }
+
+        /// <summary>
+        /// Adds Azure Key Vault as a secret source.
+        /// </summary>
+        /// <param name="builder">The builder to create the secret store.</param>
+        /// <param name="tokenCredential">The requested authentication type for connecting to the Azure Key Vault instance.</param>
+        /// <param name="configuration">The configuration related to the Azure Key Vault instance to use.</param>
+        /// <param name="allowCaching">The flag to indicate whether to include caching during secret retrieval in Azure key vault.</param>
+        /// <param name="mutateSecretName">The optional function to mutate the secret name before looking it up.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="builder"/>, <paramref name="tokenCredential"/>, or <paramref name="configuration"/> is <c>null</c>.</exception>
+        public static SecretStoreBuilder AddAzureKeyVault(
+            this SecretStoreBuilder builder,
+            TokenCredential tokenCredential,
+            IKeyVaultConfiguration configuration,
+            bool allowCaching = false,
+            Func<string, string> mutateSecretName = null)
+        {
+            Guard.NotNull(builder, nameof(builder), "Requires a secret store builder to add the Azure Key Vault secret provider");
+            Guard.NotNull(tokenCredential, nameof(tokenCredential), "Requires an Azure Key Vault authentication instance to add the secret provider to the secret store");
+            Guard.NotNull(configuration, nameof(configuration), "Requires an Azure Key Vault configuration instance to add the secret provider to the secret store");
+
+            ICacheConfiguration cacheConfiguration = allowCaching ? new CacheConfiguration() : null;
+            return AddAzureKeyVault(builder, tokenCredential, configuration, cacheConfiguration, mutateSecretName);
         }
 
         /// <summary>

--- a/src/Arcus.Security.Providers.AzureKeyVault/Extensions/SecretStoreBuilderExtensions.cs
+++ b/src/Arcus.Security.Providers.AzureKeyVault/Extensions/SecretStoreBuilderExtensions.cs
@@ -613,10 +613,6 @@ namespace Microsoft.Extensions.Hosting
         {
             return builder.AddProvider(serviceProvider =>
             {
-                IKeyVaultAuthentication authentication = createAuthentication(serviceProvider);
-                var logger = serviceProvider.GetService<ILogger<KeyVaultSecretProvider>>();
-                var keyVaultSecretProvider = new KeyVaultSecretProvider(authentication, configuration, logger);
-
                 if (cacheConfiguration is null)
                 {
                     return keyVaultSecretProvider;

--- a/src/Arcus.Security.Providers.AzureKeyVault/Extensions/SecretStoreBuilderExtensions.cs
+++ b/src/Arcus.Security.Providers.AzureKeyVault/Extensions/SecretStoreBuilderExtensions.cs
@@ -228,7 +228,7 @@ namespace Microsoft.Extensions.Hosting
 
             return AddAzureKeyVault(
                 builder,
-                new ManagedIdentityCredential(clientId),
+                new ChainedTokenCredential(new ManagedIdentityCredential(clientId), new EnvironmentCredential()),
                 new KeyVaultConfiguration(rawVaultUri),
                 allowCaching,
                 mutateSecretName);
@@ -293,7 +293,7 @@ namespace Microsoft.Extensions.Hosting
 
             return AddAzureKeyVault(
                 builder,
-                new ManagedIdentityCredential(clientId),
+                new ChainedTokenCredential(new ManagedIdentityCredential(clientId), new EnvironmentCredential()),
                 new KeyVaultConfiguration(rawVaultUri),
                 cacheConfiguration,
                 mutateSecretName);

--- a/src/Arcus.Security.Providers.AzureKeyVault/Extensions/SecretStoreBuilderExtensions.cs
+++ b/src/Arcus.Security.Providers.AzureKeyVault/Extensions/SecretStoreBuilderExtensions.cs
@@ -523,8 +523,18 @@ namespace Microsoft.Extensions.Hosting
                        || exception.Response.StatusCode == HttpStatusCode.BadRequest;
             });
 
-            var keyVaultSecretProvider = new KeyVaultSecretProvider(authentication, configuration);
-            return WithCachedSecretProvider(builder, keyVaultSecretProvider, cacheConfiguration, mutateSecretName);
+            return builder.AddProvider(serviceProvider =>
+            {
+                IKeyVaultAuthentication authentication = createAuthentication(serviceProvider);
+                var keyVaultSecretProvider = new KeyVaultSecretProvider(authentication, configuration);    
+                
+                if (cacheConfiguration is null)
+                {
+                    return keyVaultSecretProvider;
+                }
+                
+                return new CachedSecretProvider(keyVaultSecretProvider, cacheConfiguration);
+            }, mutateSecretName);
         }
 
         /// <summary>

--- a/src/Arcus.Security.Providers.AzureKeyVault/KeyVaultSecretProvider.cs
+++ b/src/Arcus.Security.Providers.AzureKeyVault/KeyVaultSecretProvider.cs
@@ -14,6 +14,7 @@ using Microsoft.Azure.KeyVault;
 using Microsoft.Azure.KeyVault.Models;
 using Microsoft.Rest.TransientFaultHandling;
 using Polly;
+using Polly.Retry;
 
 namespace Arcus.Security.Providers.AzureKeyVault
 {
@@ -269,7 +270,7 @@ namespace Arcus.Security.Providers.AzureKeyVault
                     .ExecuteAsync(secretOperation);
         }
 
-        private static Polly.Retry.RetryPolicy GetExponentialBackOffRetryPolicy<TException>(Func<TException, bool> exceptionPredicate) 
+        private static AsyncRetryPolicy GetExponentialBackOffRetryPolicy<TException>(Func<TException, bool> exceptionPredicate) 
             where TException : Exception
         {
             /* Client-side throttling using exponential back-off when Key Vault service limit exceeds:

--- a/src/Arcus.Security.Providers.AzureKeyVault/KeyVaultSecretProvider.cs
+++ b/src/Arcus.Security.Providers.AzureKeyVault/KeyVaultSecretProvider.cs
@@ -85,8 +85,10 @@ namespace Arcus.Security.Providers.AzureKeyVault
 
             _authentication = authentication;
             _isUsingAzureSdk = false;
+            
+            Logger = logger ?? NullLogger<KeyVaultSecretProvider>.Instance;
         }
-
+        
         /// <summary>
         /// Initializes a new instance of the <see cref="KeyVaultSecretProvider"/> class.
         /// </summary>
@@ -95,6 +97,19 @@ namespace Arcus.Security.Providers.AzureKeyVault
         /// <exception cref="ArgumentNullException">The <paramref name="tokenCredential"/> cannot be <c>null</c>.</exception>
         /// <exception cref="ArgumentNullException">The <paramref name="vaultConfiguration"/> cannot be <c>null</c>.</exception>
         public KeyVaultSecretProvider(TokenCredential tokenCredential, IKeyVaultConfiguration vaultConfiguration)
+            : this(tokenCredential, vaultConfiguration, NullLogger<KeyVaultSecretProvider>.Instance)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="KeyVaultSecretProvider"/> class.
+        /// </summary>
+        /// <param name="tokenCredential">The requested authentication type for connecting to the Azure Key Vault instance</param>
+        /// <param name="vaultConfiguration">Configuration related to the Azure Key Vault instance to use</param>
+        /// <param name="logger">The logger to write diagnostic trace messages during the interaction with the Azure Key Vault.</param>
+        /// <exception cref="ArgumentNullException">The <paramref name="tokenCredential"/> cannot be <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException">The <paramref name="vaultConfiguration"/> cannot be <c>null</c>.</exception>
+        public KeyVaultSecretProvider(TokenCredential tokenCredential, IKeyVaultConfiguration vaultConfiguration, ILogger<KeyVaultSecretProvider> logger)
         {
             Guard.NotNull(vaultConfiguration, nameof(vaultConfiguration), "Requires a Azure Key Vault configuration to setup the secret provider");
             Guard.NotNull(tokenCredential, nameof(tokenCredential), "Requires an Azure Key Vault authentication instance to authenticate with the vault");

--- a/src/Arcus.Security.Tests.Integration/Constants.cs
+++ b/src/Arcus.Security.Tests.Integration/Constants.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Arcus.Security.Tests.Integration
+{
+    public static class Constants
+    {
+        public const string AzureTenantIdEnvironmentVariable = "AZURE_TENANT_ID",
+                            AzureServicePrincipalClientIdVariable = "AZURE_CLIENT_ID",
+                            AzureServicePrincipalClientSecretVariable = "AZURE_CLIENT_SECRET";
+    }
+}

--- a/src/Arcus.Security.Tests.Integration/Fixture/TestConfig.cs
+++ b/src/Arcus.Security.Tests.Integration/Fixture/TestConfig.cs
@@ -69,16 +69,6 @@ namespace Arcus.Security.Tests.Integration.Fixture
         }
 
         /// <summary>
-        /// Gets the configured client ID of the managed identity from the application configuration.
-        /// </summary>
-        /// <exception cref="KeyNotFoundException">Thrown when there's no client ID for the managed identity found in the application configuration.</exception>
-        public string GetManagedIdentityClientId()
-        {
-            string clientId = GetRequiredValue("Arcus:ManagedIdentity:ClientId");
-            return clientId;
-        }
-
-        /// <summary>
         /// Gets the configured HashiCorp Vault execution file.
         /// </summary>
         public FileInfo GetHashiCorpVaultBin()

--- a/src/Arcus.Security.Tests.Integration/Fixture/TestConfig.cs
+++ b/src/Arcus.Security.Tests.Integration/Fixture/TestConfig.cs
@@ -39,6 +39,26 @@ namespace Arcus.Security.Tests.Integration.Fixture
         }
 
         /// <summary>
+        /// Gets the configured tenant ID from the application configuration.
+        /// </summary>
+        /// <exception cref="KeyNotFoundException">Thrown when there's no tenant ID found in the application configuration.</exception>
+        public string GetTenantId()
+        {
+            string tenantId = GetRequiredValue("Arcus:Tenant");
+            return tenantId;
+        }
+
+        /// <summary>
+        /// Gets the configured application ID from the application configuration.
+        /// </summary>
+        /// <exception cref="KeyNotFoundException">Thrown when there's no application ID found in the application configuration.</exception>
+        public string GetApplicationId()
+        {
+            string applicationId = GetRequiredValue("Arcus:ServicePrincipal:ApplicationId");
+            return applicationId;
+        }
+
+        /// <summary>
         /// Gets the configured HashiCorp Vault execution file.
         /// </summary>
         public FileInfo GetHashiCorpVaultBin()
@@ -70,6 +90,18 @@ namespace Arcus.Security.Tests.Integration.Fixture
             }
 
             return vaultFile;
+        }
+
+        private string GetRequiredValue(string key)
+        {
+            string value = _configuration[key];
+            if (String.IsNullOrWhiteSpace(value))
+            {
+                throw new KeyNotFoundException(
+                    $"Could not find configuration value for key: '{key}', was blank");
+            }
+
+            return value;
         }
 
         /// <summary>

--- a/src/Arcus.Security.Tests.Integration/Fixture/TestConfig.cs
+++ b/src/Arcus.Security.Tests.Integration/Fixture/TestConfig.cs
@@ -59,6 +59,16 @@ namespace Arcus.Security.Tests.Integration.Fixture
         }
 
         /// <summary>
+        /// Gets the configured client secret of the service principal from the application configuration.
+        /// </summary>
+        /// <exception cref="KeyNotFoundException">Thrown when there's no application secret found in the application configuration.</exception>
+        public string GetServicePrincipalClientSecret()
+        {
+            string clientSecret = GetRequiredValue("Arcus:ServicePrincipal:AccessKey");
+            return clientSecret;
+        }
+
+        /// <summary>
         /// Gets the configured client ID of the managed identity from the application configuration.
         /// </summary>
         /// <exception cref="KeyNotFoundException">Thrown when there's no client ID for the managed identity found in the application configuration.</exception>

--- a/src/Arcus.Security.Tests.Integration/Fixture/TestConfig.cs
+++ b/src/Arcus.Security.Tests.Integration/Fixture/TestConfig.cs
@@ -49,13 +49,23 @@ namespace Arcus.Security.Tests.Integration.Fixture
         }
 
         /// <summary>
-        /// Gets the configured application ID from the application configuration.
+        /// Gets the configured client ID of the service principal from the application configuration.
         /// </summary>
         /// <exception cref="KeyNotFoundException">Thrown when there's no application ID found in the application configuration.</exception>
-        public string GetApplicationId()
+        public string GetServicePrincipalClientId()
         {
-            string applicationId = GetRequiredValue("Arcus:ServicePrincipal:ApplicationId");
-            return applicationId;
+            string clientId = GetRequiredValue("Arcus:ServicePrincipal:ApplicationId");
+            return clientId;
+        }
+
+        /// <summary>
+        /// Gets the configured client ID of the managed identity from the application configuration.
+        /// </summary>
+        /// <exception cref="KeyNotFoundException">Thrown when there's no client ID for the managed identity found in the application configuration.</exception>
+        public string GetManagedIdentityClientId()
+        {
+            string clientId = GetRequiredValue("Arcus:ManagedIdentity:ClientId");
+            return clientId;
         }
 
         /// <summary>

--- a/src/Arcus.Security.Tests.Integration/IntegrationTest.cs
+++ b/src/Arcus.Security.Tests.Integration/IntegrationTest.cs
@@ -1,4 +1,5 @@
-﻿using Arcus.Testing.Logging;
+﻿using Arcus.Security.Tests.Integration.Fixture;
+using Arcus.Testing.Logging;
 using Microsoft.Extensions.Configuration;
 using Xunit.Abstractions;
 
@@ -6,7 +7,7 @@ namespace Arcus.Security.Tests.Integration
 {
     public class IntegrationTest
     {
-        protected IConfiguration Configuration { get; }
+        protected TestConfig Configuration { get; }
         protected XunitTestLogger Logger { get; }
 
         public IntegrationTest(ITestOutputHelper testOutput)
@@ -14,11 +15,7 @@ namespace Arcus.Security.Tests.Integration
             Logger = new XunitTestLogger(testOutput);
 
             // The appsettings.local.json allows users to override (gitignored) settings locally for testing purposes
-            Configuration = new ConfigurationBuilder()
-                .AddJsonFile(path: "appsettings.json")
-                .AddJsonFile(path: "appsettings.local.json", optional: true)
-                .AddEnvironmentVariables()
-                .Build();
+            Configuration = TestConfig.Create();
         }
     }
 }

--- a/src/Arcus.Security.Tests.Integration/KeyVault/KeyVaultSecretProviderTests.cs
+++ b/src/Arcus.Security.Tests.Integration/KeyVault/KeyVaultSecretProviderTests.cs
@@ -113,7 +113,7 @@ namespace Arcus.Security.Tests.Integration.KeyVault
         }
 
         [Fact]
-        public async Task KeyVaultSecretProvider_WithUserAssignedManagedIdentity_GetSecret_Succeeds()
+        public async Task KeyVaultSecretProvider_WithManagedIdentity_GetSecret_Succeeds()
         {
             // Arrange
             var keyVaultUri = Configuration.GetValue<string>("Arcus:KeyVault:Uri");
@@ -153,7 +153,7 @@ namespace Arcus.Security.Tests.Integration.KeyVault
         }
 
         [Fact]
-        public async Task KeyVaultSecretProvider_WithUserAssignedManagedIdentity_GetSecret_NonExistingSecret_ThrowsSecretNotFoundException()
+        public async Task KeyVaultSecretProvider_WithManagedIdentity_GetSecret_NonExistingSecret_ThrowsSecretNotFoundException()
         {
             // Arrange
             var keyVaultUri = Configuration.GetValue<string>("Arcus:KeyVault:Uri");

--- a/src/Arcus.Security.Tests.Integration/KeyVault/KeyVaultSecretProviderTests.cs
+++ b/src/Arcus.Security.Tests.Integration/KeyVault/KeyVaultSecretProviderTests.cs
@@ -113,7 +113,7 @@ namespace Arcus.Security.Tests.Integration.KeyVault
         }
 
         [Fact]
-        public async Task KeyVaultSecretProvider_WithCustomManagedServiceIdentity_GetSecret_Succeeds()
+        public async Task KeyVaultSecretProvider_WithUserAssignedManagedIdentity_GetSecret_Succeeds()
         {
             // Arrange
             var keyVaultUri = Configuration.GetValue<string>("Arcus:KeyVault:Uri");
@@ -133,7 +133,7 @@ namespace Arcus.Security.Tests.Integration.KeyVault
         }
 
         [Fact]
-        public async Task KeyVaultSecretProvider_WithCustomManagedIdentity_GetSecret_Succeeds()
+        public async Task KeyVaultSecretProvider_WithUserAssignedManagedIdentity_GetSecret_Succeeds()
         {
             // Arrange
             var keyVaultUri = Configuration.GetValue<string>("Arcus:KeyVault:Uri");
@@ -153,7 +153,7 @@ namespace Arcus.Security.Tests.Integration.KeyVault
         }
 
         [Fact]
-        public async Task KeyVaultSecretProvider_WithCustomManagedServiceIdentity_GetSecret_NonExistingSecret_ThrowsSecretNotFoundException()
+        public async Task KeyVaultSecretProvider_WithUserAssignedManagedIdentity_GetSecret_NonExistingSecret_ThrowsSecretNotFoundException()
         {
             // Arrange
             var keyVaultUri = Configuration.GetValue<string>("Arcus:KeyVault:Uri");
@@ -172,7 +172,7 @@ namespace Arcus.Security.Tests.Integration.KeyVault
         }
 
         [Fact]
-        public async Task KeyVaultSecretProvider_WithCustomManagedIdentity_GetSecret_NonExistingSecret_ThrowsSecretNotFoundException()
+        public async Task KeyVaultSecretProvider_WithUserAssignedManagedIdentity_GetSecret_NonExistingSecret_ThrowsSecretNotFoundException()
         {
             // Arrange
             var keyVaultUri = Configuration.GetValue<string>("Arcus:KeyVault:Uri");

--- a/src/Arcus.Security.Tests.Integration/KeyVault/KeyVaultSecretProviderTests.cs
+++ b/src/Arcus.Security.Tests.Integration/KeyVault/KeyVaultSecretProviderTests.cs
@@ -137,10 +137,10 @@ namespace Arcus.Security.Tests.Integration.KeyVault
         {
             // Arrange
             var keyVaultUri = Configuration.GetValue<string>("Arcus:KeyVault:Uri");
-            string applicationId = Configuration.GetApplicationId();
+            string clientId = Configuration.GetManagedIdentityClientId();
             var keyName = Configuration.GetValue<string>("Arcus:KeyVault:TestKeyName");
             var keyVaultSecretProvider = new KeyVaultSecretProvider(
-                tokenCredential: new ManagedIdentityCredential(applicationId), 
+                tokenCredential: new ManagedIdentityCredential(clientId), 
                 vaultConfiguration: new KeyVaultConfiguration(keyVaultUri));
 
             // Act
@@ -176,10 +176,10 @@ namespace Arcus.Security.Tests.Integration.KeyVault
         {
             // Arrange
             var keyVaultUri = Configuration.GetValue<string>("Arcus:KeyVault:Uri");
-            string applicationId = Configuration.GetApplicationId();
+            string clientId = Configuration.GetManagedIdentityClientId();
             var notExistingKeyName = $"secret-{Guid.NewGuid():N}";
             var keyVaultSecretProvider = new KeyVaultSecretProvider(
-                tokenCredential: new ManagedIdentityCredential(clientId: applicationId), 
+                tokenCredential: new ManagedIdentityCredential(clientId), 
                 vaultConfiguration: new KeyVaultConfiguration(keyVaultUri));
 
             // Assert

--- a/src/Arcus.Security.Tests.Integration/KeyVault/SecretStoreBuilderExtensionsTests.cs
+++ b/src/Arcus.Security.Tests.Integration/KeyVault/SecretStoreBuilderExtensionsTests.cs
@@ -3,6 +3,7 @@ using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
 using Arcus.Security.Core;
+using Arcus.Security.Tests.Core.Fixture;
 using Arcus.Security.Tests.Integration.Fixture;
 using Azure;
 using Azure.Identity;
@@ -709,7 +710,9 @@ namespace Arcus.Security.Tests.Integration.KeyVault
         {
             // Arrange
             var keyVaultUri = Configuration.GetValue<string>("Arcus:KeyVault:Uri");
-            string clientId = Configuration.GetManagedIdentityClientId();
+            string tenantId = Configuration.GetTenantId();
+            string clientId = Configuration.GetServicePrincipalClientId();
+            var clientKey = Configuration.GetServicePrincipalClientSecret();
             var keyName = Configuration.GetValue<string>("Arcus:KeyVault:TestKeyName");
 
             var builder = new HostBuilder();
@@ -718,13 +721,18 @@ namespace Arcus.Security.Tests.Integration.KeyVault
             builder.ConfigureSecretStore((config, stores) => stores.AddAzureKeyVaultWithManagedIdentity(keyVaultUri, clientId));
 
             // Assert
-            IHost host = builder.Build();
-            var provider = host.Services.GetRequiredService<ISecretProvider>();
+            using (TemporaryEnvironmentVariable.Create(AzureTenantIdEnvironmentVariable, tenantId))
+            using (TemporaryEnvironmentVariable.Create(AzureServicePrincipalClientIdVariable, clientId))
+            using (TemporaryEnvironmentVariable.Create(AzureServicePrincipalClientSecretVariable, clientKey))
+            {
+                IHost host = builder.Build();
+                var provider = host.Services.GetRequiredService<ISecretProvider>();
 
-            Secret secret = await provider.GetSecretAsync(keyName);
-            Assert.NotNull(secret);
-            Assert.NotNull(secret.Value);
-            Assert.NotNull(secret.Version);
+                Secret secret = await provider.GetSecretAsync(keyName);
+                Assert.NotNull(secret);
+                Assert.NotNull(secret.Value);
+                Assert.NotNull(secret.Version); 
+            }
         }
 
         [Fact]
@@ -732,7 +740,9 @@ namespace Arcus.Security.Tests.Integration.KeyVault
         {
             // Arrange
             var keyVaultUri = Configuration.GetValue<string>("Arcus:KeyVault:Uri");
-            string clientId = Configuration.GetManagedIdentityClientId();
+            string tenantId = Configuration.GetTenantId();
+            string clientId = Configuration.GetServicePrincipalClientId();
+            string clientKey = Configuration.GetServicePrincipalClientSecret();
             var keyName = Configuration.GetValue<string>("Arcus:KeyVault:TestKeyName");
 
             var builder = new HostBuilder();
@@ -745,13 +755,18 @@ namespace Arcus.Security.Tests.Integration.KeyVault
             });
 
             // Assert
-            IHost host = builder.Build();
-            var provider = host.Services.GetRequiredService<ISecretProvider>();
+            using (TemporaryEnvironmentVariable.Create(Constants.AzureTenantIdEnvironmentVariable, tenantId))
+            using (TemporaryEnvironmentVariable.Create(Constants.AzureServicePrincipalClientIdVariable, clientId))
+            using (TemporaryEnvironmentVariable.Create(Constants.AzureServicePrincipalClientSecretVariable, clientKey))
+            {
+                IHost host = builder.Build();
+                var provider = host.Services.GetRequiredService<ISecretProvider>();
 
-            Secret secret = await provider.GetSecretAsync("Test-" + keyName);
-            Assert.NotNull(secret);
-            Assert.NotNull(secret.Value);
-            Assert.NotNull(secret.Version);
+                Secret secret = await provider.GetSecretAsync("Test-" + keyName);
+                Assert.NotNull(secret);
+                Assert.NotNull(secret.Value);
+                Assert.NotNull(secret.Version); 
+            }
         }
 
         [Fact]
@@ -759,7 +774,9 @@ namespace Arcus.Security.Tests.Integration.KeyVault
         {
             // Arrange
             var keyVaultUri = Configuration.GetValue<string>("Arcus:KeyVault:Uri");
-            string clientId = Configuration.GetManagedIdentityClientId();
+            string tenantId = Configuration.GetTenantId();
+            string clientId = Configuration.GetServicePrincipalClientId();
+            string clientKey = Configuration.GetServicePrincipalClientSecret();
             var keyName = Configuration.GetValue<string>("Arcus:KeyVault:TestKeyName");
 
             var builder = new HostBuilder();
@@ -772,11 +789,16 @@ namespace Arcus.Security.Tests.Integration.KeyVault
             });
 
             // Assert
-            IHost host = builder.Build();
-            var provider = host.Services.GetRequiredService<ISecretProvider>();
+            using (TemporaryEnvironmentVariable.Create(Constants.AzureTenantIdEnvironmentVariable, tenantId))
+            using (TemporaryEnvironmentVariable.Create(Constants.AzureServicePrincipalClientIdVariable, clientId))
+            using (TemporaryEnvironmentVariable.Create(Constants.AzureServicePrincipalClientSecretVariable, clientKey))
+            {
+                IHost host = builder.Build();
+                var provider = host.Services.GetRequiredService<ISecretProvider>();
 
-            await Assert.ThrowsAsync<SecretNotFoundException>(
-                () => provider.GetSecretAsync(keyName));
+                await Assert.ThrowsAsync<SecretNotFoundException>(
+                    () => provider.GetSecretAsync(keyName)); 
+            }
         }
 
         [Fact]
@@ -784,7 +806,9 @@ namespace Arcus.Security.Tests.Integration.KeyVault
         {
             // Arrange
             var keyVaultUri = Configuration.GetValue<string>("Arcus:KeyVault:Uri");
-            string clientId = Configuration.GetManagedIdentityClientId();
+            string tenantId = Configuration.GetTenantId();
+            string clientId = Configuration.GetServicePrincipalClientId();
+            string clientKey = Configuration.GetServicePrincipalClientSecret();
             var keyName = Configuration.GetValue<string>("Arcus:KeyVault:TestKeyName");
 
             var builder = new HostBuilder();
@@ -797,14 +821,19 @@ namespace Arcus.Security.Tests.Integration.KeyVault
             });
 
             // Assert
-            IHost host = builder.Build();
-            var provider = host.Services.GetRequiredService<ISecretProvider>();
+            using (TemporaryEnvironmentVariable.Create(Constants.AzureTenantIdEnvironmentVariable, tenantId))
+            using (TemporaryEnvironmentVariable.Create(Constants.AzureServicePrincipalClientIdVariable, clientId))
+            using (TemporaryEnvironmentVariable.Create(Constants.AzureServicePrincipalClientSecretVariable, clientKey))
+            {
+                IHost host = builder.Build();
+                var provider = host.Services.GetRequiredService<ISecretProvider>();
 
-            Secret secret = await provider.GetSecretAsync(keyName);
-            Assert.NotNull(secret);
-            Assert.NotNull(secret.Value);
-            Assert.NotNull(secret.Version);
-            Assert.True(cacheConfiguration.IsCalled);
+                Secret secret = await provider.GetSecretAsync(keyName);
+                Assert.NotNull(secret);
+                Assert.NotNull(secret.Value);
+                Assert.NotNull(secret.Version);
+                Assert.True(cacheConfiguration.IsCalled); 
+            }
         }
 
         [Fact]
@@ -812,7 +841,9 @@ namespace Arcus.Security.Tests.Integration.KeyVault
         {
             // Arrange
             var keyVaultUri = Configuration.GetValue<string>("Arcus:KeyVault:Uri");
-            string clientId = Configuration.GetManagedIdentityClientId();
+            string tenantId = Configuration.GetTenantId();
+            string clientId = Configuration.GetServicePrincipalClientId();
+            string clientKey = Configuration.GetServicePrincipalClientSecret();
             var keyName = "Unknown.Secret.Name";
 
             var builder = new HostBuilder();
@@ -825,11 +856,16 @@ namespace Arcus.Security.Tests.Integration.KeyVault
             });
 
             // Assert
-            IHost host = builder.Build();
-            var provider = host.Services.GetRequiredService<ISecretProvider>();
+            using (TemporaryEnvironmentVariable.Create(Constants.AzureTenantIdEnvironmentVariable, tenantId))
+            using (TemporaryEnvironmentVariable.Create(Constants.AzureServicePrincipalClientIdVariable, clientId))
+            using (TemporaryEnvironmentVariable.Create(Constants.AzureServicePrincipalClientSecretVariable, clientKey))
+            {
+                IHost host = builder.Build();
+                var provider = host.Services.GetRequiredService<ISecretProvider>();
 
-            await Assert.ThrowsAsync<SecretNotFoundException>(
-                () => provider.GetSecretAsync(keyName));
+                await Assert.ThrowsAsync<SecretNotFoundException>(
+                    () => provider.GetSecretAsync(keyName)); 
+            }
         }
 
         [Fact]
@@ -837,7 +873,9 @@ namespace Arcus.Security.Tests.Integration.KeyVault
         {
             // Arrange
             var keyVaultUri = Configuration.GetValue<string>("Arcus:KeyVault:Uri");
-            string clientId = Configuration.GetManagedIdentityClientId();
+            string tenantId = Configuration.GetTenantId();
+            string clientId = Configuration.GetServicePrincipalClientId();
+            string clientKey = Configuration.GetServicePrincipalClientSecret();
             var keyName = Configuration.GetValue<string>("Arcus:KeyVault:TestKeyName");
 
             var builder = new HostBuilder();
@@ -851,14 +889,19 @@ namespace Arcus.Security.Tests.Integration.KeyVault
             });
 
             // Assert
-            IHost host = builder.Build();
-            var provider = host.Services.GetRequiredService<ISecretProvider>();
+            using (TemporaryEnvironmentVariable.Create(Constants.AzureTenantIdEnvironmentVariable, tenantId))
+            using (TemporaryEnvironmentVariable.Create(Constants.AzureServicePrincipalClientIdVariable, clientId))
+            using (TemporaryEnvironmentVariable.Create(Constants.AzureServicePrincipalClientSecretVariable, clientKey))
+            {
+                IHost host = builder.Build();
+                var provider = host.Services.GetRequiredService<ISecretProvider>();
 
-            Secret secret = await provider.GetSecretAsync("Test-" + keyName);
-            Assert.NotNull(secret);
-            Assert.NotNull(secret.Value);
-            Assert.NotNull(secret.Version);
-            Assert.True(cacheConfiguration.IsCalled);
+                Secret secret = await provider.GetSecretAsync("Test-" + keyName);
+                Assert.NotNull(secret);
+                Assert.NotNull(secret.Value);
+                Assert.NotNull(secret.Version);
+                Assert.True(cacheConfiguration.IsCalled); 
+            }
         }
 
         [Fact]
@@ -866,7 +909,9 @@ namespace Arcus.Security.Tests.Integration.KeyVault
         {
             // Arrange
             var keyVaultUri = Configuration.GetValue<string>("Arcus:KeyVault:Uri");
-            string clientId = Configuration.GetManagedIdentityClientId();
+            string tenantId = Configuration.GetTenantId();
+            string clientId = Configuration.GetServicePrincipalClientId();
+            string clientKey = Configuration.GetServicePrincipalClientSecret();
             var keyName = Configuration.GetValue<string>("Arcus:KeyVault:TestKeyName");
 
             var builder = new HostBuilder();
@@ -880,10 +925,15 @@ namespace Arcus.Security.Tests.Integration.KeyVault
             });
 
             // Assert
-            IHost host = builder.Build();
-            var provider = host.Services.GetRequiredService<ISecretProvider>();
+            using (TemporaryEnvironmentVariable.Create(Constants.AzureTenantIdEnvironmentVariable, tenantId))
+            using (TemporaryEnvironmentVariable.Create(Constants.AzureServicePrincipalClientIdVariable, clientId))
+            using (TemporaryEnvironmentVariable.Create(Constants.AzureServicePrincipalClientSecretVariable, clientKey))
+            {
+                IHost host = builder.Build();
+                var provider = host.Services.GetRequiredService<ISecretProvider>();
 
-            await Assert.ThrowsAsync<SecretNotFoundException>(() => provider.GetSecretAsync(keyName));
+                await Assert.ThrowsAsync<SecretNotFoundException>(() => provider.GetSecretAsync(keyName)); 
+            }
         }
 
         [Fact]

--- a/src/Arcus.Security.Tests.Integration/KeyVault/SecretStoreBuilderExtensionsTests.cs
+++ b/src/Arcus.Security.Tests.Integration/KeyVault/SecretStoreBuilderExtensionsTests.cs
@@ -721,9 +721,9 @@ namespace Arcus.Security.Tests.Integration.KeyVault
             builder.ConfigureSecretStore((config, stores) => stores.AddAzureKeyVaultWithManagedIdentity(keyVaultUri, clientId));
 
             // Assert
-            using (TemporaryEnvironmentVariable.Create(AzureTenantIdEnvironmentVariable, tenantId))
-            using (TemporaryEnvironmentVariable.Create(AzureServicePrincipalClientIdVariable, clientId))
-            using (TemporaryEnvironmentVariable.Create(AzureServicePrincipalClientSecretVariable, clientKey))
+            using (TemporaryEnvironmentVariable.Create(Constants.AzureTenantIdEnvironmentVariable, tenantId))
+            using (TemporaryEnvironmentVariable.Create(Constants.AzureServicePrincipalClientIdVariable, clientId))
+            using (TemporaryEnvironmentVariable.Create(Constants.AzureServicePrincipalClientSecretVariable, clientKey))
             {
                 IHost host = builder.Build();
                 var provider = host.Services.GetRequiredService<ISecretProvider>();

--- a/src/Arcus.Security.Tests.Integration/KeyVault/SecretStoreBuilderExtensionsTests.cs
+++ b/src/Arcus.Security.Tests.Integration/KeyVault/SecretStoreBuilderExtensionsTests.cs
@@ -4,6 +4,7 @@ using System.Net.Http;
 using System.Threading.Tasks;
 using Arcus.Security.Core;
 using Arcus.Security.Tests.Integration.Fixture;
+using Azure;
 using Azure.Identity;
 using Microsoft.Azure.KeyVault.Models;
 using Microsoft.Extensions.Configuration;
@@ -704,17 +705,17 @@ namespace Arcus.Security.Tests.Integration.KeyVault
         }
 
         [Fact]
-        public async Task AddAzureKeyVaultWith_WithManagedIdentity_GetSecretSucceeds()
+        public async Task AddAzureKeyVault_WithManagedIdentity_GetSecretSucceeds()
         {
             // Arrange
             var keyVaultUri = Configuration.GetValue<string>("Arcus:KeyVault:Uri");
-            string applicationId = Configuration.GetApplicationId();
+            string clientId = Configuration.GetManagedIdentityClientId();
             var keyName = Configuration.GetValue<string>("Arcus:KeyVault:TestKeyName");
 
             var builder = new HostBuilder();
 
             // Act
-            builder.ConfigureSecretStore((config, stores) => stores.AddAzureKeyVaultWithManagedIdentity(keyVaultUri, applicationId));
+            builder.ConfigureSecretStore((config, stores) => stores.AddAzureKeyVaultWithManagedIdentity(keyVaultUri, clientId));
 
             // Assert
             IHost host = builder.Build();
@@ -731,7 +732,7 @@ namespace Arcus.Security.Tests.Integration.KeyVault
         {
             // Arrange
             var keyVaultUri = Configuration.GetValue<string>("Arcus:KeyVault:Uri");
-            string applicationId = Configuration.GetApplicationId();
+            string clientId = Configuration.GetManagedIdentityClientId();
             var keyName = Configuration.GetValue<string>("Arcus:KeyVault:TestKeyName");
 
             var builder = new HostBuilder();
@@ -740,7 +741,7 @@ namespace Arcus.Security.Tests.Integration.KeyVault
             builder.ConfigureSecretStore((config, stores) =>
             {
                 stores.AddAzureKeyVaultWithManagedIdentity(
-                    keyVaultUri, applicationId, mutateSecretName: secretName => secretName.Remove(0, 5));
+                    keyVaultUri, clientId, mutateSecretName: secretName => secretName.Remove(0, 5));
             });
 
             // Assert
@@ -758,7 +759,7 @@ namespace Arcus.Security.Tests.Integration.KeyVault
         {
             // Arrange
             var keyVaultUri = Configuration.GetValue<string>("Arcus:KeyVault:Uri");
-            string applicationId = Configuration.GetApplicationId();
+            string clientId = Configuration.GetManagedIdentityClientId();
             var keyName = Configuration.GetValue<string>("Arcus:KeyVault:TestKeyName");
 
             var builder = new HostBuilder();
@@ -767,7 +768,7 @@ namespace Arcus.Security.Tests.Integration.KeyVault
             builder.ConfigureSecretStore((config, stores) =>
             {
                 stores.AddAzureKeyVaultWithManagedIdentity(
-                    keyVaultUri, applicationId, mutateSecretName: secretName => "SOMETHING-WRONG-" + secretName);
+                    keyVaultUri, clientId, mutateSecretName: secretName => "SOMETHING-WRONG-" + secretName);
             });
 
             // Assert
@@ -783,7 +784,7 @@ namespace Arcus.Security.Tests.Integration.KeyVault
         {
             // Arrange
             var keyVaultUri = Configuration.GetValue<string>("Arcus:KeyVault:Uri");
-            string applicationId = Configuration.GetApplicationId();
+            string clientId = Configuration.GetManagedIdentityClientId();
             var keyName = Configuration.GetValue<string>("Arcus:KeyVault:TestKeyName");
 
             var builder = new HostBuilder();
@@ -792,7 +793,7 @@ namespace Arcus.Security.Tests.Integration.KeyVault
             // Act
             builder.ConfigureSecretStore((config, stores) =>
             {
-                stores.AddAzureKeyVaultWithManagedIdentity(keyVaultUri, cacheConfiguration, applicationId);
+                stores.AddAzureKeyVaultWithManagedIdentity(keyVaultUri, cacheConfiguration, clientId);
             });
 
             // Assert
@@ -811,7 +812,7 @@ namespace Arcus.Security.Tests.Integration.KeyVault
         {
             // Arrange
             var keyVaultUri = Configuration.GetValue<string>("Arcus:KeyVault:Uri");
-            string applicationId = Configuration.GetApplicationId();
+            string clientId = Configuration.GetManagedIdentityClientId();
             var keyName = "Unknown.Secret.Name";
 
             var builder = new HostBuilder();
@@ -820,7 +821,7 @@ namespace Arcus.Security.Tests.Integration.KeyVault
             // Act
             builder.ConfigureSecretStore((config, stores) =>
             {
-                stores.AddAzureKeyVaultWithManagedIdentity(keyVaultUri, clientId: applicationId, cacheConfiguration: cacheConfiguration);
+                stores.AddAzureKeyVaultWithManagedIdentity(keyVaultUri, clientId: clientId, cacheConfiguration: cacheConfiguration);
             });
 
             // Assert
@@ -836,7 +837,7 @@ namespace Arcus.Security.Tests.Integration.KeyVault
         {
             // Arrange
             var keyVaultUri = Configuration.GetValue<string>("Arcus:KeyVault:Uri");
-            string applicationId = Configuration.GetApplicationId();
+            string clientId = Configuration.GetManagedIdentityClientId();
             var keyName = Configuration.GetValue<string>("Arcus:KeyVault:TestKeyName");
 
             var builder = new HostBuilder();
@@ -846,7 +847,7 @@ namespace Arcus.Security.Tests.Integration.KeyVault
             builder.ConfigureSecretStore((config, stores) =>
             {
                 stores.AddAzureKeyVaultWithManagedIdentity(
-                    keyVaultUri, clientId: applicationId, cacheConfiguration: cacheConfiguration, mutateSecretName: secretName => secretName.Remove(0, 5));
+                    keyVaultUri, clientId: clientId, cacheConfiguration: cacheConfiguration, mutateSecretName: secretName => secretName.Remove(0, 5));
             });
 
             // Assert
@@ -865,7 +866,7 @@ namespace Arcus.Security.Tests.Integration.KeyVault
         {
             // Arrange
             var keyVaultUri = Configuration.GetValue<string>("Arcus:KeyVault:Uri");
-            string applicationId = Configuration.GetApplicationId();
+            string clientId = Configuration.GetManagedIdentityClientId();
             var keyName = Configuration.GetValue<string>("Arcus:KeyVault:TestKeyName");
 
             var builder = new HostBuilder();
@@ -875,7 +876,7 @@ namespace Arcus.Security.Tests.Integration.KeyVault
             builder.ConfigureSecretStore((config, stores) =>
             {
                 stores.AddAzureKeyVaultWithManagedIdentity(
-                    keyVaultUri, clientId: applicationId, cacheConfiguration: cacheConfiguration, mutateSecretName: secretName => "SOMETHING-WRONG-" + secretName);
+                    keyVaultUri, clientId: clientId, cacheConfiguration: cacheConfiguration, mutateSecretName: secretName => "SOMETHING-WRONG-" + secretName);
             });
 
             // Assert
@@ -930,7 +931,8 @@ namespace Arcus.Security.Tests.Integration.KeyVault
             IHost host = builder.Build();
             var provider = host.Services.GetRequiredService<ISecretProvider>();
 
-            var exception = await Assert.ThrowsAsync<AuthenticationFailedException>(() => provider.GetSecretAsync(keyName));
+            var exception = await Assert.ThrowsAsync<RequestFailedException>(() => provider.GetSecretAsync(keyName));
+            Assert.Equal((int) HttpStatusCode.Forbidden, exception.Status);
         }
     }
 }

--- a/src/Arcus.Security.Tests.Integration/KeyVault/SecretStoreBuilderExtensionsTests.cs
+++ b/src/Arcus.Security.Tests.Integration/KeyVault/SecretStoreBuilderExtensionsTests.cs
@@ -4,6 +4,7 @@ using System.Net.Http;
 using System.Threading.Tasks;
 using Arcus.Security.Core;
 using Arcus.Security.Tests.Integration.Fixture;
+using Azure.Identity;
 using Microsoft.Azure.KeyVault.Models;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -482,6 +483,454 @@ namespace Arcus.Security.Tests.Integration.KeyVault
 
             var exception = await Assert.ThrowsAsync<KeyVaultErrorException>(() => provider.GetSecretAsync(keyName));
             Assert.Equal(HttpStatusCode.Forbidden, exception.Response.StatusCode);
+        }
+
+        [Fact]
+        public async Task AddAzureKeyVaultWithTenant_WithServicePrincipal_GetSecretSucceeds()
+        {
+            // Arrange
+            string tenantId = Configuration.GetTenantId();
+            string applicationId = Configuration.GetValue<string>("Arcus:ServicePrincipal:ApplicationId");
+            var clientKey = Configuration.GetValue<string>("Arcus:ServicePrincipal:AccessKey");
+            var keyVaultUri = Configuration.GetValue<string>("Arcus:KeyVault:Uri");
+            var keyName = Configuration.GetValue<string>("Arcus:KeyVault:TestKeyName");
+
+            var builder = new HostBuilder();
+
+            // Act
+            builder.ConfigureSecretStore((config, stores) =>
+            {
+                stores.AddAzureKeyVaultWithServicePrincipal(keyVaultUri, tenantId, applicationId, clientKey);
+            });
+
+            // Assert
+            IHost host = builder.Build();
+            var provider = host.Services.GetRequiredService<ISecretProvider>();
+
+            Secret secret = await provider.GetSecretAsync(keyName);
+            Assert.NotNull(secret);
+            Assert.NotNull(secret.Value);
+            Assert.NotNull(secret.Version);
+        }
+
+        [Fact]
+        public async Task AddAzureKeyVaultWithTenant_WithServicePrincipal_GetSecretFails()
+        {
+            // Arrange
+            string tenantId = Configuration.GetTenantId();
+            string applicationId = Configuration.GetValue<string>("Arcus:ServicePrincipal:ApplicationId");
+            var clientKey = Configuration.GetValue<string>("Arcus:ServicePrincipal:AccessKey");
+            var keyVaultUri = Configuration.GetValue<string>("Arcus:KeyVault:Uri");
+            var keyName = "UnknownSecretName";
+
+            var builder = new HostBuilder();
+
+            // Act
+            builder.ConfigureSecretStore((config, stores) =>
+            {
+                stores.AddAzureKeyVaultWithServicePrincipal(keyVaultUri, tenantId, applicationId, clientKey);
+            });
+            
+            // Assert
+            IHost host = builder.Build();
+            var provider = host.Services.GetRequiredService<ISecretProvider>();
+
+            await Assert.ThrowsAsync<SecretNotFoundException>(() => provider.GetSecretAsync(keyName));
+        }
+
+        [Fact]
+        public async Task AddAzureKeyVaultWithTenant_WithServicePrincipalToDots_GetsSecretSucceeds()
+        {
+            // Arrange
+            string tenantId = Configuration.GetTenantId();
+            string applicationId = Configuration.GetValue<string>("Arcus:ServicePrincipal:ApplicationId");
+            var clientKey = Configuration.GetValue<string>("Arcus:ServicePrincipal:AccessKey");
+            var keyVaultUri = Configuration.GetValue<string>("Arcus:KeyVault:Uri");
+            var keyName = Configuration.GetValue<string>("Arcus:KeyVault:TestKeyName");
+
+            var builder = new HostBuilder();
+
+            // Act
+            builder.ConfigureSecretStore((config, stores) =>
+            {
+                stores.AddAzureKeyVaultWithServicePrincipal(
+                    keyVaultUri, tenantId, applicationId, clientKey, mutateSecretName: secretName => secretName.Remove(0, 5));
+            });
+
+            // Assert
+            IHost host = builder.Build();
+            var provider = host.Services.GetRequiredService<ISecretProvider>();
+
+            Secret secret = await provider.GetSecretAsync("Test-" + keyName);
+            Assert.NotNull(secret);
+            Assert.NotNull(secret.Value);
+            Assert.NotNull(secret.Version);
+        }
+
+        [Fact]
+        public async Task AddAzureKeyVaultWithTenant_WithServicePrincipalWrongMutation_GetsSecretsFails()
+        {
+            // Arrange
+            string tenantId = Configuration.GetTenantId();
+            string applicationId = Configuration.GetValue<string>("Arcus:ServicePrincipal:ApplicationId");
+            var clientKey = Configuration.GetValue<string>("Arcus:ServicePrincipal:AccessKey");
+            var keyVaultUri = Configuration.GetValue<string>("Arcus:KeyVault:Uri");
+            var keyName = Configuration.GetValue<string>("Arcus:KeyVault:TestKeyName");
+
+            var builder = new HostBuilder();
+
+            // Act
+            builder.ConfigureSecretStore((config, stores) =>
+            {
+                stores.AddAzureKeyVaultWithServicePrincipal(
+                    keyVaultUri, tenantId, applicationId, clientKey, mutateSecretName: secretName => "SOMETHING-WRONG-" + secretName);
+            });
+
+            // Assert
+            IHost host = builder.Build();
+            var provider = host.Services.GetRequiredService<ISecretProvider>();
+
+            await Assert.ThrowsAsync<SecretNotFoundException>(
+                () => provider.GetSecretAsync(keyName));
+        }
+
+        [Fact]
+        public async Task AddAzureKeyVaultWithTenant_WithCachedServicePrincipal_GetSecretSucceeds()
+        {
+            // Arrange
+            string tenantId = Configuration.GetTenantId();
+            string applicationId = Configuration.GetValue<string>("Arcus:ServicePrincipal:ApplicationId");
+            var clientKey = Configuration.GetValue<string>("Arcus:ServicePrincipal:AccessKey");
+            var keyVaultUri = Configuration.GetValue<string>("Arcus:KeyVault:Uri");
+            var keyName = Configuration.GetValue<string>("Arcus:KeyVault:TestKeyName");
+
+            var builder = new HostBuilder();
+
+            // Act
+            builder.ConfigureSecretStore((config, stores) =>
+            {
+                stores.AddAzureKeyVaultWithServicePrincipal(keyVaultUri, tenantId, applicationId, clientKey, allowCaching: true);
+            });
+
+            // Assert
+            IHost host = builder.Build();
+            var provider = host.Services.GetRequiredService<ISecretProvider>();
+
+            Secret secret = await provider.GetSecretAsync(keyName);
+            Assert.NotNull(secret);
+            Assert.NotNull(secret.Value);
+            Assert.NotNull(secret.Version);
+        }
+
+        [Fact]
+        public async Task AddAzureKeyVaultWithTenant_WithCachedServicePrincipal_GetSecretFails()
+        {
+            // Arrange
+            string applicationId = Configuration.GetValue<string>("Arcus:ServicePrincipal:ApplicationId");
+            var clientKey = Configuration.GetValue<string>("Arcus:ServicePrincipal:AccessKey");
+            var keyVaultUri = Configuration.GetValue<string>("Arcus:KeyVault:Uri");
+            string tenantId = Configuration.GetTenantId();
+            var keyName = "Unknown.Secret.Name";
+
+            var builder = new HostBuilder();
+
+            // Act
+            builder.ConfigureSecretStore((config, stores) =>
+            {
+                stores.AddAzureKeyVaultWithServicePrincipal(keyVaultUri, tenantId, applicationId, clientKey, allowCaching: true);
+            });
+
+            // Assert
+            IHost host = builder.Build();
+            var provider = host.Services.GetRequiredService<ISecretProvider>();
+
+            await Assert.ThrowsAsync<SecretNotFoundException>(() => provider.GetSecretAsync(keyName));
+        }
+
+        [Fact]
+        public async Task AddAzureKeyVaultWithTenant_WithCachedServicePrincipalRemovesPrefix_GetsSecretsSucceeds()
+        {
+            // Arrange
+            string tenantId = Configuration.GetTenantId();
+            string applicationId = Configuration.GetValue<string>("Arcus:ServicePrincipal:ApplicationId");
+            var clientKey = Configuration.GetValue<string>("Arcus:ServicePrincipal:AccessKey");
+            var keyVaultUri = Configuration.GetValue<string>("Arcus:KeyVault:Uri");
+            var keyName = Configuration.GetValue<string>("Arcus:KeyVault:TestKeyName");
+
+            var builder = new HostBuilder();
+
+            // Act
+            builder.ConfigureSecretStore((config, stores) =>
+            {
+                stores.AddAzureKeyVaultWithServicePrincipal(
+                    keyVaultUri, tenantId, applicationId, clientKey, allowCaching: true, mutateSecretName: secretName => secretName.Remove(0, 5));
+            });
+
+            // Assert
+            IHost host = builder.Build();
+            var provider = host.Services.GetRequiredService<ISecretProvider>();
+
+            Secret secret = await provider.GetSecretAsync("Test-" + keyName);
+            Assert.NotNull(secret);
+            Assert.NotNull(secret.Value);
+            Assert.NotNull(secret.Version);
+        }
+
+        [Fact]
+        public async Task AddAzureKeyVaultWithTenant_WithCachedServicePrincipalWrongMutation_GetsSecretFails()
+        {
+            // Arrange
+            string tenantId = Configuration.GetTenantId();
+            string applicationId = Configuration.GetValue<string>("Arcus:ServicePrincipal:ApplicationId");
+            var clientKey = Configuration.GetValue<string>("Arcus:ServicePrincipal:AccessKey");
+            var keyVaultUri = Configuration.GetValue<string>("Arcus:KeyVault:Uri");
+            var keyName = Configuration.GetValue<string>("Arcus:KeyVault:TestKeyName");
+
+            var builder = new HostBuilder();
+
+            // Act
+            builder.ConfigureSecretStore((config, stores) =>
+            {
+                stores.AddAzureKeyVaultWithServicePrincipal(
+                    keyVaultUri, tenantId, applicationId, clientKey, allowCaching: true, mutateSecretName: secretName => "SOMETHING-WRONG-" + secretName);
+            });
+
+            // Assert
+            IHost host = builder.Build();
+            var provider = host.Services.GetRequiredService<ISecretProvider>();
+
+            await Assert.ThrowsAsync<SecretNotFoundException>(
+                () => provider.GetSecretAsync(keyName));
+        }
+
+        [Fact]
+        public async Task AddAzureKeyVaultWith_WithManagedIdentity_GetSecretSucceeds()
+        {
+            // Arrange
+            var keyVaultUri = Configuration.GetValue<string>("Arcus:KeyVault:Uri");
+            string applicationId = Configuration.GetApplicationId();
+            var keyName = Configuration.GetValue<string>("Arcus:KeyVault:TestKeyName");
+
+            var builder = new HostBuilder();
+
+            // Act
+            builder.ConfigureSecretStore((config, stores) => stores.AddAzureKeyVaultWithManagedIdentity(keyVaultUri, applicationId));
+
+            // Assert
+            IHost host = builder.Build();
+            var provider = host.Services.GetRequiredService<ISecretProvider>();
+
+            Secret secret = await provider.GetSecretAsync(keyName);
+            Assert.NotNull(secret);
+            Assert.NotNull(secret.Value);
+            Assert.NotNull(secret.Version);
+        }
+
+        [Fact]
+        public async Task AddAzureKeyVault_WithManagedIdentityRemovesPrefix_GetsSecretSucceeds()
+        {
+            // Arrange
+            var keyVaultUri = Configuration.GetValue<string>("Arcus:KeyVault:Uri");
+            string applicationId = Configuration.GetApplicationId();
+            var keyName = Configuration.GetValue<string>("Arcus:KeyVault:TestKeyName");
+
+            var builder = new HostBuilder();
+
+            // Act
+            builder.ConfigureSecretStore((config, stores) =>
+            {
+                stores.AddAzureKeyVaultWithManagedIdentity(
+                    keyVaultUri, applicationId, mutateSecretName: secretName => secretName.Remove(0, 5));
+            });
+
+            // Assert
+            IHost host = builder.Build();
+            var provider = host.Services.GetRequiredService<ISecretProvider>();
+
+            Secret secret = await provider.GetSecretAsync("Test-" + keyName);
+            Assert.NotNull(secret);
+            Assert.NotNull(secret.Value);
+            Assert.NotNull(secret.Version);
+        }
+
+        [Fact]
+        public async Task AddAzureKeyVault_WithManagedIdentityWrongMutation_GetsSecretFails()
+        {
+            // Arrange
+            var keyVaultUri = Configuration.GetValue<string>("Arcus:KeyVault:Uri");
+            string applicationId = Configuration.GetApplicationId();
+            var keyName = Configuration.GetValue<string>("Arcus:KeyVault:TestKeyName");
+
+            var builder = new HostBuilder();
+
+            // Act
+            builder.ConfigureSecretStore((config, stores) =>
+            {
+                stores.AddAzureKeyVaultWithManagedIdentity(
+                    keyVaultUri, applicationId, mutateSecretName: secretName => "SOMETHING-WRONG-" + secretName);
+            });
+
+            // Assert
+            IHost host = builder.Build();
+            var provider = host.Services.GetRequiredService<ISecretProvider>();
+
+            await Assert.ThrowsAsync<SecretNotFoundException>(
+                () => provider.GetSecretAsync(keyName));
+        }
+
+        [Fact]
+        public async Task AddAzureKeyVault_WithCachedManagedIdentity_GetSecretSucceeds()
+        {
+            // Arrange
+            var keyVaultUri = Configuration.GetValue<string>("Arcus:KeyVault:Uri");
+            string applicationId = Configuration.GetApplicationId();
+            var keyName = Configuration.GetValue<string>("Arcus:KeyVault:TestKeyName");
+
+            var builder = new HostBuilder();
+            var cacheConfiguration = new SpyCacheConfiguration();
+
+            // Act
+            builder.ConfigureSecretStore((config, stores) =>
+            {
+                stores.AddAzureKeyVaultWithManagedIdentity(keyVaultUri, cacheConfiguration, applicationId);
+            });
+
+            // Assert
+            IHost host = builder.Build();
+            var provider = host.Services.GetRequiredService<ISecretProvider>();
+
+            Secret secret = await provider.GetSecretAsync(keyName);
+            Assert.NotNull(secret);
+            Assert.NotNull(secret.Value);
+            Assert.NotNull(secret.Version);
+            Assert.True(cacheConfiguration.IsCalled);
+        }
+
+        [Fact]
+        public async Task AddAzureKeyVault_WithCachedManagedIdentity_GetSecretFails()
+        {
+            // Arrange
+            var keyVaultUri = Configuration.GetValue<string>("Arcus:KeyVault:Uri");
+            string applicationId = Configuration.GetApplicationId();
+            var keyName = "Unknown.Secret.Name";
+
+            var builder = new HostBuilder();
+            var cacheConfiguration = new SpyCacheConfiguration();
+
+            // Act
+            builder.ConfigureSecretStore((config, stores) =>
+            {
+                stores.AddAzureKeyVaultWithManagedIdentity(keyVaultUri, clientId: applicationId, cacheConfiguration: cacheConfiguration);
+            });
+
+            // Assert
+            IHost host = builder.Build();
+            var provider = host.Services.GetRequiredService<ISecretProvider>();
+
+            await Assert.ThrowsAsync<SecretNotFoundException>(
+                () => provider.GetSecretAsync(keyName));
+        }
+
+        [Fact]
+        public async Task AddAzureKeyVault_WithCachedManagedIdentityRemovesPrefix_GetsSecretSucceeds()
+        {
+            // Arrange
+            var keyVaultUri = Configuration.GetValue<string>("Arcus:KeyVault:Uri");
+            string applicationId = Configuration.GetApplicationId();
+            var keyName = Configuration.GetValue<string>("Arcus:KeyVault:TestKeyName");
+
+            var builder = new HostBuilder();
+            var cacheConfiguration = new SpyCacheConfiguration();
+
+            // Act
+            builder.ConfigureSecretStore((config, stores) =>
+            {
+                stores.AddAzureKeyVaultWithManagedIdentity(
+                    keyVaultUri, clientId: applicationId, cacheConfiguration: cacheConfiguration, mutateSecretName: secretName => secretName.Remove(0, 5));
+            });
+
+            // Assert
+            IHost host = builder.Build();
+            var provider = host.Services.GetRequiredService<ISecretProvider>();
+
+            Secret secret = await provider.GetSecretAsync("Test-" + keyName);
+            Assert.NotNull(secret);
+            Assert.NotNull(secret.Value);
+            Assert.NotNull(secret.Version);
+            Assert.True(cacheConfiguration.IsCalled);
+        }
+
+        [Fact]
+        public async Task AddAzureKeyVault_WithCachedManagedIdentityWrongMutation_GetsSecretFails()
+        {
+            // Arrange
+            var keyVaultUri = Configuration.GetValue<string>("Arcus:KeyVault:Uri");
+            string applicationId = Configuration.GetApplicationId();
+            var keyName = Configuration.GetValue<string>("Arcus:KeyVault:TestKeyName");
+
+            var builder = new HostBuilder();
+            var cacheConfiguration = new SpyCacheConfiguration();
+
+            // Act
+            builder.ConfigureSecretStore((config, stores) =>
+            {
+                stores.AddAzureKeyVaultWithManagedIdentity(
+                    keyVaultUri, clientId: applicationId, cacheConfiguration: cacheConfiguration, mutateSecretName: secretName => "SOMETHING-WRONG-" + secretName);
+            });
+
+            // Assert
+            IHost host = builder.Build();
+            var provider = host.Services.GetRequiredService<ISecretProvider>();
+
+            await Assert.ThrowsAsync<SecretNotFoundException>(() => provider.GetSecretAsync(keyName));
+        }
+
+        [Fact]
+        public async Task AddAzureKeyVaultWithTenant_WithWrongServicePrincipalCredentials_Throws()
+        {
+            // Arrange
+            var keyVaultUri = Configuration.GetValue<string>("Arcus:KeyVault:Uri");
+            string tenantId = Configuration.GetTenantId();
+            var keyName = Configuration.GetValue<string>("Arcus:KeyVault:TestKeyName");
+
+            var builder = new HostBuilder();
+
+            // Act
+            builder.ConfigureSecretStore((config, stores) =>
+            {
+                stores.AddAzureKeyVaultWithServicePrincipal(keyVaultUri, tenantId, "wrong-app-id", "wrong-access-key");
+            });
+
+            // Assert
+            IHost host = builder.Build();
+            var provider = host.Services.GetRequiredService<ISecretProvider>();
+
+            var exception = await Assert.ThrowsAsync<AuthenticationFailedException>(() => provider.GetSecretAsync(keyName));
+        }
+
+        [Fact]
+        public async Task AddAzureKeyVaultWithTenant_WithWrongUnauthorizedServicePrincipal_Throws()
+        {
+            // Arrange
+            string tenantId = Configuration.GetTenantId();
+            string applicationId = Configuration.GetValue<string>("Arcus:UnauthorizedServicePrincipal:ApplicationId");
+            var clientKey = Configuration.GetValue<string>("Arcus:UnauthorizedServicePrincipal:AccessKey");
+            var keyVaultUri = Configuration.GetValue<string>("Arcus:KeyVault:Uri");
+            var keyName = Configuration.GetValue<string>("Arcus:KeyVault:TestKeyName");
+
+            var builder = new HostBuilder();
+
+            // Act
+            builder.ConfigureSecretStore((config, stores) =>
+            {
+                stores.AddAzureKeyVaultWithServicePrincipal(keyVaultUri, tenantId, applicationId, clientKey);
+            });
+
+            // Assert
+            IHost host = builder.Build();
+            var provider = host.Services.GetRequiredService<ISecretProvider>();
+
+            var exception = await Assert.ThrowsAsync<AuthenticationFailedException>(() => provider.GetSecretAsync(keyName));
         }
     }
 }

--- a/src/Arcus.Security.Tests.Integration/appsettings.json
+++ b/src/Arcus.Security.Tests.Integration/appsettings.json
@@ -18,6 +18,9 @@
         "ConnectionString": "#{Arcus_MSI_AzureServicesAuth_ConnectionString}#"
       }
     },
+    "ManagedIdentity": {
+      "ClientId": "#{Arcus.ManagedIdentity.ClientId}#"
+    },
     "HashiCorp": {
       "VaultBin": "#{Arcus.HashiCorp.VaultBin}#"
     }

--- a/src/Arcus.Security.Tests.Integration/appsettings.json
+++ b/src/Arcus.Security.Tests.Integration/appsettings.json
@@ -1,5 +1,6 @@
 ﻿{
   "Arcus": {
+    "Tenant": "#{Arcus.Tenant}#", 
     "KeyVault": {
       "Uri": "#{Arcus_KeyVault_Uri}#",
       "TestKeyName": "#{Arcus_KeyVault_TestKeyName}#"

--- a/src/Arcus.Security.Tests.Integration/appsettings.json
+++ b/src/Arcus.Security.Tests.Integration/appsettings.json
@@ -18,9 +18,6 @@
         "ConnectionString": "#{Arcus_MSI_AzureServicesAuth_ConnectionString}#"
       }
     },
-    "ManagedIdentity": {
-      "ClientId": "#{Arcus.ManagedIdentity.ClientId}#"
-    },
     "HashiCorp": {
       "VaultBin": "#{Arcus.HashiCorp.VaultBin}#"
     }

--- a/src/Arcus.Security.Tests.Unit/Blanks.cs
+++ b/src/Arcus.Security.Tests.Unit/Blanks.cs
@@ -1,0 +1,32 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+
+namespace Arcus.Security.Tests.Unit
+{
+    /// <summary>
+    /// Represents a series of blank data inputs that can be used during data-driven tests.
+    /// </summary>
+    public class Blanks : IEnumerable<object[]>
+    {
+        /// <summary>
+        /// Returns an enumerator that iterates through the collection.
+        /// </summary>
+        /// <returns>An enumerator that can be used to iterate through the collection.</returns>
+        public IEnumerator<object[]> GetEnumerator()
+        {
+            yield return new object[] { null };
+            yield return new object[] { "" };
+            yield return new object[] { "  " };
+            yield return new object[] { "    " };
+        }
+
+        /// <summary>
+        /// Returns an enumerator that iterates through a collection.
+        /// </summary>
+        /// <returns>An <see cref="System.Collections.IEnumerator"></see> object that can be used to iterate through the collection.</returns>
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+    }
+}

--- a/src/Arcus.Security.Tests.Unit/KeyVault/KeyVaultSecretProviderTests.cs
+++ b/src/Arcus.Security.Tests.Unit/KeyVault/KeyVaultSecretProviderTests.cs
@@ -8,12 +8,36 @@ using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
 using Arcus.Security.Providers.AzureKeyVault;
+using Azure.Core;
+using Moq;
 using Xunit;
 
 namespace Arcus.Security.Tests.Unit.KeyVault
 {
     public class KeyVaultSecretProviderTests
     {
+        [Fact]
+        public void KeyVaultSecretProvider_WithoutTokenCredential_Throws()
+        {
+            // Arrange
+            var config = Mock.Of<IKeyVaultConfiguration>();
+
+            // Act / Assert
+            Assert.ThrowsAny<ArgumentException>(
+                () => new KeyVaultSecretProvider(tokenCredential: null, vaultConfiguration: config));
+        }
+
+        [Fact]
+        public void KeyVaultSecretProvider_WithTokenCredentialWithoutVaultConfiguration_Throws()
+        {
+            // Arrange
+            var authentication = Mock.Of<TokenCredential>();
+
+            // Act / Assert
+            Assert.ThrowsAny<ArgumentException>(
+                () => new KeyVaultSecretProvider(authentication, vaultConfiguration: null));
+        }
+
         [Fact]
         public void KeyVaultSecretProvider_CreateWithEmptyUri_ShouldFailWithUriFormatException()
         {
@@ -50,7 +74,7 @@ namespace Arcus.Security.Tests.Unit.KeyVault
             string uri = GenerateVaultUri();
 
             // Act & Assert
-            Assert.ThrowsAny<ArgumentException>(() => new KeyVaultSecretProvider(null, new KeyVaultConfiguration(uri)));
+            Assert.ThrowsAny<ArgumentException>(() => new KeyVaultSecretProvider(authentication: null, new KeyVaultConfiguration(uri)));
         }
 
         [Fact]

--- a/src/Arcus.Security.Tests.Unit/KeyVault/SecretStoreBuilderExtensionsTests.cs
+++ b/src/Arcus.Security.Tests.Unit/KeyVault/SecretStoreBuilderExtensionsTests.cs
@@ -107,6 +107,129 @@ namespace Arcus.Security.Tests.Unit.KeyVault
 
         [Theory]
         [ClassData(typeof(Blanks))]
+        public void AddAzureKeyVaultWithCertificateUsingTenant_WithBlankVaultUri_Throws(string vaultUri)
+        {
+            // Arrange
+            var builder = new HostBuilder();
+            
+            // Act
+            builder.ConfigureSecretStore(
+                (config, stores) => stores.AddAzureKeyVaultWithCertificate(vaultUri, "tenant-id", "client-id", new X509Certificate2()));
+
+            // Assert
+            Assert.ThrowsAny<ArgumentException>(() => builder.Build());
+        }
+
+        [Theory]
+        [ClassData(typeof(Blanks))]
+        public void AddAzureKeyVaultWithCertificateUsingTenant_WithCachingWithBlankVaultUri_Throws(string vaultUri)
+        {
+            // Arrange
+            var builder = new HostBuilder();
+            var cacheConfiguration = Mock.Of<ICacheConfiguration>();
+
+            // Act
+            builder.ConfigureSecretStore(
+                (config, stores) => stores.AddAzureKeyVaultWithCertificate(vaultUri, "tenant-id", "client-id", new X509Certificate2(), cacheConfiguration: cacheConfiguration));
+
+            // Assert
+            Assert.ThrowsAny<ArgumentException>(() => builder.Build());
+        }
+
+        [Theory]
+        [ClassData(typeof(Blanks))]
+        public void AddAzureKeyVaultWithCertificateUsingTenant_WithBlankClientId_Throws(string clientId)
+        {
+            // Arrange
+            var builder = new HostBuilder();
+
+            // Act
+            builder.ConfigureSecretStore(
+                (config, stores) => stores.AddAzureKeyVaultWithCertificate("vault-uri", "tenant-id", clientId, new X509Certificate2()));
+
+            // Assert
+            Assert.ThrowsAny<ArgumentException>(() => builder.Build());
+        }
+
+        [Theory]
+        [ClassData(typeof(Blanks))]
+        public void AddAzureKeyVaultWithCertificateUsingTenant_WithCachingWithBlankClientId_Throws(string clientId)
+        {
+            // Arrange
+            var builder = new HostBuilder();
+            var cacheConfiguration = Mock.Of<ICacheConfiguration>();
+
+            // Act
+            builder.ConfigureSecretStore(
+                (config, stores) => stores.AddAzureKeyVaultWithCertificate("vault-uri", "tenant-id", clientId, new X509Certificate2(), cacheConfiguration));
+
+            // Assert
+            Assert.ThrowsAny<ArgumentException>(() => builder.Build());
+        }
+
+        [Fact]
+        public void AddAzureKeyVaultWithCertificateUsingTenant_WithoutCertificate_Throws()
+        {
+            // Arrange
+            var builder = new HostBuilder();
+
+            // Act
+            builder.ConfigureSecretStore(
+                (config, stores) => stores.AddAzureKeyVaultWithCertificate("vault-uri", "tenant-id", "client-id", certificate: null));
+
+            // Assert
+            Assert.ThrowsAny<ArgumentException>(() => builder.Build());
+        }
+
+        [Fact]
+        public void AddAzureKeyVaultWithCertificateUsingTenant_WithCachingWithoutCertificate_Throws()
+        {
+            // Arrange
+            var builder = new HostBuilder();
+            var cacheConfiguration = Mock.Of<ICacheConfiguration>();
+
+            // Act
+            builder.ConfigureSecretStore(
+                (config, stores) => stores.AddAzureKeyVaultWithCertificate("vault-uri", "tenant-id", "client-id", certificate: null, cacheConfiguration: cacheConfiguration));
+
+            // Assert
+            Assert.ThrowsAny<ArgumentException>(() => builder.Build());
+        }
+
+        [Theory]
+        [ClassData(typeof(Blanks))]
+        public void AddAzureKeyVaultWithCertificateUsingTenant_WithBlankTenant_Throws(string tenantId)
+        {
+            // Arrange
+            var builder = new HostBuilder();
+            var cacheConfiguration = Mock.Of<ICacheConfiguration>();
+
+            // Act
+            builder.ConfigureSecretStore(
+                (config, stores) => stores.AddAzureKeyVaultWithCertificate("vault-uri", tenantId, "client-id", new X509Certificate2(), cacheConfiguration));
+
+            // Assert
+            Assert.ThrowsAny<ArgumentException>(() => builder.Build());
+        }
+
+        [Theory]
+        [ClassData(typeof(Blanks))]
+        public void AddAzureKeyVaultWithCertificateUsingTenant_WithCachingWithBlankTenant_Throws(string tenantId)
+        {
+            // Arrange
+            var builder = new HostBuilder();
+            var cacheConfiguration = Mock.Of<ICacheConfiguration>();
+
+            // Act
+            builder.ConfigureSecretStore(
+                (config, stores) => stores.AddAzureKeyVaultWithCertificate("vault-uri", tenantId, "client-id", new X509Certificate2()));
+
+            // Assert
+            Assert.ThrowsAny<ArgumentException>(() => builder.Build());
+        }
+
+        [Theory]
+        [ClassData(typeof(Blanks))]
         public void AddAzureKeyVaultWithManagedServiceIdentity_WithBlankVaultUri_Throws(string vaultUri)
         {
             // Arrange
@@ -131,6 +254,37 @@ namespace Arcus.Security.Tests.Unit.KeyVault
             // Act
             builder.ConfigureSecretStore(
                 (config, stores) => stores.AddAzureKeyVaultWithManagedServiceIdentity(vaultUri, cacheConfiguration: cacheConfiguration));
+
+            // Assert
+            Assert.ThrowsAny<ArgumentException>(() => builder.Build());
+        }
+
+        [Theory]
+        [ClassData(typeof(Blanks))]
+        public void AddAzureKeyVaultWithManagedIdentity_WithBlankVaultUri_Throws(string vaultUri)
+        {
+            // Arrange
+            var builder = new HostBuilder();
+
+            // Act
+            builder.ConfigureSecretStore(
+                (config, stores) => stores.AddAzureKeyVaultWithManagedIdentity(vaultUri));
+
+            // Assert
+            Assert.ThrowsAny<ArgumentException>(() => builder.Build());
+        }
+
+        [Theory]
+        [ClassData(typeof(Blanks))]
+        public void AddAzureKeyVaultWithManagedIdentity_WithCachingWithBlankVaultUri_Throws(string vaultUri)
+        {
+            // Arrange
+            var builder = new HostBuilder();
+            var cacheConfiguration = Mock.Of<ICacheConfiguration>();
+
+            // Act
+            builder.ConfigureSecretStore(
+                (config, stores) => stores.AddAzureKeyVaultWithManagedIdentity(vaultUri, cacheConfiguration: cacheConfiguration));
 
             // Assert
             Assert.ThrowsAny<ArgumentException>(() => builder.Build());
@@ -229,6 +383,134 @@ namespace Arcus.Security.Tests.Unit.KeyVault
             Assert.ThrowsAny<ArgumentException>(() => builder.Build());
         }
 
+
+
+
+
+        [Theory]
+        [ClassData(typeof(Blanks))]
+        public void AddAzureKeyVaultWithServicePrincipalWithTenant_WithBlankVaultUri_Throws(string vaultUri)
+        {
+            // Arrange
+            var builder = new HostBuilder();
+
+            // Act
+            builder.ConfigureSecretStore(
+                (config, stores) => stores.AddAzureKeyVaultWithServicePrincipal(vaultUri, "tenant-id", "client-id", "client-secret"));
+
+            // Assert
+            Assert.ThrowsAny<ArgumentException>(() => builder.Build());
+        }
+
+        [Theory]
+        [ClassData(typeof(Blanks))]
+        public void AddAzureKeyVaultWithServicePrincipalWithTenant_WithCachingWithBlankVaultUri_Throws(string vaultUri)
+        {
+            // Arrange
+            var builder = new HostBuilder();
+            var cacheConfiguration = Mock.Of<ICacheConfiguration>();
+
+            // Act
+            builder.ConfigureSecretStore(
+                (config, stores) => stores.AddAzureKeyVaultWithServicePrincipal(vaultUri, "tenant-id", "client-id", "client-secret", cacheConfiguration));
+
+            // Assert
+            Assert.ThrowsAny<ArgumentException>(() => builder.Build());
+        }
+
+        [Theory]
+        [ClassData(typeof(Blanks))]
+        public void AddAzureKeyVaultWithServicePrincipalWithTenant_WithBlankClientId_Throws(string clientId)
+        {
+            // Arrange
+            var builder = new HostBuilder();
+
+            // Act
+            builder.ConfigureSecretStore(
+                (config, stores) => stores.AddAzureKeyVaultWithServicePrincipal("vault-uri", "tenant-id", clientId, "client-secret"));
+
+            // Assert
+            Assert.ThrowsAny<ArgumentException>(() => builder.Build());
+        }
+
+        [Theory]
+        [ClassData(typeof(Blanks))]
+        public void AddAzureKeyVaultWithServicePrincipalWithTenant_WithCachingWithBlankClientId_Throws(string clientId)
+        {
+            // Arrange
+            var builder = new HostBuilder();
+            var cacheConfiguration = Mock.Of<ICacheConfiguration>();
+
+            // Act
+            builder.ConfigureSecretStore(
+                (config, stores) => stores.AddAzureKeyVaultWithServicePrincipal("vault-uri", "tenant-id", clientId, "client-secret", cacheConfiguration));
+
+            // Assert
+            Assert.ThrowsAny<ArgumentException>(() => builder.Build());
+        }
+
+        [Theory]
+        [ClassData(typeof(Blanks))]
+        public void AddAzureKeyVaultWithServicePrincipalWithTenant_WithBlankClientSecret_Throws(string tenantId)
+        {
+            // Arrange
+            var builder = new HostBuilder();
+
+            // Act
+            builder.ConfigureSecretStore(
+                (config, stores) => stores.AddAzureKeyVaultWithServicePrincipal("vault-uri", "tenant-id", "client-id", tenantId));
+
+            // Assert
+            Assert.ThrowsAny<ArgumentException>(() => builder.Build());
+        }
+
+        [Theory]
+        [ClassData(typeof(Blanks))]
+        public void AddAzureKeyVaultWithServicePrincipalWithTenant_WithCachingWithBlankClientSecret_Throws(string clientSecret)
+        {
+            // Arrange
+            var builder = new HostBuilder();
+            var cacheConfiguration = Mock.Of<ICacheConfiguration>();
+
+            // Act
+            builder.ConfigureSecretStore(
+                (config, stores) => stores.AddAzureKeyVaultWithServicePrincipal("vault-uri", "tenant-id", "client-id", clientSecret, cacheConfiguration: cacheConfiguration));
+
+            // Assert
+            Assert.ThrowsAny<ArgumentException>(() => builder.Build());
+        }
+
+        [Theory]
+        [ClassData(typeof(Blanks))]
+        public void AddAzureKeyVaultWithServicePrincipalWithTenant_WithCachingWithBlankTenant_Throws(string tenantId)
+        {
+            // Arrange
+            var builder = new HostBuilder();
+            var cacheConfiguration = Mock.Of<ICacheConfiguration>();
+
+            // Act
+            builder.ConfigureSecretStore(
+                (config, stores) => stores.AddAzureKeyVaultWithServicePrincipal("vault-uri", tenantId, "client-id", "client-secret", cacheConfiguration: cacheConfiguration));
+
+            // Assert
+            Assert.ThrowsAny<ArgumentException>(() => builder.Build());
+        }
+
+        [Theory]
+        [ClassData(typeof(Blanks))]
+        public void AddAzureKeyVaultWithServicePrincipalWithTenant_WithBlankTenant_Throws(string tenantId)
+        {
+            // Arrange
+            var builder = new HostBuilder();
+
+            // Act
+            builder.ConfigureSecretStore(
+                (config, stores) => stores.AddAzureKeyVaultWithServicePrincipal("vault-uri", tenantId, "client-id", "client-secret"));
+
+            // Assert
+            Assert.ThrowsAny<ArgumentException>(() => builder.Build());
+        }
+
         [Fact]
         public void AddAzureKeyVault_WithoutAuthentication_Throws()
         {
@@ -284,7 +566,7 @@ namespace Arcus.Security.Tests.Unit.KeyVault
 
             // Act
             builder.ConfigureSecretStore(
-                (config, stores) => stores.AddAzureKeyVault(credential, configuration: null));
+                (config, stores) => stores.AddAzureKeyVault(credential, configuration: null, allowCaching: false));
 
             // Assert
             Assert.ThrowsAny<ArgumentException>(() => builder.Build());
@@ -315,7 +597,7 @@ namespace Arcus.Security.Tests.Unit.KeyVault
 
             // Act
             builder.ConfigureSecretStore(
-                (config, stores) => stores.AddAzureKeyVault(tokenCredential: null, configuration: configuration));
+                (config, stores) => stores.AddAzureKeyVault(tokenCredential: null, configuration: configuration, allowCaching: false));
 
             // Assert
             Assert.ThrowsAny<ArgumentException>(() => builder.Build());

--- a/src/Arcus.Security.Tests.Unit/KeyVault/SecretStoreBuilderExtensionsTests.cs
+++ b/src/Arcus.Security.Tests.Unit/KeyVault/SecretStoreBuilderExtensionsTests.cs
@@ -1,0 +1,340 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Security.Cryptography.X509Certificates;
+using System.Text;
+using Arcus.Security.Core.Caching.Configuration;
+using Arcus.Security.Providers.AzureKeyVault.Authentication;
+using Arcus.Security.Providers.AzureKeyVault.Configuration;
+using Azure.Core;
+using Microsoft.Extensions.Hosting;
+using Moq;
+using Xunit;
+
+namespace Arcus.Security.Tests.Unit.KeyVault
+{
+    public class SecretStoreBuilderExtensionsTests
+    {
+        [Theory]
+        [ClassData(typeof(Blanks))]
+        public void AddAzureKeyVaultWithCertificate_WithBlankVaultUri_Throws(string vaultUri)
+        {
+            // Arrange
+            var builder = new HostBuilder();
+            
+            // Act
+            builder.ConfigureSecretStore(
+                (config, stores) => stores.AddAzureKeyVaultWithCertificate(vaultUri, "client-id", new X509Certificate2()));
+
+            // Assert
+            Assert.ThrowsAny<ArgumentException>(() => builder.Build());
+        }
+
+        [Theory]
+        [ClassData(typeof(Blanks))]
+        public void AddAzureKeyVaultWithCertificate_WithCachingWithBlankVaultUri_Throws(string vaultUri)
+        {
+            // Arrange
+            var builder = new HostBuilder();
+            var cacheConfiguration = Mock.Of<ICacheConfiguration>();
+
+            // Act
+            builder.ConfigureSecretStore(
+                (config, stores) => stores.AddAzureKeyVaultWithCertificate(vaultUri, "client-id", new X509Certificate2(), cacheConfiguration: cacheConfiguration));
+
+            // Assert
+            Assert.ThrowsAny<ArgumentException>(() => builder.Build());
+        }
+
+        [Theory]
+        [ClassData(typeof(Blanks))]
+        public void AddAzureKeyVaultWithCertificate_WithBlankClientId_Throws(string clientId)
+        {
+            // Arrange
+            var builder = new HostBuilder();
+
+            // Act
+            builder.ConfigureSecretStore(
+                (config, stores) => stores.AddAzureKeyVaultWithCertificate("vault-uri", clientId, new X509Certificate2()));
+
+            // Assert
+            Assert.ThrowsAny<ArgumentException>(() => builder.Build());
+        }
+
+        [Theory]
+        [ClassData(typeof(Blanks))]
+        public void AddAzureKeyVaultWithCertificate_WithCachingWithBlankClientId_Throws(string clientId)
+        {
+            // Arrange
+            var builder = new HostBuilder();
+            var cacheConfiguration = Mock.Of<ICacheConfiguration>();
+
+            // Act
+            builder.ConfigureSecretStore(
+                (config, stores) => stores.AddAzureKeyVaultWithCertificate("vault-uri", clientId, new X509Certificate2(), cacheConfiguration));
+
+            // Assert
+            Assert.ThrowsAny<ArgumentException>(() => builder.Build());
+        }
+
+        [Fact]
+        public void AddAzureKeyVaultWithCertificate_WithoutCertificate_Throws()
+        {
+            // Arrange
+            var builder = new HostBuilder();
+
+            // Act
+            builder.ConfigureSecretStore(
+                (config, stores) => stores.AddAzureKeyVaultWithCertificate("vault-uri", "client-id", certificate: null));
+
+            // Assert
+            Assert.ThrowsAny<ArgumentException>(() => builder.Build());
+        }
+
+        [Fact]
+        public void AddAzureKeyVaultWithCertificate_WithCachingWithoutCertificate_Throws()
+        {
+            // Arrange
+            var builder = new HostBuilder();
+            var cacheConfiguration = Mock.Of<ICacheConfiguration>();
+
+            // Act
+            builder.ConfigureSecretStore(
+                (config, stores) => stores.AddAzureKeyVaultWithCertificate("vault-uri", "client-id", certificate: null, cacheConfiguration: cacheConfiguration));
+
+            // Assert
+            Assert.ThrowsAny<ArgumentException>(() => builder.Build());
+        }
+
+        [Theory]
+        [ClassData(typeof(Blanks))]
+        public void AddAzureKeyVaultWithManagedServiceIdentity_WithBlankVaultUri_Throws(string vaultUri)
+        {
+            // Arrange
+            var builder = new HostBuilder();
+
+            // Act
+            builder.ConfigureSecretStore(
+                (config, stores) => stores.AddAzureKeyVaultWithManagedServiceIdentity(vaultUri));
+
+            // Assert
+            Assert.ThrowsAny<ArgumentException>(() => builder.Build());
+        }
+
+        [Theory]
+        [ClassData(typeof(Blanks))]
+        public void AddAzureKeyVaultWithManagedServiceIdentity_WithCachingWithBlankVaultUri_Throws(string vaultUri)
+        {
+            // Arrange
+            var builder = new HostBuilder();
+            var cacheConfiguration = Mock.Of<ICacheConfiguration>();
+
+            // Act
+            builder.ConfigureSecretStore(
+                (config, stores) => stores.AddAzureKeyVaultWithManagedServiceIdentity(vaultUri, cacheConfiguration: cacheConfiguration));
+
+            // Assert
+            Assert.ThrowsAny<ArgumentException>(() => builder.Build());
+        }
+
+        [Theory]
+        [ClassData(typeof(Blanks))]
+        public void AddAzureKeyVaultWithServicePrincipal_WithBlankVaultUri_Throws(string vaultUri)
+        {
+            // Arrange
+            var builder = new HostBuilder();
+
+            // Act
+            builder.ConfigureSecretStore(
+                (config, stores) => stores.AddAzureKeyVaultWithServicePrincipal(vaultUri, "client-id", "client-secret"));
+
+            // Assert
+            Assert.ThrowsAny<ArgumentException>(() => builder.Build());
+        }
+
+        [Theory]
+        [ClassData(typeof(Blanks))]
+        public void AddAzureKeyVaultWithServicePrincipal_WithCachingWithBlankVaultUri_Throws(string vaultUri)
+        {
+            // Arrange
+            var builder = new HostBuilder();
+            var cacheConfiguration = Mock.Of<ICacheConfiguration>();
+
+            // Act
+            builder.ConfigureSecretStore(
+                (config, stores) => stores.AddAzureKeyVaultWithServicePrincipal(vaultUri, "client-id", "client-secret", cacheConfiguration));
+
+            // Assert
+            Assert.ThrowsAny<ArgumentException>(() => builder.Build());
+        }
+
+        [Theory]
+        [ClassData(typeof(Blanks))]
+        public void AddAzureKeyVaultWithServicePrincipal_WithBlankClientId_Throws(string clientId)
+        {
+            // Arrange
+            var builder = new HostBuilder();
+
+            // Act
+            builder.ConfigureSecretStore(
+                (config, stores) => stores.AddAzureKeyVaultWithServicePrincipal("vault-uri", clientId, "client-secret"));
+
+            // Assert
+            Assert.ThrowsAny<ArgumentException>(() => builder.Build());
+        }
+
+        [Theory]
+        [ClassData(typeof(Blanks))]
+        public void AddAzureKeyVaultWithServicePrincipal_WithCachingWithBlankClientId_Throws(string clientId)
+        {
+            // Arrange
+            var builder = new HostBuilder();
+            var cacheConfiguration = Mock.Of<ICacheConfiguration>();
+
+            // Act
+            builder.ConfigureSecretStore(
+                (config, stores) => stores.AddAzureKeyVaultWithServicePrincipal("vault-uri", clientId, "client-secret", cacheConfiguration));
+
+            // Assert
+            Assert.ThrowsAny<ArgumentException>(() => builder.Build());
+        }
+
+        [Theory]
+        [ClassData(typeof(Blanks))]
+        public void AddAzureKeyVaultWithServicePrincipal_WithBlankClientSecret_Throws(string clientSecret)
+        {
+            // Arrange
+            var builder = new HostBuilder();
+
+            // Act
+            builder.ConfigureSecretStore(
+                (config, stores) => stores.AddAzureKeyVaultWithServicePrincipal("vault-uri", "client-id", clientSecret));
+
+            // Assert
+            Assert.ThrowsAny<ArgumentException>(() => builder.Build());
+        }
+
+        [Theory]
+        [ClassData(typeof(Blanks))]
+        public void AddAzureKeyVaultWithServicePrincipal_WithCachingWithBlankClientSecret_Throws(string clientSecret)
+        {
+            // Arrange
+            var builder = new HostBuilder();
+            var cacheConfiguration = Mock.Of<ICacheConfiguration>();
+
+            // Act
+            builder.ConfigureSecretStore(
+                (config, stores) => stores.AddAzureKeyVaultWithServicePrincipal("vault-uri", "client-id", clientSecret, cacheConfiguration: cacheConfiguration));
+
+            // Assert
+            Assert.ThrowsAny<ArgumentException>(() => builder.Build());
+        }
+
+        [Fact]
+        public void AddAzureKeyVault_WithoutAuthentication_Throws()
+        {
+            // Arrange
+            var builder = new HostBuilder();
+            var configuration = Mock.Of<IKeyVaultConfiguration>();
+
+            // Act
+            builder.ConfigureSecretStore(
+                (config, stores) => stores.AddAzureKeyVault(authentication: null, configuration: configuration));
+
+            // Assert
+            Assert.ThrowsAny<ArgumentException>(() => builder.Build());
+        }
+
+        [Fact]
+        public void AddAzureKeyVault_WithCachingWithoutAuthentication_Throws()
+        {
+            // Arrange
+            var builder = new HostBuilder();
+            var configuration = Mock.Of<IKeyVaultConfiguration>();
+            var cacheConfiguration = Mock.Of<ICacheConfiguration>();
+
+            // Act
+            builder.ConfigureSecretStore(
+                (config, stores) => stores.AddAzureKeyVault(authentication: null, configuration: configuration, cacheConfiguration: cacheConfiguration));
+
+            // Assert
+            Assert.ThrowsAny<ArgumentException>(() => builder.Build());
+        }
+
+        [Fact]
+        public void AddAzureKeyVault_WithoutVaultConfiguration_Throws()
+        {
+            // Arrange
+            var builder = new HostBuilder();
+            var authentication = Mock.Of<IKeyVaultAuthentication>();
+
+            // Act
+            builder.ConfigureSecretStore(
+                (config, stores) => stores.AddAzureKeyVault(authentication, configuration: null));
+
+            // Assert
+            Assert.ThrowsAny<ArgumentException>(() => builder.Build());
+        }
+
+        [Fact]
+        public void AddAzureKeyVaultSdk_WithoutVaultConfiguration_Throws()
+        {
+            // Arrange
+            var builder = new HostBuilder();
+            var credential = Mock.Of<TokenCredential>();
+
+            // Act
+            builder.ConfigureSecretStore(
+                (config, stores) => stores.AddAzureKeyVault(credential, configuration: null));
+
+            // Assert
+            Assert.ThrowsAny<ArgumentException>(() => builder.Build());
+        }
+
+        [Fact]
+        public void AddAzureKeyVaultSdk_WithCachingWithoutVaultConfiguration_Throws()
+        {
+            // Arrange
+            var builder = new HostBuilder();
+            var credential = Mock.Of<TokenCredential>();
+            var cacheConfiguration = Mock.Of<ICacheConfiguration>();
+
+            // Act
+            builder.ConfigureSecretStore(
+                (config, stores) => stores.AddAzureKeyVault(credential, configuration: null, cacheConfiguration: cacheConfiguration));
+
+            // Assert
+            Assert.ThrowsAny<ArgumentException>(() => builder.Build());
+        }
+
+        [Fact]
+        public void AddAzureKeyVaultSdk_WithoutTokenCredential_Throws()
+        {
+            // Arrange
+            var builder = new HostBuilder();
+            var configuration = Mock.Of<IKeyVaultConfiguration>();
+
+            // Act
+            builder.ConfigureSecretStore(
+                (config, stores) => stores.AddAzureKeyVault(tokenCredential: null, configuration: configuration));
+
+            // Assert
+            Assert.ThrowsAny<ArgumentException>(() => builder.Build());
+        }
+
+        [Fact]
+        public void AddAzureKeyVaultSdk_WithCachingWithoutTokenCredential_Throws()
+        {
+            // Arrange
+            var builder = new HostBuilder();
+            var configuration = Mock.Of<IKeyVaultConfiguration>();
+            var cacheConfiguration = Mock.Of<ICacheConfiguration>();
+
+            // Act
+            builder.ConfigureSecretStore(
+                (config, stores) => stores.AddAzureKeyVault(tokenCredential: null, configuration: configuration, cacheConfiguration: cacheConfiguration));
+
+            // Assert
+            Assert.ThrowsAny<ArgumentException>(() => builder.Build());
+        }
+    }
+}

--- a/src/Arcus.Security.Tests.Unit/KeyVault/SecretStoreBuilderExtensionsTests.cs
+++ b/src/Arcus.Security.Tests.Unit/KeyVault/SecretStoreBuilderExtensionsTests.cs
@@ -383,10 +383,6 @@ namespace Arcus.Security.Tests.Unit.KeyVault
             Assert.ThrowsAny<ArgumentException>(() => builder.Build());
         }
 
-
-
-
-
         [Theory]
         [ClassData(typeof(Blanks))]
         public void AddAzureKeyVaultWithServicePrincipalWithTenant_WithBlankVaultUri_Throws(string vaultUri)


### PR DESCRIPTION
Provide capability to use both the 'old' as the 'new' SDK packages for interacting with the Azure Key Vault.
This includes double support in the secret provider itself, and updating the secret store builder extensions to have support for these new authentication types.

Closes #191 