### PR TITLE
Fix - use default Azure TokenCredential for more dev-friendliness

### DIFF
--- a/src/Arcus.Security.Providers.AzureKeyVault/Extensions/SecretStoreBuilderExtensions.cs
+++ b/src/Arcus.Security.Providers.AzureKeyVault/Extensions/SecretStoreBuilderExtensions.cs
@@ -326,7 +326,7 @@ namespace Microsoft.Extensions.Hosting
 
             return AddAzureKeyVault(
                 builder,
-                new ChainedTokenCredential(new ManagedIdentityCredential(clientId), new EnvironmentCredential()),
+                new DefaultAzureCredential(new DefaultAzureCredentialOptions { ManagedIdentityClientId = clientId }), 
                 new KeyVaultConfiguration(rawVaultUri),
                 configureOptions,
                 name,
@@ -424,7 +424,7 @@ namespace Microsoft.Extensions.Hosting
 
             return AddAzureKeyVault(
                 builder,
-                new ChainedTokenCredential(new ManagedIdentityCredential(clientId), new EnvironmentCredential()),
+                new DefaultAzureCredential(new DefaultAzureCredentialOptions { ManagedIdentityClientId = clientId }), 
                 new KeyVaultConfiguration(rawVaultUri),
                 cacheConfiguration,
                 configureOptions,


### PR DESCRIPTION
Uses the default `DefaultAzureCredential` which behind the scenes uses the managed identity and environment variables (like we chained together), but also uses the Azure CLI information to make it more dev-friendly.

Relates to #217 