### PR TITLE
Feature - opt-in of security events in secret store

### DIFF
--- a/docs/preview/features/secret-store/index.md
+++ b/docs/preview/features/secret-store/index.md
@@ -131,4 +131,21 @@ public class MyHttpTrigger
 }
 ```
 
+## Secret store configuration
+The secret store as additional configuration that controls the behavior of the store.
+See below the available features so you can setup your secret store for your needs.
+
+### Include security auditing
+The secret store has the ability to audit each secret retrieval so malicious activity can be spotted more easily.
+This functionality is available in both the regular .NET Core as Azure Functions environment.
+
+```csharp
+.ConfigureSecretStore((config, stores) =>
+{
+    // Will log an security event for each retrieved secret, including the secret name and the provider that has tried to retrieve the secret.
+    // Default: `false`
+    stores.WithAuditing(options => options.EmitSecurityEvents = true);
+})
+```
+
 [&larr; back](/)

--- a/src/Arcus.Security.Core/Arcus.Security.Core.csproj
+++ b/src/Arcus.Security.Core/Arcus.Security.Core.csproj
@@ -20,6 +20,7 @@
 
 
   <ItemGroup>
+    <PackageReference Include="Arcus.Observability.Telemetry.Core" Version="1.0.0" />
     <PackageReference Include="Guard.Net" Version="1.2.0" />
     <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="3.1.8" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="3.1.8" />

--- a/src/Arcus.Security.Core/CompositeSecretProvider.cs
+++ b/src/Arcus.Security.Core/CompositeSecretProvider.cs
@@ -9,6 +9,7 @@ using GuardNet;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
 
 namespace Arcus.Security.Core
 {
@@ -19,6 +20,7 @@ namespace Arcus.Security.Core
     {
         private readonly IEnumerable<SecretStoreSource> _secretProviders;
         private readonly IEnumerable<CriticalExceptionFilter> _criticalExceptionFilters;
+        private readonly SecretStoreAuditingOptions _auditingOptions;
         private readonly ILogger _logger;
 
         /// <summary>
@@ -26,21 +28,26 @@ namespace Arcus.Security.Core
         /// </summary>
         /// <param name="secretProviderSources">The sequence of all available registered secret provider registrations.</param>
         /// <param name="criticalExceptionFilters">The sequence of all available registered critical exception filters.</param>
+        /// <param name="auditingOptions">The customized options to configure the auditing of the secret store.</param>
         /// <param name="logger">The logger instance to write diagnostic messages during the retrieval of secrets via the registered <paramref name="secretProviderSources"/>.</param>
-        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="secretProviderSources"/> or <paramref name="criticalExceptionFilters"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="secretProviderSources"/> or <paramref name="criticalExceptionFilters"/> or <paramref name="auditingOptions"/> is <c>null</c>.</exception>
         /// <exception cref="ArgumentException">Thrown when the <paramref name="secretProviderSources"/> of the <paramref name="criticalExceptionFilters"/> contains any <c>null</c> values.</exception>
         public CompositeSecretProvider(
             IEnumerable<SecretStoreSource> secretProviderSources, 
             IEnumerable<CriticalExceptionFilter> criticalExceptionFilters,
+            IOptions<SecretStoreAuditingOptions> auditingOptions,
             ILogger<CompositeSecretProvider> logger)
         {
             Guard.NotNull(secretProviderSources, nameof(secretProviderSources), "Requires a series of registered secret provider registrations to retrieve secrets");
             Guard.NotNull(criticalExceptionFilters, nameof(criticalExceptionFilters), "Requires a series of registered critical exception filters to determine if a thrown exception is critical");
+            Guard.NotNull(auditingOptions, nameof(auditingOptions), "Requires a set of options to configure the auditing of the secret store");
             Guard.For<ArgumentException>(() => secretProviderSources.Any(source => source is null), "Requires all registered secret provider registrations to be not 'null'");
             Guard.For<ArgumentException>(() => criticalExceptionFilters.Any(filter => filter is null), "Requires all registered critical exception filters to be not 'null'");
-            
+            Guard.NotNull<SecretStoreAuditingOptions, ArgumentException>(auditingOptions.Value, "Requires a value for the set of options to configure the auditing of the secret store");
+
             _secretProviders = secretProviderSources;
             _criticalExceptionFilters = criticalExceptionFilters;
+            _auditingOptions = auditingOptions.Value;
             _logger = logger ?? NullLogger<CompositeSecretProvider>.Instance;
         }
 
@@ -225,14 +232,14 @@ namespace Arcus.Security.Core
             SecretStoreSource source, 
             Func<SecretStoreSource, Task<T>> callRegisteredProvider) where T : class
         {
-            /* TODO: use 'Arcus.Observability.Telemetry.Core' 'LogSecurityEvent' instead once the SQL dependency is moved
-                        -> https://github.com/arcus-azure/arcus.observability/issues/131 */
-            _logger.LogInformation("Events {EventName} (Context: {@EventContext})", "Get Secret", new Dictionary<string, object>
+            if (_auditingOptions.EmitSecurityEvents)
             {
-                ["EventType"] = "Security",
-                ["SecretName"] = secretName,
-                ["SecretProviderType"] = source.SecretProvider.GetType().Name
-            });
+                _logger.LogSecurityEvent("Get Secret", new Dictionary<string, object>
+                {
+                    ["SecretName"] = secretName,
+                    ["SecretProviderType"] = source.SecretProvider.GetType().Name
+                }); 
+            }
 
             Task<T> resultAsync = callRegisteredProvider(source);
             if (resultAsync is null)

--- a/src/Arcus.Security.Core/CompositeSecretProvider.cs
+++ b/src/Arcus.Security.Core/CompositeSecretProvider.cs
@@ -237,7 +237,7 @@ namespace Arcus.Security.Core
                 _logger.LogSecurityEvent("Get Secret", new Dictionary<string, object>
                 {
                     ["SecretName"] = secretName,
-                    ["SecretProviderType"] = source.SecretProvider.GetType().Name
+                    ["SecretProvider"] = source.SecretProvider.GetType().Name
                 }); 
             }
 

--- a/src/Arcus.Security.Core/SecretStoreAuditingOptions.cs
+++ b/src/Arcus.Security.Core/SecretStoreAuditingOptions.cs
@@ -1,0 +1,13 @@
+﻿namespace Arcus.Security.Core
+{
+    /// <summary>
+    /// Represents configurable options related to auditing during the lifetime of the secret store.
+    /// </summary>
+    public class SecretStoreAuditingOptions
+    {
+        /// <summary>
+        /// Gets or sets the flag to indicate whether or not to emit security events when requesting secrets from the secret store.
+        /// </summary>
+        public bool EmitSecurityEvents { get; set; } = false;
+    }
+}

--- a/src/Arcus.Security.Tests.Core/Arcus.Security.Tests.Core.csproj
+++ b/src/Arcus.Security.Tests.Core/Arcus.Security.Tests.Core.csproj
@@ -6,7 +6,7 @@
 
   <ItemGroup>
     <PackageReference Include="Guard.Net" Version="1.2.0" />
-    <PackageReference Include="Arcus.Testing.Logging" Version="0.1.0" />
+    <PackageReference Include="Arcus.Testing.Logging" Version="0.2.0-preview-1" />
   </ItemGroup>
 
 </Project>

--- a/src/Arcus.Security.Tests.Core/Stubs/TestLoggerProvider.cs
+++ b/src/Arcus.Security.Tests.Core/Stubs/TestLoggerProvider.cs
@@ -1,0 +1,36 @@
+﻿using Microsoft.Extensions.Logging;
+
+namespace Arcus.Security.Tests.Core.Stubs
+{
+    /// <summary>
+    /// Represents an <see cref="ILoggerProvider"/> that delegates the logger creation to an fixed instance.
+    /// </summary>
+    public class TestLoggerProvider : ILoggerProvider
+    {
+        private readonly ILogger _logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TestLoggerProvider"/> class.
+        /// </summary>
+        public TestLoggerProvider(ILogger logger)
+        {
+            _logger = logger;
+        }
+
+        /// <summary>
+        /// Creates a new <see cref="T:Microsoft.Extensions.Logging.ILogger" /> instance.
+        /// </summary>
+        /// <param name="categoryName">The category name for messages produced by the logger.</param>
+        public ILogger CreateLogger(string categoryName)
+        {
+            return _logger;
+        }
+
+        /// <summary>
+        /// Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.
+        /// </summary>
+        public void Dispose()
+        {
+        }
+    }
+}

--- a/src/Arcus.Security.Tests.Unit/Core/SecretStoreBuilderTests.cs
+++ b/src/Arcus.Security.Tests.Unit/Core/SecretStoreBuilderTests.cs
@@ -41,5 +41,17 @@ namespace Arcus.Security.Tests.Unit.Core
             Assert.ThrowsAny<ArgumentException>(
                 () => builder.AddCriticalException<AuthenticationException>(exceptionFilter: null));
         }
+
+        [Fact]
+        public void WithAuditing_WithoutFunction_Throws()
+        {
+            // Arrange
+            var services = new ServiceCollection();
+            var builder = new SecretStoreBuilder(services);
+
+            // Act / assert
+            Assert.ThrowsAny<ArgumentException>(
+                () => builder.WithAuditing(configureOptions: null));
+        }
     }
 }


### PR DESCRIPTION
Provide the capability to opt-in for the emitted security events when requesting a secret through the secret store.
This includes the extension to configure this, alongside the necessary tests and docs update.

Closes #177 
Closes #205 