### PR TITLE
Feature - simplify Azure Key Vault secret store overloads

### DIFF
--- a/src/Arcus.Security.Providers.AzureKeyVault/Extensions/SecretStoreBuilderExtensions.cs
+++ b/src/Arcus.Security.Providers.AzureKeyVault/Extensions/SecretStoreBuilderExtensions.cs
@@ -787,7 +787,6 @@ namespace Microsoft.Extensions.Hosting
         /// <param name="cacheConfiguration">The configuration to control how the caching will be done.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="builder"/> is <c>null</c>.</exception>
         /// <exception cref="ArgumentException">Thrown when the <paramref name="rawVaultUri"/>, <paramref name="clientId"/>, or <paramref name="clientKey"/> is blank.</exception>
-
         public static SecretStoreBuilder AddAzureKeyVaultWithServicePrincipal(
             this SecretStoreBuilder builder,
             string rawVaultUri,

--- a/src/Arcus.Security.Providers.AzureKeyVault/Extensions/SecretStoreBuilderExtensions.cs
+++ b/src/Arcus.Security.Providers.AzureKeyVault/Extensions/SecretStoreBuilderExtensions.cs
@@ -100,6 +100,43 @@ namespace Microsoft.Extensions.Hosting
         /// <param name="clientId">The identifier of the application requesting the authentication token.</param>
         /// <param name="certificate">The certificate that is used as credential.</param>
         /// <param name="allowCaching">The flag to indicate whether to include caching during secret retrieval in Azure key vault.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="builder"/> or <paramref name="certificate"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="rawVaultUri"/> or <paramref name="clientId"/> is blank.</exception>
+        public static SecretStoreBuilder AddAzureKeyVaultWithCertificate(
+            this SecretStoreBuilder builder,
+            string rawVaultUri,
+            string tenantId,
+            string clientId,
+            X509Certificate2 certificate,
+            bool allowCaching = false)
+        {
+            Guard.NotNull(builder, nameof(builder), "Requires a secret store builder to add the Azure Key Vault secret provider");
+            Guard.NotNullOrWhitespace(rawVaultUri, nameof(rawVaultUri), "Requires a non-blank URI of the Azure Key Vault instance to add the secret provider to the secret store");
+            Guard.NotNullOrWhitespace(tenantId, nameof(tenantId), "Requires a non-blank tenant ID of the directory where the client or application is located");
+            Guard.NotNullOrWhitespace(clientId, nameof(clientId), "Requires a non-blank client ID of the application requesting the authentication token that has read permissions on the Azure Key Vault to add a secret provider to the secret store");
+            Guard.NotNull(certificate, nameof(certificate), "Requires a certificate that is being used as credential on the Azure Key Vault to add the secret provider to the secret store");
+            
+            return AddAzureKeyVaultWithCertificate(
+                builder, 
+                rawVaultUri, 
+                tenantId, 
+                clientId, 
+                certificate,
+                configureOptions: null, 
+                name: null, 
+                mutateSecretName: null, 
+                allowCaching: allowCaching);
+        }
+
+        /// <summary>
+        /// Adds Azure Key Vault as a secret source which uses certificate authentication.
+        /// </summary>
+        /// <param name="builder">The builder to create the secret store.</param>
+        /// <param name="rawVaultUri">The Uri of the Azure Key Vault you want to connect to.</param>
+        /// <param name="tenantId">The Azure Active Directory tenant (directory) ID of the client or application.</param>
+        /// <param name="clientId">The identifier of the application requesting the authentication token.</param>
+        /// <param name="certificate">The certificate that is used as credential.</param>
+        /// <param name="allowCaching">The flag to indicate whether to include caching during secret retrieval in Azure key vault.</param>
         /// <param name="configureOptions">The optional additional options to configure the Azure Key Vault secret source.</param>
         /// <param name="name">The unique name to register this Azure Key Vault provider in the secret store.</param>
         /// <param name="mutateSecretName">The optional function to mutate the secret name before looking it up.</param>
@@ -197,6 +234,43 @@ namespace Microsoft.Extensions.Hosting
                 mutateSecretName: mutateSecretName);
         }
 
+        /// <summary>
+        /// Adds Azure Key Vault as a secret source which uses certificate authentication.
+        /// </summary>
+        /// <param name="builder">The builder to create the secret store.</param>
+        /// <param name="rawVaultUri">The Uri of the Azure Key Vault you want to connect to.</param>
+        /// <param name="tenantId">The Azure Active Directory tenant (directory) ID of the client or application.</param>
+        /// <param name="clientId">The identifier of the application requesting the authentication token.</param>
+        /// <param name="certificate">The certificate that is used as credential.</param>
+        /// <param name="cacheConfiguration">The configuration to control how the caching will be done.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="builder"/> or <paramref name="certificate"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="rawVaultUri"/> or <paramref name="clientId"/> is blank.</exception>
+        public static SecretStoreBuilder AddAzureKeyVaultWithCertificate(
+            this SecretStoreBuilder builder,
+            string rawVaultUri,
+            string tenantId,
+            string clientId,
+            X509Certificate2 certificate,
+            ICacheConfiguration cacheConfiguration)
+        {
+            Guard.NotNull(builder, nameof(builder), "Requires a secret store builder to add the Azure Key Vault secret provider");
+            Guard.NotNullOrWhitespace(rawVaultUri, nameof(rawVaultUri), "Requires a non-blank URI of the Azure Key Vault instance to add the secret provider to the secret store");
+            Guard.NotNullOrWhitespace(tenantId, nameof(tenantId), "Requires a non-blank tenant ID of the directory where the client or application is located");
+            Guard.NotNullOrWhitespace(clientId, nameof(clientId), "Requires a non-blank client ID of the application requesting the authentication token that has read permissions on the Azure Key Vault to add a secret provider to the secret store");
+            Guard.NotNull(certificate, nameof(certificate), "Requires a certificate that is being used as credential on the Azure Key Vault to add the secret provider to the secret store");
+
+            return AddAzureKeyVaultWithCertificate(
+                builder,
+                rawVaultUri,
+                tenantId,
+                clientId,
+                certificate,
+                cacheConfiguration,
+                configureOptions: null,
+                name: null,
+                mutateSecretName: null);
+        }
+        
         /// <summary>
         /// Adds Azure Key Vault as a secret source which uses certificate authentication.
         /// </summary>
@@ -307,6 +381,36 @@ namespace Microsoft.Extensions.Hosting
         ///     The optional client id to authenticate for a user assigned managed identity.
         ///     More information on user assigned managed identities can be found here: https://docs.microsoft.com/en-us/azure/active-directory/managed-identities-azure-resources/overview#how-a-user-assigned-managed-identity-works-with-an-azure-vm</param>
         /// <param name="allowCaching">The flag to indicate whether to include caching during secret retrieval in Azure key vault.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="builder"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="rawVaultUri"/> is blank.</exception>
+        public static SecretStoreBuilder AddAzureKeyVaultWithManagedIdentity(
+            this SecretStoreBuilder builder,
+            string rawVaultUri,
+            string clientId,
+            bool allowCaching = false)
+        {
+            Guard.NotNull(builder, nameof(builder), "Requires a secret store builder to add the Azure Key Vault secret provider");
+            Guard.NotNullOrWhitespace(rawVaultUri, nameof(rawVaultUri), "Requires a non-blank URI of the Azure Key Vault instance to add the secret provider to the secret store");
+
+            return AddAzureKeyVaultWithManagedIdentity(
+                builder,
+                rawVaultUri,
+                clientId,
+                configureOptions: null,
+                name: null,
+                mutateSecretName: null,
+                allowCaching: allowCaching);
+        }
+
+        /// <summary>
+        /// Adds Azure Key Vault as a secret source which uses Managed Identity authentication.
+        /// </summary>
+        /// <param name="builder">The builder to create the secret store.</param>
+        /// <param name="rawVaultUri">The Uri of the Azure Key Vault you want to connect to.</param>
+        /// <param name="clientId">
+        ///     The optional client id to authenticate for a user assigned managed identity.
+        ///     More information on user assigned managed identities can be found here: https://docs.microsoft.com/en-us/azure/active-directory/managed-identities-azure-resources/overview#how-a-user-assigned-managed-identity-works-with-an-azure-vm</param>
+        /// <param name="allowCaching">The flag to indicate whether to include caching during secret retrieval in Azure key vault.</param>
         /// <param name="configureOptions">The optional additional options to configure the Azure Key Vault secret source.</param>
         /// <param name="name">The unique name to register this Azure Key Vault provider in the secret store.</param>
         /// <param name="mutateSecretName">The optional function to mutate the secret name before looking it up.</param>
@@ -394,6 +498,36 @@ namespace Microsoft.Extensions.Hosting
                 cacheConfiguration,
                 mutateSecretName,
                 configureOptions);
+        }
+
+        /// <summary>
+        /// Adds Azure Key Vault as a secret source which uses Managed Identity authentication.
+        /// </summary>
+        /// <param name="builder">The builder to create the secret store.</param>
+        /// <param name="rawVaultUri">The Uri of the Azure Key Vault you want to connect to.</param>
+        /// <param name="clientId">
+        ///     The optional client id to authenticate for a user assigned managed identity.
+        ///     More information on user assigned managed identities can be found here: https://docs.microsoft.com/en-us/azure/active-directory/managed-identities-azure-resources/overview#how-a-user-assigned-managed-identity-works-with-an-azure-vm</param>
+        /// <param name="cacheConfiguration">The configuration to control how the caching will be done.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="builder"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="rawVaultUri"/> is blank.</exception>
+        public static SecretStoreBuilder AddAzureKeyVaultWithManagedIdentity(
+            this SecretStoreBuilder builder,
+            string rawVaultUri,
+            ICacheConfiguration cacheConfiguration,
+            string clientId)
+        {
+            Guard.NotNull(builder, nameof(builder), "Requires a secret store builder to add the Azure Key Vault secret provider");
+            Guard.NotNullOrWhitespace(rawVaultUri, nameof(rawVaultUri), "Requires a non-blank URI of the Azure Key Vault instance to add the secret provider to the secret store");
+
+            return AddAzureKeyVaultWithManagedIdentity(
+                builder,
+                rawVaultUri,
+                cacheConfiguration,
+                clientId,
+                configureOptions: null,
+                name: null,
+                mutateSecretName: null);
         }
 
         /// <summary>
@@ -507,6 +641,43 @@ namespace Microsoft.Extensions.Hosting
         /// <param name="clientId">The ClientId of the service principal, used to connect to Azure Key Vault</param>
         /// <param name="clientKey">The Secret ClientKey of the service principal, used to connect to Azure Key Vault</param>
         /// <param name="allowCaching">The flag to indicate whether to include caching during secret retrieval in Azure key vault.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="builder"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="rawVaultUri"/>, <paramref name="clientId"/>, or <paramref name="clientKey"/> is blank.</exception>
+        public static SecretStoreBuilder AddAzureKeyVaultWithServicePrincipal(
+            this SecretStoreBuilder builder,
+            string rawVaultUri,
+            string tenantId,
+            string clientId,
+            string clientKey,
+            bool allowCaching = false)
+        {
+            Guard.NotNull(builder, nameof(builder), "Requires a secret store builder to add the Azure Key Vault secret provider");
+            Guard.NotNullOrWhitespace(rawVaultUri, nameof(rawVaultUri), "Requires a non-blank URI of the Azure Key Vault instance to add the secret provider to the secret store");
+            Guard.NotNullOrWhitespace(tenantId, nameof(tenantId), "Requires a non-blank tenant ID of the directory where the Service Principal is located");
+            Guard.NotNullOrWhitespace(clientId, nameof(clientId), "Requires a non-blank client ID of the Service Principal that has permissions to read the secrets in the Azure Key Vault to add the secret provider to the secret store");
+            Guard.NotNullOrWhitespace(clientKey, nameof(clientKey), "Requires a non-blank client access key of the Service Principal that has permissions to read the secrets in the Azure Key Vault to add to the secret provider to the secret store");
+
+            return AddAzureKeyVaultWithServicePrincipal(
+                builder,
+                rawVaultUri,
+                tenantId,
+                clientId,
+                clientKey,
+                configureOptions: null,
+                name: null,
+                mutateSecretName: null,
+                allowCaching: allowCaching);
+        }
+        
+        /// <summary>
+        /// Adds Azure Key Vault as a secret source which uses client secret authentication.
+        /// </summary>
+        /// <param name="builder">The builder to create the secret store.</param>
+        /// <param name="rawVaultUri">The Uri of the Azure Key Vault you want to connect to.</param>
+        /// <param name="tenantId">The Azure Active Directory tenant (directory) Id of the service principal.</param>
+        /// <param name="clientId">The ClientId of the service principal, used to connect to Azure Key Vault</param>
+        /// <param name="clientKey">The Secret ClientKey of the service principal, used to connect to Azure Key Vault</param>
+        /// <param name="allowCaching">The flag to indicate whether to include caching during secret retrieval in Azure key vault.</param>
         /// <param name="configureOptions">The optional additional options to configure the Azure Key Vault secret source.</param>
         /// <param name="name">The unique name to register this Azure Key Vault provider in the secret store.</param>
         /// <param name="mutateSecretName">The optional function to mutate the secret name before looking it up.</param>
@@ -603,6 +774,44 @@ namespace Microsoft.Extensions.Hosting
                 cacheConfiguration: cacheConfiguration,
                 mutateSecretName: mutateSecretName,
                 configureOptions: configureOptions);
+        }
+
+        /// <summary>
+        /// Adds Azure Key Vault as a secret source which uses client secret authentication.
+        /// </summary>
+        /// <param name="builder">The builder to create the secret store.</param>
+        /// <param name="rawVaultUri">The Uri of the Azure Key Vault you want to connect to.</param>
+        /// <param name="tenantId">The Azure Active Directory tenant (directory) Id of the service principal.</param>
+        /// <param name="clientId">The ClientId of the service principal, used to connect to Azure Key Vault</param>
+        /// <param name="clientKey">The Secret ClientKey of the service principal, used to connect to Azure Key Vault</param>
+        /// <param name="cacheConfiguration">The configuration to control how the caching will be done.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="builder"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="rawVaultUri"/>, <paramref name="clientId"/>, or <paramref name="clientKey"/> is blank.</exception>
+
+        public static SecretStoreBuilder AddAzureKeyVaultWithServicePrincipal(
+            this SecretStoreBuilder builder,
+            string rawVaultUri,
+            string tenantId,
+            string clientId,
+            string clientKey,
+            ICacheConfiguration cacheConfiguration)
+        {
+            Guard.NotNull(builder, nameof(builder), "Requires a secret store builder to add the Azure Key Vault secret provider");
+            Guard.NotNullOrWhitespace(rawVaultUri, nameof(rawVaultUri), "Requires a non-blank URI of the Azure Key Vault instance to add the secret provider to the secret store");
+            Guard.NotNullOrWhitespace(tenantId, nameof(tenantId), "Requires a non-blank tenant ID of the directory where the Service Principal is located");
+            Guard.NotNullOrWhitespace(clientId, nameof(clientId), "Requires a non-blank client ID of the Service Principal that has permissions to read the secrets in the Azure Key Vault to add the secret provider to the secret store");
+            Guard.NotNullOrWhitespace(clientKey, nameof(clientKey), "Requires a non-blank client access key of the Service Principal that has permissions to read the secrets in the Azure Key Vault to add to the secret provider to the secret store");
+
+            return AddAzureKeyVaultWithServicePrincipal(
+                builder,
+                rawVaultUri,
+                tenantId,
+                clientId,
+                clientKey,
+                cacheConfiguration,
+                configureOptions: null,
+                name: null,
+                mutateSecretName: null);
         }
 
         /// <summary>
@@ -802,6 +1011,34 @@ namespace Microsoft.Extensions.Hosting
         /// <param name="tokenCredential">The requested authentication type for connecting to the Azure Key Vault instance.</param>
         /// <param name="configuration">The configuration related to the Azure Key Vault instance to use.</param>
         /// <param name="allowCaching">The flag to indicate whether to include caching during secret retrieval in Azure key vault.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="builder"/>, <paramref name="tokenCredential"/>, or <paramref name="configuration"/> is <c>null</c>.</exception>
+        public static SecretStoreBuilder AddAzureKeyVault(
+            this SecretStoreBuilder builder,
+            TokenCredential tokenCredential,
+            IKeyVaultConfiguration configuration,
+            bool allowCaching = false)
+        {
+            Guard.NotNull(builder, nameof(builder), "Requires a secret store builder to add the Azure Key Vault secret provider");
+            Guard.NotNull(tokenCredential, nameof(tokenCredential), "Requires an Azure Key Vault authentication instance to add the secret provider to the secret store");
+            Guard.NotNull(configuration, nameof(configuration), "Requires an Azure Key Vault configuration instance to add the secret provider to the secret store");
+
+            return AddAzureKeyVault(
+                builder,
+                tokenCredential,
+                configuration,
+                configureOptions: null,
+                name: null,
+                mutateSecretName: null,
+                allowCaching: allowCaching);
+        }
+
+        /// <summary>
+        /// Adds Azure Key Vault as a secret source.
+        /// </summary>
+        /// <param name="builder">The builder to create the secret store.</param>
+        /// <param name="tokenCredential">The requested authentication type for connecting to the Azure Key Vault instance.</param>
+        /// <param name="configuration">The configuration related to the Azure Key Vault instance to use.</param>
+        /// <param name="allowCaching">The flag to indicate whether to include caching during secret retrieval in Azure key vault.</param>
         /// <param name="configureOptions">The optional additional options to configure the Azure Key Vault secret source.</param>
         /// <param name="name">The unique name to register this Azure Key Vault provider in the secret store.</param>
         /// <param name="mutateSecretName">The optional function to mutate the secret name before looking it up.</param>
@@ -823,6 +1060,34 @@ namespace Microsoft.Extensions.Hosting
             return AddAzureKeyVault(builder, tokenCredential, configuration, cacheConfiguration, configureOptions, name, mutateSecretName);
         }
 
+        /// <summary>
+        /// Adds Azure Key Vault as a secret source.
+        /// </summary>
+        /// <param name="builder">The builder to create the secret store.</param>
+        /// <param name="tokenCredential">The requested authentication type for connecting to the Azure Key Vault instance.</param>
+        /// <param name="configuration">The configuration related to the Azure Key Vault instance to use.</param>
+        /// <param name="cacheConfiguration">The configuration to control how the caching will be done.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="builder"/>, <paramref name="tokenCredential"/>, or <paramref name="configuration"/> is <c>null</c>.</exception>
+        public static SecretStoreBuilder AddAzureKeyVault(
+            this SecretStoreBuilder builder,
+            TokenCredential tokenCredential,
+            IKeyVaultConfiguration configuration,
+            ICacheConfiguration cacheConfiguration)
+        {
+            Guard.NotNull(builder, nameof(builder), "Requires a secret store builder to add the Azure Key Vault secret provider");
+            Guard.NotNull(tokenCredential, nameof(tokenCredential), "Requires an Azure Key Vault authentication instance to add the secret provider to the secret store");
+            Guard.NotNull(configuration, nameof(configuration), "Requires an Azure Key Vault configuration instance to add the secret provider to the secret store");
+
+            return AddAzureKeyVault(
+                builder,
+                tokenCredential,
+                configuration,
+                cacheConfiguration,
+                configureOptions: null,
+                name: null,
+                mutateSecretName: null);
+        }
+        
         /// <summary>
         /// Adds Azure Key Vault as a secret source.
         /// </summary>

--- a/src/Arcus.Security.Tests.Unit/KeyVault/Extensions/SecretStoreBuilderExtensionsTests.cs
+++ b/src/Arcus.Security.Tests.Unit/KeyVault/Extensions/SecretStoreBuilderExtensionsTests.cs
@@ -118,7 +118,7 @@ namespace Arcus.Security.Tests.Unit.KeyVault.Extensions
 
             // Act
             builder.ConfigureSecretStore(
-                (config, stores) => stores.AddAzureKeyVaultWithCertificate("vault-uri", clientId, new X509Certificate2()));
+                (config, stores) => stores.AddAzureKeyVaultWithCertificate(GenerateVaultUri(), clientId, new X509Certificate2()));
 
             // Assert
             Assert.ThrowsAny<ArgumentException>(() => builder.Build());
@@ -133,7 +133,7 @@ namespace Arcus.Security.Tests.Unit.KeyVault.Extensions
 
             // Act
             builder.ConfigureSecretStore(
-                (config, stores) => stores.AddAzureKeyVaultWithCertificateWithOptions("vault-uri", clientId, new X509Certificate2()));
+                (config, stores) => stores.AddAzureKeyVaultWithCertificateWithOptions(GenerateVaultUri(), clientId, new X509Certificate2()));
 
             // Assert
             Assert.ThrowsAny<ArgumentException>(() => builder.Build());
@@ -149,7 +149,7 @@ namespace Arcus.Security.Tests.Unit.KeyVault.Extensions
 
             // Act
             builder.ConfigureSecretStore(
-                (config, stores) => stores.AddAzureKeyVaultWithCertificate("vault-uri", clientId, new X509Certificate2(), cacheConfiguration));
+                (config, stores) => stores.AddAzureKeyVaultWithCertificate(GenerateVaultUri(), clientId, new X509Certificate2(), cacheConfiguration));
 
             // Assert
             Assert.ThrowsAny<ArgumentException>(() => builder.Build());
@@ -165,7 +165,7 @@ namespace Arcus.Security.Tests.Unit.KeyVault.Extensions
 
             // Act
             builder.ConfigureSecretStore(
-                (config, stores) => stores.AddAzureKeyVaultWithCertificateWithOptions("vault-uri", clientId, new X509Certificate2(), cacheConfiguration));
+                (config, stores) => stores.AddAzureKeyVaultWithCertificateWithOptions(GenerateVaultUri(), clientId, new X509Certificate2(), cacheConfiguration));
 
             // Assert
             Assert.ThrowsAny<ArgumentException>(() => builder.Build());
@@ -180,7 +180,7 @@ namespace Arcus.Security.Tests.Unit.KeyVault.Extensions
             var certificate = new X509Certificate2();
             
             // Act
-            builder.ConfigureSecretStore((config, stores) => stores.AddAzureKeyVaultWithCertificate("vault-uri", clientId, "tenant-id", certificate));
+            builder.ConfigureSecretStore((config, stores) => stores.AddAzureKeyVaultWithCertificate(GenerateVaultUri(), clientId, "tenant-id", certificate));
             
             // Assert
             Assert.ThrowsAny<ArgumentException>(() => builder.Build());
@@ -195,7 +195,7 @@ namespace Arcus.Security.Tests.Unit.KeyVault.Extensions
             var certificate = new X509Certificate2();
             
             // Act
-            builder.ConfigureSecretStore((config, stores) => stores.AddAzureKeyVaultWithCertificate("vault-uri", clientId, "tenant-id", certificate, cacheConfiguration: new CacheConfiguration()));
+            builder.ConfigureSecretStore((config, stores) => stores.AddAzureKeyVaultWithCertificate(GenerateVaultUri(), clientId, "tenant-id", certificate, cacheConfiguration: new CacheConfiguration()));
             
             // Assert
             Assert.ThrowsAny<ArgumentException>(() => builder.Build());
@@ -209,7 +209,7 @@ namespace Arcus.Security.Tests.Unit.KeyVault.Extensions
 
             // Act
             builder.ConfigureSecretStore(
-                (config, stores) => stores.AddAzureKeyVaultWithCertificate("vault-uri", "client-id", certificate: null));
+                (config, stores) => stores.AddAzureKeyVaultWithCertificate(GenerateVaultUri(), "client-id", certificate: null));
 
             // Assert
             Assert.ThrowsAny<ArgumentException>(() => builder.Build());
@@ -223,7 +223,7 @@ namespace Arcus.Security.Tests.Unit.KeyVault.Extensions
 
             // Act
             builder.ConfigureSecretStore(
-                (config, stores) => stores.AddAzureKeyVaultWithCertificateWithOptions("vault-uri", "client-id", certificate: null));
+                (config, stores) => stores.AddAzureKeyVaultWithCertificateWithOptions(GenerateVaultUri(), "client-id", certificate: null));
 
             // Assert
             Assert.ThrowsAny<ArgumentException>(() => builder.Build());
@@ -238,7 +238,7 @@ namespace Arcus.Security.Tests.Unit.KeyVault.Extensions
 
             // Act
             builder.ConfigureSecretStore(
-                (config, stores) => stores.AddAzureKeyVaultWithCertificate("vault-uri", "client-id", certificate: null, cacheConfiguration: cacheConfiguration));
+                (config, stores) => stores.AddAzureKeyVaultWithCertificate(GenerateVaultUri(), "client-id", certificate: null, cacheConfiguration: cacheConfiguration));
 
             // Assert
             Assert.ThrowsAny<ArgumentException>(() => builder.Build());
@@ -253,7 +253,7 @@ namespace Arcus.Security.Tests.Unit.KeyVault.Extensions
 
             // Act
             builder.ConfigureSecretStore(
-                (config, stores) => stores.AddAzureKeyVaultWithCertificateWithOptions("vault-uri", "client-id", certificate: null, cacheConfiguration: cacheConfiguration));
+                (config, stores) => stores.AddAzureKeyVaultWithCertificateWithOptions(GenerateVaultUri(), "client-id", certificate: null, cacheConfiguration: cacheConfiguration));
 
             // Assert
             Assert.ThrowsAny<ArgumentException>(() => builder.Build());
@@ -268,7 +268,7 @@ namespace Arcus.Security.Tests.Unit.KeyVault.Extensions
             var certificate = new X509Certificate2();
             
             // Act
-            builder.ConfigureSecretStore((config, stores) => stores.AddAzureKeyVaultWithCertificate("vault-uri", tenantId, "client-id", certificate));
+            builder.ConfigureSecretStore((config, stores) => stores.AddAzureKeyVaultWithCertificate(GenerateVaultUri(), tenantId, "client-id", certificate));
             
             // Assert
             Assert.ThrowsAny<ArgumentException>(() => builder.Build());
@@ -283,7 +283,7 @@ namespace Arcus.Security.Tests.Unit.KeyVault.Extensions
             var certificate = new X509Certificate2();
             
             // Act
-            builder.ConfigureSecretStore((config, stores) => stores.AddAzureKeyVaultWithCertificate("vault-uri", tenantId, "client-id", certificate, cacheConfiguration: new CacheConfiguration()));
+            builder.ConfigureSecretStore((config, stores) => stores.AddAzureKeyVaultWithCertificate(GenerateVaultUri(), tenantId, "client-id", certificate, cacheConfiguration: new CacheConfiguration()));
             
             // Assert
             Assert.ThrowsAny<ArgumentException>(() => builder.Build());
@@ -329,7 +329,7 @@ namespace Arcus.Security.Tests.Unit.KeyVault.Extensions
 
             // Act
             builder.ConfigureSecretStore(
-                (config, stores) => stores.AddAzureKeyVaultWithCertificate("vault-uri", "tenant-id", clientId, new X509Certificate2(), configureOptions: null, name: null, mutateSecretName: null));
+                (config, stores) => stores.AddAzureKeyVaultWithCertificate(GenerateVaultUri(), "tenant-id", clientId, new X509Certificate2(), configureOptions: null, name: null, mutateSecretName: null));
 
             // Assert
             Assert.ThrowsAny<ArgumentException>(() => builder.Build());
@@ -345,7 +345,7 @@ namespace Arcus.Security.Tests.Unit.KeyVault.Extensions
 
             // Act
             builder.ConfigureSecretStore(
-                (config, stores) => stores.AddAzureKeyVaultWithCertificate("vault-uri", "tenant-id", clientId, new X509Certificate2(), cacheConfiguration, configureOptions: null, name: null, mutateSecretName: null));
+                (config, stores) => stores.AddAzureKeyVaultWithCertificate(GenerateVaultUri(), "tenant-id", clientId, new X509Certificate2(), cacheConfiguration, configureOptions: null, name: null, mutateSecretName: null));
 
             // Assert
             Assert.ThrowsAny<ArgumentException>(() => builder.Build());
@@ -359,7 +359,7 @@ namespace Arcus.Security.Tests.Unit.KeyVault.Extensions
 
             // Act
             builder.ConfigureSecretStore(
-                (config, stores) => stores.AddAzureKeyVaultWithCertificate("vault-uri", "tenant-id", "client-id", certificate: null, configureOptions: null, name: null, mutateSecretName: null));
+                (config, stores) => stores.AddAzureKeyVaultWithCertificate(GenerateVaultUri(), "tenant-id", "client-id", certificate: null, configureOptions: null, name: null, mutateSecretName: null));
 
             // Assert
             Assert.ThrowsAny<ArgumentException>(() => builder.Build());
@@ -374,7 +374,7 @@ namespace Arcus.Security.Tests.Unit.KeyVault.Extensions
 
             // Act
             builder.ConfigureSecretStore(
-                (config, stores) => stores.AddAzureKeyVaultWithCertificate("vault-uri", "tenant-id", "client-id", certificate: null, cacheConfiguration: cacheConfiguration, configureOptions: null, name: null, mutateSecretName: null));
+                (config, stores) => stores.AddAzureKeyVaultWithCertificate(GenerateVaultUri(), "tenant-id", "client-id", certificate: null, cacheConfiguration: cacheConfiguration, configureOptions: null, name: null, mutateSecretName: null));
 
             // Assert
             Assert.ThrowsAny<ArgumentException>(() => builder.Build());
@@ -387,7 +387,7 @@ namespace Arcus.Security.Tests.Unit.KeyVault.Extensions
             var builder = new HostBuilder();
             
             // Act
-            builder.ConfigureSecretStore((config, stores) => stores.AddAzureKeyVaultWithCertificate("vault-uri", "tenant-id", "client-id", certificate: null));
+            builder.ConfigureSecretStore((config, stores) => stores.AddAzureKeyVaultWithCertificate(GenerateVaultUri(), "tenant-id", "client-id", certificate: null));
             
             // Assert
             Assert.ThrowsAny<ArgumentException>(() => builder.Build());
@@ -400,7 +400,7 @@ namespace Arcus.Security.Tests.Unit.KeyVault.Extensions
             var builder = new HostBuilder();
             
             // Act
-            builder.ConfigureSecretStore((config, stores) => stores.AddAzureKeyVaultWithCertificate("vault-uri", "tenant-id", "client-id", certificate: null, cacheConfiguration: new CacheConfiguration()));
+            builder.ConfigureSecretStore((config, stores) => stores.AddAzureKeyVaultWithCertificate(GenerateVaultUri(), "tenant-id", "client-id", certificate: null, cacheConfiguration: new CacheConfiguration()));
             
             // Assert
             Assert.ThrowsAny<ArgumentException>(() => builder.Build());
@@ -416,7 +416,7 @@ namespace Arcus.Security.Tests.Unit.KeyVault.Extensions
 
             // Act
             builder.ConfigureSecretStore(
-                (config, stores) => stores.AddAzureKeyVaultWithCertificate("vault-uri", tenantId, "client-id", new X509Certificate2(), cacheConfiguration, configureOptions: null, name: null, mutateSecretName: null));
+                (config, stores) => stores.AddAzureKeyVaultWithCertificate(GenerateVaultUri(), tenantId, "client-id", new X509Certificate2(), cacheConfiguration, configureOptions: null, name: null, mutateSecretName: null));
 
             // Assert
             Assert.ThrowsAny<ArgumentException>(() => builder.Build());
@@ -432,7 +432,7 @@ namespace Arcus.Security.Tests.Unit.KeyVault.Extensions
 
             // Act
             builder.ConfigureSecretStore(
-                (config, stores) => stores.AddAzureKeyVaultWithCertificate("vault-uri", tenantId, "client-id", new X509Certificate2(), cacheConfiguration, configureOptions: null, name: null, mutateSecretName: null));
+                (config, stores) => stores.AddAzureKeyVaultWithCertificate(GenerateVaultUri(), tenantId, "client-id", new X509Certificate2(), cacheConfiguration, configureOptions: null, name: null, mutateSecretName: null));
 
             // Assert
             Assert.ThrowsAny<ArgumentException>(() => builder.Build());
@@ -447,7 +447,7 @@ namespace Arcus.Security.Tests.Unit.KeyVault.Extensions
             // Act
             builder.ConfigureSecretStore((config, stores) =>
             {
-                stores.AddAzureKeyVaultWithCertificate("vault-uri",
+                stores.AddAzureKeyVaultWithCertificate(GenerateVaultUri(),
                     "tenant-id",
                     "client-id",
                     new X509Certificate2(),
@@ -469,12 +469,12 @@ namespace Arcus.Security.Tests.Unit.KeyVault.Extensions
         {
             // Arrange
             var builder = new HostBuilder();
-            var cacheConfiguration = Mock.Of<ICacheConfiguration>();
+            var cacheConfiguration = new CacheConfiguration();
 
             // Act
             builder.ConfigureSecretStore((config, stores) =>
             {
-                stores.AddAzureKeyVaultWithCertificate("vault-uri",
+                stores.AddAzureKeyVaultWithCertificate(GenerateVaultUri(),
                     "tenant-id",
                     "client-id",
                     new X509Certificate2(),
@@ -570,37 +570,6 @@ namespace Arcus.Security.Tests.Unit.KeyVault.Extensions
         
         [Theory]
         [ClassData(typeof(Blanks))]
-        public void AddAzureKeyVaultWithManagedIdentitySimple_WithoutClientId_Throws(string clientId)
-        {
-            // Arrange
-            var builder = new HostBuilder();
-
-            // Act
-            builder.ConfigureSecretStore(
-                (config, stores) => stores.AddAzureKeyVaultWithManagedIdentity("vault-uri", clientId));
-
-            // Assert
-            Assert.ThrowsAny<ArgumentException>(() => builder.Build());
-        }
-        
-        [Theory]
-        [ClassData(typeof(Blanks))]
-        public void AddAzureKeyVaultWithManagedIdentitySimpleCacheConfiguration_WithoutClientId_Throws(string clientId)
-        {
-            // Arrange
-            var builder = new HostBuilder();
-            var cacheConfiguration = new CacheConfiguration();
-            
-            // Act
-            builder.ConfigureSecretStore(
-                (config, stores) => stores.AddAzureKeyVaultWithManagedIdentity("vault-uri", cacheConfiguration, clientId));
-
-            // Assert
-            Assert.ThrowsAny<ArgumentException>(() => builder.Build());
-        }
-
-        [Theory]
-        [ClassData(typeof(Blanks))]
         public void AddAzureKeyVaultWithManagedServiceIdentityWithOptions_WithCachingWithBlankVaultUri_Throws(string vaultUri)
         {
             // Arrange
@@ -657,7 +626,7 @@ namespace Arcus.Security.Tests.Unit.KeyVault.Extensions
                 (config, stores) =>
                 {
                     stores.AddAzureKeyVaultWithManagedIdentity(
-                        "vault-uri",
+                        GenerateVaultUri(),
                         "client-id",
                         configureOptions: options => options.TrackDependency = true,
                         name: "Azure Key Vault",
@@ -683,7 +652,7 @@ namespace Arcus.Security.Tests.Unit.KeyVault.Extensions
                 (config, stores) =>
                 {
                     stores.AddAzureKeyVaultWithManagedIdentity(
-                        "vault-uri",
+                        GenerateVaultUri(),
                         cacheConfiguration: cacheConfiguration,
                         clientId: "client-id",
                         configureOptions: options => options.TrackDependency = true,
@@ -800,7 +769,7 @@ namespace Arcus.Security.Tests.Unit.KeyVault.Extensions
 
             // Act
             builder.ConfigureSecretStore(
-                (config, stores) => stores.AddAzureKeyVaultWithServicePrincipal("vault-uri", clientId, "client-secret"));
+                (config, stores) => stores.AddAzureKeyVaultWithServicePrincipal(GenerateVaultUri(), clientId, "client-secret"));
 
             // Assert
             Assert.ThrowsAny<ArgumentException>(() => builder.Build());
@@ -815,7 +784,7 @@ namespace Arcus.Security.Tests.Unit.KeyVault.Extensions
 
             // Act
             builder.ConfigureSecretStore(
-                (config, stores) => stores.AddAzureKeyVaultWithServicePrincipalWithOptions("vault-uri", clientId, "client-secret"));
+                (config, stores) => stores.AddAzureKeyVaultWithServicePrincipalWithOptions(GenerateVaultUri(), clientId, "client-secret"));
 
             // Assert
             Assert.ThrowsAny<ArgumentException>(() => builder.Build());
@@ -831,7 +800,7 @@ namespace Arcus.Security.Tests.Unit.KeyVault.Extensions
 
             // Act
             builder.ConfigureSecretStore(
-                (config, stores) => stores.AddAzureKeyVaultWithServicePrincipal("vault-uri", clientId, "client-secret", cacheConfiguration));
+                (config, stores) => stores.AddAzureKeyVaultWithServicePrincipal(GenerateVaultUri(), clientId, "client-secret", cacheConfiguration));
 
             // Assert
             Assert.ThrowsAny<ArgumentException>(() => builder.Build());
@@ -847,7 +816,7 @@ namespace Arcus.Security.Tests.Unit.KeyVault.Extensions
 
             // Act
             builder.ConfigureSecretStore(
-                (config, stores) => stores.AddAzureKeyVaultWithServicePrincipalWithOptions("vault-uri", clientId, "client-secret", cacheConfiguration));
+                (config, stores) => stores.AddAzureKeyVaultWithServicePrincipalWithOptions(GenerateVaultUri(), clientId, "client-secret", cacheConfiguration));
 
             // Assert
             Assert.ThrowsAny<ArgumentException>(() => builder.Build());
@@ -862,7 +831,7 @@ namespace Arcus.Security.Tests.Unit.KeyVault.Extensions
 
             // Act
             builder.ConfigureSecretStore(
-                (config, stores) => stores.AddAzureKeyVaultWithServicePrincipal("vault-uri", tenantId, "client-id", "client-secret"));
+                (config, stores) => stores.AddAzureKeyVaultWithServicePrincipal(GenerateVaultUri(), tenantId, "client-id", "client-secret"));
 
             // Assert
             Assert.ThrowsAny<ArgumentException>(() => builder.Build());
@@ -878,7 +847,7 @@ namespace Arcus.Security.Tests.Unit.KeyVault.Extensions
             
             // Act
             builder.ConfigureSecretStore(
-                (config, stores) => stores.AddAzureKeyVaultWithServicePrincipal("vault-uri", tenantId, "client-id", "client-secret", cacheConfiguration));
+                (config, stores) => stores.AddAzureKeyVaultWithServicePrincipal(GenerateVaultUri(), tenantId, "client-id", "client-secret", cacheConfiguration));
 
             // Assert
             Assert.ThrowsAny<ArgumentException>(() => builder.Build());
@@ -893,7 +862,7 @@ namespace Arcus.Security.Tests.Unit.KeyVault.Extensions
 
             // Act
             builder.ConfigureSecretStore(
-                (config, stores) => stores.AddAzureKeyVaultWithServicePrincipal("vault-uri", "tenant-id", clientId, "client-secret"));
+                (config, stores) => stores.AddAzureKeyVaultWithServicePrincipal(GenerateVaultUri(), "tenant-id", clientId, "client-secret"));
 
             // Assert
             Assert.ThrowsAny<ArgumentException>(() => builder.Build());
@@ -909,7 +878,7 @@ namespace Arcus.Security.Tests.Unit.KeyVault.Extensions
             
             // Act
             builder.ConfigureSecretStore(
-                (config, stores) => stores.AddAzureKeyVaultWithServicePrincipal("vault-uri", "tenant-id", clientId, "client-secret", cacheConfiguration));
+                (config, stores) => stores.AddAzureKeyVaultWithServicePrincipal(GenerateVaultUri(), "tenant-id", clientId, "client-secret", cacheConfiguration));
 
             // Assert
             Assert.ThrowsAny<ArgumentException>(() => builder.Build());
@@ -924,7 +893,7 @@ namespace Arcus.Security.Tests.Unit.KeyVault.Extensions
 
             // Act
             builder.ConfigureSecretStore(
-                (config, stores) => stores.AddAzureKeyVaultWithServicePrincipal("vault-uri", "client-id", clientSecret));
+                (config, stores) => stores.AddAzureKeyVaultWithServicePrincipal(GenerateVaultUri(), "client-id", clientSecret));
 
             // Assert
             Assert.ThrowsAny<ArgumentException>(() => builder.Build());
@@ -939,7 +908,7 @@ namespace Arcus.Security.Tests.Unit.KeyVault.Extensions
 
             // Act
             builder.ConfigureSecretStore(
-                (config, stores) => stores.AddAzureKeyVaultWithServicePrincipalWithOptions("vault-uri", "client-id", clientSecret));
+                (config, stores) => stores.AddAzureKeyVaultWithServicePrincipalWithOptions(GenerateVaultUri(), "client-id", clientSecret));
 
             // Assert
             Assert.ThrowsAny<ArgumentException>(() => builder.Build());
@@ -955,7 +924,7 @@ namespace Arcus.Security.Tests.Unit.KeyVault.Extensions
 
             // Act
             builder.ConfigureSecretStore(
-                (config, stores) => stores.AddAzureKeyVaultWithServicePrincipal("vault-uri", "client-id", clientSecret, cacheConfiguration: cacheConfiguration));
+                (config, stores) => stores.AddAzureKeyVaultWithServicePrincipal(GenerateVaultUri(), "client-id", clientSecret, cacheConfiguration: cacheConfiguration));
 
             // Assert
             Assert.ThrowsAny<ArgumentException>(() => builder.Build());
@@ -971,7 +940,7 @@ namespace Arcus.Security.Tests.Unit.KeyVault.Extensions
 
             // Act
             builder.ConfigureSecretStore(
-                (config, stores) => stores.AddAzureKeyVaultWithServicePrincipalWithOptions("vault-uri", "client-id", clientSecret, cacheConfiguration: cacheConfiguration));
+                (config, stores) => stores.AddAzureKeyVaultWithServicePrincipalWithOptions(GenerateVaultUri(), "client-id", clientSecret, cacheConfiguration: cacheConfiguration));
 
             // Assert
             Assert.ThrowsAny<ArgumentException>(() => builder.Build());
@@ -986,7 +955,7 @@ namespace Arcus.Security.Tests.Unit.KeyVault.Extensions
 
             // Act
             builder.ConfigureSecretStore(
-                (config, stores) => stores.AddAzureKeyVaultWithServicePrincipal("vault-uri", "tenant-id", "client-id", clientKey));
+                (config, stores) => stores.AddAzureKeyVaultWithServicePrincipal(GenerateVaultUri(), "tenant-id", "client-id", clientKey));
 
             // Assert
             Assert.ThrowsAny<ArgumentException>(() => builder.Build());
@@ -1002,7 +971,7 @@ namespace Arcus.Security.Tests.Unit.KeyVault.Extensions
             
             // Act
             builder.ConfigureSecretStore(
-                (config, stores) => stores.AddAzureKeyVaultWithServicePrincipal("vault-uri", "tenant-id", "client-id", clientKey, cacheConfiguration));
+                (config, stores) => stores.AddAzureKeyVaultWithServicePrincipal(GenerateVaultUri(), "tenant-id", "client-id", clientKey, cacheConfiguration));
 
             // Assert
             Assert.ThrowsAny<ArgumentException>(() => builder.Build());
@@ -1048,7 +1017,7 @@ namespace Arcus.Security.Tests.Unit.KeyVault.Extensions
 
             // Act
             builder.ConfigureSecretStore(
-                (config, stores) => stores.AddAzureKeyVaultWithServicePrincipal("vault-uri", "tenant-id", clientId, "client-secret", configureOptions: null, name: null, mutateSecretName: null));
+                (config, stores) => stores.AddAzureKeyVaultWithServicePrincipal(GenerateVaultUri(), "tenant-id", clientId, "client-secret", configureOptions: null, name: null, mutateSecretName: null));
 
             // Assert
             Assert.ThrowsAny<ArgumentException>(() => builder.Build());
@@ -1064,7 +1033,7 @@ namespace Arcus.Security.Tests.Unit.KeyVault.Extensions
 
             // Act
             builder.ConfigureSecretStore(
-                (config, stores) => stores.AddAzureKeyVaultWithServicePrincipal("vault-uri", "tenant-id", clientId, "client-secret", cacheConfiguration, configureOptions: null, name: null, mutateSecretName: null));
+                (config, stores) => stores.AddAzureKeyVaultWithServicePrincipal(GenerateVaultUri(), "tenant-id", clientId, "client-secret", cacheConfiguration, configureOptions: null, name: null, mutateSecretName: null));
 
             // Assert
             Assert.ThrowsAny<ArgumentException>(() => builder.Build());
@@ -1079,7 +1048,7 @@ namespace Arcus.Security.Tests.Unit.KeyVault.Extensions
 
             // Act
             builder.ConfigureSecretStore(
-                (config, stores) => stores.AddAzureKeyVaultWithServicePrincipal("vault-uri", "tenant-id", "client-id", tenantId, configureOptions: null, name: null, mutateSecretName: null));
+                (config, stores) => stores.AddAzureKeyVaultWithServicePrincipal(GenerateVaultUri(), "tenant-id", "client-id", tenantId, configureOptions: null, name: null, mutateSecretName: null));
 
             // Assert
             Assert.ThrowsAny<ArgumentException>(() => builder.Build());
@@ -1095,7 +1064,7 @@ namespace Arcus.Security.Tests.Unit.KeyVault.Extensions
 
             // Act
             builder.ConfigureSecretStore(
-                (config, stores) => stores.AddAzureKeyVaultWithServicePrincipal("vault-uri", "tenant-id", "client-id", clientSecret, cacheConfiguration: cacheConfiguration, configureOptions: null, name: null, mutateSecretName: null));
+                (config, stores) => stores.AddAzureKeyVaultWithServicePrincipal(GenerateVaultUri(), "tenant-id", "client-id", clientSecret, cacheConfiguration: cacheConfiguration, configureOptions: null, name: null, mutateSecretName: null));
 
             // Assert
             Assert.ThrowsAny<ArgumentException>(() => builder.Build());
@@ -1111,7 +1080,7 @@ namespace Arcus.Security.Tests.Unit.KeyVault.Extensions
 
             // Act
             builder.ConfigureSecretStore(
-                (config, stores) => stores.AddAzureKeyVaultWithServicePrincipal("vault-uri", tenantId, "client-id", "client-secret", cacheConfiguration: cacheConfiguration, configureOptions: null, name: null, mutateSecretName: null));
+                (config, stores) => stores.AddAzureKeyVaultWithServicePrincipal(GenerateVaultUri(), tenantId, "client-id", "client-secret", cacheConfiguration: cacheConfiguration, configureOptions: null, name: null, mutateSecretName: null));
 
             // Assert
             Assert.ThrowsAny<ArgumentException>(() => builder.Build());
@@ -1126,7 +1095,7 @@ namespace Arcus.Security.Tests.Unit.KeyVault.Extensions
 
             // Act
             builder.ConfigureSecretStore(
-                (config, stores) => stores.AddAzureKeyVaultWithServicePrincipal("vault-uri", tenantId, "client-id", "client-secret", configureOptions: null, name: null, mutateSecretName: null));
+                (config, stores) => stores.AddAzureKeyVaultWithServicePrincipal(GenerateVaultUri(), tenantId, "client-id", "client-secret", configureOptions: null, name: null, mutateSecretName: null));
 
             // Assert
             Assert.ThrowsAny<ArgumentException>(() => builder.Build());
@@ -1143,7 +1112,7 @@ namespace Arcus.Security.Tests.Unit.KeyVault.Extensions
                 (config, stores) =>
                 {
                     stores.AddAzureKeyVaultWithServicePrincipal(
-                        "vault-uri",
+                        GenerateVaultUri(),
                         "tenant-id",
                         "client-id",
                         "client-secret",
@@ -1172,7 +1141,7 @@ namespace Arcus.Security.Tests.Unit.KeyVault.Extensions
                 (config, stores) =>
                 {
                     stores.AddAzureKeyVaultWithServicePrincipal(
-                        "vault-uri",
+                        GenerateVaultUri(),
                         "tenant-id",
                         "client-id",
                         "client-secret",
@@ -1411,7 +1380,7 @@ namespace Arcus.Security.Tests.Unit.KeyVault.Extensions
             // Arrange
             var builder = new HostBuilder();
             var credential = Mock.Of<TokenCredential>();
-            var configuration = new KeyVaultConfiguration("https://my-secrets.vault.azure.net");
+            var configuration = new KeyVaultConfiguration(GenerateVaultUri());
             
             // Act
             builder.ConfigureSecretStore((config, stores) => stores.AddAzureKeyVault(credential, configuration));
@@ -1429,7 +1398,7 @@ namespace Arcus.Security.Tests.Unit.KeyVault.Extensions
             // Arrange
             var builder = new HostBuilder();
             var credential = Mock.Of<TokenCredential>();
-            var configuration = new KeyVaultConfiguration("https://my-secrets.vault.azure.net");
+            var configuration = new KeyVaultConfiguration(GenerateVaultUri());
             var cacheConfiguration = new CacheConfiguration();
             
             // Act
@@ -1448,7 +1417,7 @@ namespace Arcus.Security.Tests.Unit.KeyVault.Extensions
             // Arrange
             var builder = new HostBuilder();
             var credential = Mock.Of<TokenCredential>();
-            var configuration = new KeyVaultConfiguration("https://my-secrets.vault.azure.net");
+            var configuration = new KeyVaultConfiguration(GenerateVaultUri());
             
             // Act
             builder.ConfigureSecretStore((config, stores) =>
@@ -1475,7 +1444,7 @@ namespace Arcus.Security.Tests.Unit.KeyVault.Extensions
             // Arrange
             var builder = new HostBuilder();
             var credential = Mock.Of<TokenCredential>();
-            var configuration = new KeyVaultConfiguration("https://my-secrets.vault.azure.net");
+            var configuration = new KeyVaultConfiguration(GenerateVaultUri());
             var cacheConfiguration = new CacheConfiguration();
             
             // Act
@@ -1495,6 +1464,12 @@ namespace Arcus.Security.Tests.Unit.KeyVault.Extensions
             {
                 Assert.NotNull(host.Services.GetRequiredService<ISecretProvider>());
             }
+        }
+
+        private static string GenerateVaultUri()
+        {
+            string vaultUri = $"https://{Guid.NewGuid().ToString("N").Substring(0, 24)}.vault.azure.net/";
+            return vaultUri;
         }
     }
 }

--- a/src/Arcus.Security.Tests.Unit/KeyVault/Extensions/SecretStoreBuilderExtensionsTests.cs
+++ b/src/Arcus.Security.Tests.Unit/KeyVault/Extensions/SecretStoreBuilderExtensionsTests.cs
@@ -2,15 +2,18 @@
 using System.Collections.Generic;
 using System.Security.Cryptography.X509Certificates;
 using System.Text;
+using Arcus.Security.Core;
 using Arcus.Security.Core.Caching.Configuration;
 using Arcus.Security.Providers.AzureKeyVault.Authentication;
 using Arcus.Security.Providers.AzureKeyVault.Configuration;
 using Azure.Core;
+using Microsoft.Azure.KeyVault.Core;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Moq;
 using Xunit;
 
-namespace Arcus.Security.Tests.Unit.KeyVault
+namespace Arcus.Security.Tests.Unit.KeyVault.Extensions
 {
     public class SecretStoreBuilderExtensionsTests
     {
@@ -78,6 +81,36 @@ namespace Arcus.Security.Tests.Unit.KeyVault
 
         [Theory]
         [ClassData(typeof(Blanks))]
+        public void AddAzureKeyVaultWithCertificateSimple_WithoutVaultUri_Throws(string vaultUri)
+        {
+            // Arrange
+            var builder = new HostBuilder();
+            var certificate = new X509Certificate2();
+            
+            // Act
+            builder.ConfigureSecretStore((config, stores) => stores.AddAzureKeyVaultWithCertificate(vaultUri, "tenant-id", "client-id", certificate));
+            
+            // Assert
+            Assert.ThrowsAny<ArgumentException>(() => builder.Build());
+        }
+        
+        [Theory]
+        [ClassData(typeof(Blanks))]
+        public void AddAzureKeyVaultWithCertificateSimpleCacheConfiguration_WithoutVaultUri_Throws(string vaultUri)
+        {
+            // Arrange
+            var builder = new HostBuilder();
+            var certificate = new X509Certificate2();
+            
+            // Act
+            builder.ConfigureSecretStore((config, stores) => stores.AddAzureKeyVaultWithCertificate(vaultUri, "tenant-id", "client-id", certificate, cacheConfiguration: new CacheConfiguration()));
+            
+            // Assert
+            Assert.ThrowsAny<ArgumentException>(() => builder.Build());
+        }
+
+        [Theory]
+        [ClassData(typeof(Blanks))]
         public void AddAzureKeyVaultWithCertificate_WithBlankClientId_Throws(string clientId)
         {
             // Arrange
@@ -137,6 +170,36 @@ namespace Arcus.Security.Tests.Unit.KeyVault
             // Assert
             Assert.ThrowsAny<ArgumentException>(() => builder.Build());
         }
+        
+        [Theory]
+        [ClassData(typeof(Blanks))]
+        public void AddAzureKeyVaultWithCertificateSimple_WithoutClientId_Throws(string clientId)
+        {
+            // Arrange
+            var builder = new HostBuilder();
+            var certificate = new X509Certificate2();
+            
+            // Act
+            builder.ConfigureSecretStore((config, stores) => stores.AddAzureKeyVaultWithCertificate("vault-uri", clientId, "tenant-id", certificate));
+            
+            // Assert
+            Assert.ThrowsAny<ArgumentException>(() => builder.Build());
+        }
+        
+        [Theory]
+        [ClassData(typeof(Blanks))]
+        public void AddAzureKeyVaultWithCertificateSimpleCacheConfiguration_WithoutClientId_Throws(string clientId)
+        {
+            // Arrange
+            var builder = new HostBuilder();
+            var certificate = new X509Certificate2();
+            
+            // Act
+            builder.ConfigureSecretStore((config, stores) => stores.AddAzureKeyVaultWithCertificate("vault-uri", clientId, "tenant-id", certificate, cacheConfiguration: new CacheConfiguration()));
+            
+            // Assert
+            Assert.ThrowsAny<ArgumentException>(() => builder.Build());
+        }
 
         [Fact]
         public void AddAzureKeyVaultWithCertificate_WithoutCertificate_Throws()
@@ -192,6 +255,36 @@ namespace Arcus.Security.Tests.Unit.KeyVault
             builder.ConfigureSecretStore(
                 (config, stores) => stores.AddAzureKeyVaultWithCertificateWithOptions("vault-uri", "client-id", certificate: null, cacheConfiguration: cacheConfiguration));
 
+            // Assert
+            Assert.ThrowsAny<ArgumentException>(() => builder.Build());
+        }
+        
+        [Theory]
+        [ClassData(typeof(Blanks))]
+        public void AddAzureKeyVaultWithCertificateSimple_WithoutTenant_Throws(string tenantId)
+        {
+            // Arrange
+            var builder = new HostBuilder();
+            var certificate = new X509Certificate2();
+            
+            // Act
+            builder.ConfigureSecretStore((config, stores) => stores.AddAzureKeyVaultWithCertificate("vault-uri", tenantId, "client-id", certificate));
+            
+            // Assert
+            Assert.ThrowsAny<ArgumentException>(() => builder.Build());
+        }
+        
+        [Theory]
+        [ClassData(typeof(Blanks))]
+        public void AddAzureKeyVaultWithCertificateSimpleCacheConfiguration_WithoutTenant_Throws(string tenantId)
+        {
+            // Arrange
+            var builder = new HostBuilder();
+            var certificate = new X509Certificate2();
+            
+            // Act
+            builder.ConfigureSecretStore((config, stores) => stores.AddAzureKeyVaultWithCertificate("vault-uri", tenantId, "client-id", certificate, cacheConfiguration: new CacheConfiguration()));
+            
             // Assert
             Assert.ThrowsAny<ArgumentException>(() => builder.Build());
         }
@@ -286,6 +379,32 @@ namespace Arcus.Security.Tests.Unit.KeyVault
             // Assert
             Assert.ThrowsAny<ArgumentException>(() => builder.Build());
         }
+        
+        [Fact]
+        public void AddAzureKeyVaultWithCertificateSimple_WithoutCertificate_Throws()
+        {
+            // Arrange
+            var builder = new HostBuilder();
+            
+            // Act
+            builder.ConfigureSecretStore((config, stores) => stores.AddAzureKeyVaultWithCertificate("vault-uri", "tenant-id", "client-id", certificate: null));
+            
+            // Assert
+            Assert.ThrowsAny<ArgumentException>(() => builder.Build());
+        }
+        
+        [Fact]
+        public void AddAzureKeyVaultWithCertificateSimpleCacheConfiguration_WithoutCertificate_Throws()
+        {
+            // Arrange
+            var builder = new HostBuilder();
+            
+            // Act
+            builder.ConfigureSecretStore((config, stores) => stores.AddAzureKeyVaultWithCertificate("vault-uri", "tenant-id", "client-id", certificate: null, cacheConfiguration: new CacheConfiguration()));
+            
+            // Assert
+            Assert.ThrowsAny<ArgumentException>(() => builder.Build());
+        }
 
         [Theory]
         [ClassData(typeof(Blanks))]
@@ -317,6 +436,59 @@ namespace Arcus.Security.Tests.Unit.KeyVault
 
             // Assert
             Assert.ThrowsAny<ArgumentException>(() => builder.Build());
+        }
+        
+        [Fact]
+        public void AddAzureKeyVaultWithCertificateUsingTenant_WithValidArguments_CreatesProvider()
+        {
+            // Arrange
+            var builder = new HostBuilder();
+
+            // Act
+            builder.ConfigureSecretStore((config, stores) =>
+            {
+                stores.AddAzureKeyVaultWithCertificate("vault-uri",
+                    "tenant-id",
+                    "client-id",
+                    new X509Certificate2(),
+                    configureOptions: options => options.TrackDependency = true,
+                    name: "Azure Key Vault",
+                    mutateSecretName: name => name.Replace(":", "."),
+                    allowCaching: true);
+            });
+
+            // Assert
+            using (IHost host = builder.Build())
+            {
+                Assert.NotNull(host.Services.GetRequiredService<ISecretProvider>());
+            }
+        }
+        
+        [Fact]
+        public void AddAzureKeyVaultWithCertificateWithCacheConfiguration_WithValidArguments_CreatesProvider()
+        {
+            // Arrange
+            var builder = new HostBuilder();
+            var cacheConfiguration = Mock.Of<ICacheConfiguration>();
+
+            // Act
+            builder.ConfigureSecretStore((config, stores) =>
+            {
+                stores.AddAzureKeyVaultWithCertificate("vault-uri",
+                    "tenant-id",
+                    "client-id",
+                    new X509Certificate2(),
+                    cacheConfiguration,
+                    configureOptions: options => options.TrackDependency = true,
+                    name: "Azure Key Vault",
+                    mutateSecretName: name => name.Replace(":", "."));
+            });
+
+            // Assert
+            using (IHost host = builder.Build())
+            {
+                Assert.NotNull(host.Services.GetRequiredService<ISecretProvider>());
+            }
         }
 
         [Theory]
@@ -360,6 +532,68 @@ namespace Arcus.Security.Tests.Unit.KeyVault
             // Act
             builder.ConfigureSecretStore(
                 (config, stores) => stores.AddAzureKeyVaultWithManagedServiceIdentity(vaultUri, cacheConfiguration: cacheConfiguration));
+
+            // Assert
+            Assert.ThrowsAny<ArgumentException>(() => builder.Build());
+        }
+        
+        [Theory]
+        [ClassData(typeof(Blanks))]
+        public void AddAzureKeyVaultWithManagedIdentitySimple_WithoutVaultUri_Throws(string vaultUri)
+        {
+            // Arrange
+            var builder = new HostBuilder();
+
+            // Act
+            builder.ConfigureSecretStore(
+                (config, stores) => stores.AddAzureKeyVaultWithManagedIdentity(vaultUri, "client-id"));
+
+            // Assert
+            Assert.ThrowsAny<ArgumentException>(() => builder.Build());
+        }
+        
+        [Theory]
+        [ClassData(typeof(Blanks))]
+        public void AddAzureKeyVaultWithManagedIdentitySimpleCacheConfiguration_WithoutVaultUri_Throws(string vaultUri)
+        {
+            // Arrange
+            var builder = new HostBuilder();
+            var cacheConfiguration = new CacheConfiguration();
+            
+            // Act
+            builder.ConfigureSecretStore(
+                (config, stores) => stores.AddAzureKeyVaultWithManagedIdentity(vaultUri, cacheConfiguration, "client-id"));
+
+            // Assert
+            Assert.ThrowsAny<ArgumentException>(() => builder.Build());
+        }
+        
+        [Theory]
+        [ClassData(typeof(Blanks))]
+        public void AddAzureKeyVaultWithManagedIdentitySimple_WithoutClientId_Throws(string clientId)
+        {
+            // Arrange
+            var builder = new HostBuilder();
+
+            // Act
+            builder.ConfigureSecretStore(
+                (config, stores) => stores.AddAzureKeyVaultWithManagedIdentity("vault-uri", clientId));
+
+            // Assert
+            Assert.ThrowsAny<ArgumentException>(() => builder.Build());
+        }
+        
+        [Theory]
+        [ClassData(typeof(Blanks))]
+        public void AddAzureKeyVaultWithManagedIdentitySimpleCacheConfiguration_WithoutClientId_Throws(string clientId)
+        {
+            // Arrange
+            var builder = new HostBuilder();
+            var cacheConfiguration = new CacheConfiguration();
+            
+            // Act
+            builder.ConfigureSecretStore(
+                (config, stores) => stores.AddAzureKeyVaultWithManagedIdentity("vault-uri", cacheConfiguration, clientId));
 
             // Assert
             Assert.ThrowsAny<ArgumentException>(() => builder.Build());
@@ -410,6 +644,58 @@ namespace Arcus.Security.Tests.Unit.KeyVault
 
             // Assert
             Assert.ThrowsAny<ArgumentException>(() => builder.Build());
+        }
+        
+        [Fact]
+        public void AddAzureKeyVaultWithManagedIdentity_WithValidArguments_CreatesProvider()
+        {
+            // Arrange
+            var builder = new HostBuilder();
+            
+            // Act
+            builder.ConfigureSecretStore(
+                (config, stores) =>
+                {
+                    stores.AddAzureKeyVaultWithManagedIdentity(
+                        "vault-uri",
+                        "client-id",
+                        configureOptions: options => options.TrackDependency = true,
+                        name: "Azure Key Vault",
+                        mutateSecretName: name => name.Replace(":", "."));
+                });
+
+            // Assert
+            using (IHost host = builder.Build())
+            {
+                Assert.NotNull(host.Services.GetRequiredService<ISecretProvider>());
+            }
+        }
+        
+        [Fact]
+        public void AddAzureKeyVaultWithManagedIdentityWithCacheConfiguration_WithValidArguments_CreatesProvider()
+        {
+            // Arrange
+            var builder = new HostBuilder();
+            var cacheConfiguration = new CacheConfiguration();
+            
+            // Act
+            builder.ConfigureSecretStore(
+                (config, stores) =>
+                {
+                    stores.AddAzureKeyVaultWithManagedIdentity(
+                        "vault-uri",
+                        cacheConfiguration: cacheConfiguration,
+                        clientId: "client-id",
+                        configureOptions: options => options.TrackDependency = true,
+                        name: "Azure Key Vault",
+                        mutateSecretName: name => name.Replace(":", "."));
+                });
+
+            // Assert
+            using (IHost host = builder.Build())
+            {
+                Assert.NotNull(host.Services.GetRequiredService<ISecretProvider>());
+            }
         }
 
         [Theory]
@@ -469,6 +755,37 @@ namespace Arcus.Security.Tests.Unit.KeyVault
             // Act
             builder.ConfigureSecretStore(
                 (config, stores) => stores.AddAzureKeyVaultWithServicePrincipalWithOptions(vaultUri, "client-id", "client-secret", cacheConfiguration));
+
+            // Assert
+            Assert.ThrowsAny<ArgumentException>(() => builder.Build());
+        }
+        
+        [Theory]
+        [ClassData(typeof(Blanks))]
+        public void AddAzureKeyVaultWithServicePrincipalSimple_WithBlankVaultUri_Throws(string vaultUri)
+        {
+            // Arrange
+            var builder = new HostBuilder();
+
+            // Act
+            builder.ConfigureSecretStore(
+                (config, stores) => stores.AddAzureKeyVaultWithServicePrincipal(vaultUri, "tenant-id", "client-id", "client-secret"));
+
+            // Assert
+            Assert.ThrowsAny<ArgumentException>(() => builder.Build());
+        }
+        
+        [Theory]
+        [ClassData(typeof(Blanks))]
+        public void AddAzureKeyVaultWithServicePrincipalSimpleCacheConfiguration_WithBlankVaultUri_Throws(string vaultUri)
+        {
+            // Arrange
+            var builder = new HostBuilder();
+            var cacheConfiguration = new CacheConfiguration();
+            
+            // Act
+            builder.ConfigureSecretStore(
+                (config, stores) => stores.AddAzureKeyVaultWithServicePrincipal(vaultUri, "tenant-id", "client-id", "client-secret", cacheConfiguration));
 
             // Assert
             Assert.ThrowsAny<ArgumentException>(() => builder.Build());
@@ -535,6 +852,68 @@ namespace Arcus.Security.Tests.Unit.KeyVault
             // Assert
             Assert.ThrowsAny<ArgumentException>(() => builder.Build());
         }
+        
+        [Theory]
+        [ClassData(typeof(Blanks))]
+        public void AddAzureKeyVaultWithServicePrincipalSimple_WithoutTenantId_Throws(string tenantId)
+        {
+            // Arrange
+            var builder = new HostBuilder();
+
+            // Act
+            builder.ConfigureSecretStore(
+                (config, stores) => stores.AddAzureKeyVaultWithServicePrincipal("vault-uri", tenantId, "client-id", "client-secret"));
+
+            // Assert
+            Assert.ThrowsAny<ArgumentException>(() => builder.Build());
+        }
+        
+        [Theory]
+        [ClassData(typeof(Blanks))]
+        public void AddAzureKeyVaultWithServicePrincipalSimpleCacheConfiguration_WithoutTenantId_Throws(string tenantId)
+        {
+            // Arrange
+            var builder = new HostBuilder();
+            var cacheConfiguration = new CacheConfiguration();
+            
+            // Act
+            builder.ConfigureSecretStore(
+                (config, stores) => stores.AddAzureKeyVaultWithServicePrincipal("vault-uri", tenantId, "client-id", "client-secret", cacheConfiguration));
+
+            // Assert
+            Assert.ThrowsAny<ArgumentException>(() => builder.Build());
+        }
+        
+        [Theory]
+        [ClassData(typeof(Blanks))]
+        public void AddAzureKeyVaultWithServicePrincipalSimple_WithoutClientId_Throws(string clientId)
+        {
+            // Arrange
+            var builder = new HostBuilder();
+
+            // Act
+            builder.ConfigureSecretStore(
+                (config, stores) => stores.AddAzureKeyVaultWithServicePrincipal("vault-uri", "tenant-id", clientId, "client-secret"));
+
+            // Assert
+            Assert.ThrowsAny<ArgumentException>(() => builder.Build());
+        }
+        
+        [Theory]
+        [ClassData(typeof(Blanks))]
+        public void AddAzureKeyVaultWithServicePrincipalSimpleCacheConfiguration_WithoutClientId_Throws(string clientId)
+        {
+            // Arrange
+            var builder = new HostBuilder();
+            var cacheConfiguration = new CacheConfiguration();
+            
+            // Act
+            builder.ConfigureSecretStore(
+                (config, stores) => stores.AddAzureKeyVaultWithServicePrincipal("vault-uri", "tenant-id", clientId, "client-secret", cacheConfiguration));
+
+            // Assert
+            Assert.ThrowsAny<ArgumentException>(() => builder.Build());
+        }
 
         [Theory]
         [ClassData(typeof(Blanks))]
@@ -593,6 +972,37 @@ namespace Arcus.Security.Tests.Unit.KeyVault
             // Act
             builder.ConfigureSecretStore(
                 (config, stores) => stores.AddAzureKeyVaultWithServicePrincipalWithOptions("vault-uri", "client-id", clientSecret, cacheConfiguration: cacheConfiguration));
+
+            // Assert
+            Assert.ThrowsAny<ArgumentException>(() => builder.Build());
+        }
+        
+        [Theory]
+        [ClassData(typeof(Blanks))]
+        public void AddAzureKeyVaultWithServicePrincipalSimple_WithoutClientKey_Throws(string clientKey)
+        {
+            // Arrange
+            var builder = new HostBuilder();
+
+            // Act
+            builder.ConfigureSecretStore(
+                (config, stores) => stores.AddAzureKeyVaultWithServicePrincipal("vault-uri", "tenant-id", "client-id", clientKey));
+
+            // Assert
+            Assert.ThrowsAny<ArgumentException>(() => builder.Build());
+        }
+        
+        [Theory]
+        [ClassData(typeof(Blanks))]
+        public void AddAzureKeyVaultWithServicePrincipalSimpleCacheConfiguration_WithoutClientKey_Throws(string clientKey)
+        {
+            // Arrange
+            var builder = new HostBuilder();
+            var cacheConfiguration = new CacheConfiguration();
+            
+            // Act
+            builder.ConfigureSecretStore(
+                (config, stores) => stores.AddAzureKeyVaultWithServicePrincipal("vault-uri", "tenant-id", "client-id", clientKey, cacheConfiguration));
 
             // Assert
             Assert.ThrowsAny<ArgumentException>(() => builder.Build());
@@ -721,6 +1131,63 @@ namespace Arcus.Security.Tests.Unit.KeyVault
             // Assert
             Assert.ThrowsAny<ArgumentException>(() => builder.Build());
         }
+        
+        [Fact]
+        public void AddAzureKeyVaultWithServicePrincipalWithTenant_WithValidArguments_CreatesProvider()
+        {
+            // Arrange
+            var builder = new HostBuilder();
+
+            // Act
+            builder.ConfigureSecretStore(
+                (config, stores) =>
+                {
+                    stores.AddAzureKeyVaultWithServicePrincipal(
+                        "vault-uri",
+                        "tenant-id",
+                        "client-id",
+                        "client-secret",
+                        configureOptions: options => options.TrackDependency = true,
+                        name: "Azure Key Vault",
+                        mutateSecretName: name => name.Replace(":", "."),
+                        allowCaching: true);
+                });
+
+            // Assert
+            using (IHost host = builder.Build())
+            {
+                Assert.NotNull(host.Services.GetRequiredService<ISecretProvider>());
+            }
+        }
+        
+        [Fact]
+        public void AddAzureKeyVaultWithServicePrincipalWithCacheConfiguration_WithValidArguments_CreatesProvider()
+        {
+            // Arrange
+            var builder = new HostBuilder();
+            var cacheConfiguration = new CacheConfiguration();
+            
+            // Act
+            builder.ConfigureSecretStore(
+                (config, stores) =>
+                {
+                    stores.AddAzureKeyVaultWithServicePrincipal(
+                        "vault-uri",
+                        "tenant-id",
+                        "client-id",
+                        "client-secret",
+                        configureOptions: options => options.TrackDependency = true,
+                        name: "Azure Key Vault",
+                        mutateSecretName: name => name.Replace(":", "."),
+                        cacheConfiguration: cacheConfiguration);
+                });
+
+            // Assert
+            using (IHost host = builder.Build())
+            {
+                Assert.NotNull(host.Services.GetRequiredService<ISecretProvider>());
+            }
+        }
 
         [Fact]
         public void AddAzureKeyVault_WithoutAuthentication_Throws()
@@ -815,6 +1282,21 @@ namespace Arcus.Security.Tests.Unit.KeyVault
         }
 
         [Fact]
+        public void AddAzureKeyVaultSdkSimple_WithoutVaultConfiguration_Throws()
+        {
+            // Arrange
+            var builder = new HostBuilder();
+            var credential = Mock.Of<TokenCredential>();
+            
+            // Act
+            builder.ConfigureSecretStore((config, stores) =>
+                stores.AddAzureKeyVault(tokenCredential: credential, configuration: null));
+            
+            // Assert
+            Assert.ThrowsAny<ArgumentException>(() => builder.Build());
+        }
+
+        [Fact]
         public void AddAzureKeyVaultSdk_WithoutVaultConfiguration_Throws()
         {
             // Arrange
@@ -824,6 +1306,37 @@ namespace Arcus.Security.Tests.Unit.KeyVault
             // Act
             builder.ConfigureSecretStore(
                 (config, stores) => stores.AddAzureKeyVault(credential, configuration: null, allowCaching: false, configureOptions: null, name: null, mutateSecretName: null));
+
+            // Assert
+            Assert.ThrowsAny<ArgumentException>(() => builder.Build());
+        }
+        
+        [Fact]
+        public void AddAzureKeyVaultSdkSimple_WithoutTokenCredential_Throws()
+        {
+            // Arrange
+            var builder = new HostBuilder();
+            var configuration = Mock.Of<IKeyVaultConfiguration>();
+            
+            // Act
+            builder.ConfigureSecretStore((config, stores) =>
+                stores.AddAzureKeyVault(tokenCredential: null, configuration: configuration));
+            
+            // Assert
+            Assert.ThrowsAny<ArgumentException>(() => builder.Build());
+        }
+        
+        [Fact]
+        public void AddAzureKeyVaultSdkSimpleCacheConfiguration_WithoutVaultConfiguration_Throws()
+        {
+            // Arrange
+            var builder = new HostBuilder();
+            var credential = Mock.Of<TokenCredential>();
+            var cacheConfiguration = Mock.Of<ICacheConfiguration>();
+
+            // Act
+            builder.ConfigureSecretStore(
+                (config, stores) => stores.AddAzureKeyVault(credential, configuration: null, cacheConfiguration: cacheConfiguration));
 
             // Assert
             Assert.ThrowsAny<ArgumentException>(() => builder.Build());
@@ -874,6 +1387,114 @@ namespace Arcus.Security.Tests.Unit.KeyVault
 
             // Assert
             Assert.ThrowsAny<ArgumentException>(() => builder.Build());
+        }
+        
+        [Fact]
+        public void AddAzureKeyVaultSdkSimpleCacheConfiguration_WithoutTokenCredential_Throws()
+        {
+            // Arrange
+            var builder = new HostBuilder();
+            var configuration = Mock.Of<IKeyVaultConfiguration>();
+            var cacheConfiguration = Mock.Of<ICacheConfiguration>();
+
+            // Act
+            builder.ConfigureSecretStore(
+                (config, stores) => stores.AddAzureKeyVault(tokenCredential: null, configuration: configuration, cacheConfiguration: cacheConfiguration));
+
+            // Assert
+            Assert.ThrowsAny<ArgumentException>(() => builder.Build());
+        }
+
+        [Fact]
+        public void AddAzureKeyVaultSdkSimple_WithValidArguments_CreatesProvider()
+        {
+            // Arrange
+            var builder = new HostBuilder();
+            var credential = Mock.Of<TokenCredential>();
+            var configuration = new KeyVaultConfiguration("https://my-secrets.vault.azure.net");
+            
+            // Act
+            builder.ConfigureSecretStore((config, stores) => stores.AddAzureKeyVault(credential, configuration));
+
+            // Assert
+            using (IHost host = builder.Build())
+            {
+                Assert.NotNull(host.Services.GetRequiredService<ISecretProvider>());
+            }
+        }
+        
+        [Fact]
+        public void AddAzureKeyVaultSdkSimpleCacheConfiguration_WithValidArguments_CreatesProvider()
+        {
+            // Arrange
+            var builder = new HostBuilder();
+            var credential = Mock.Of<TokenCredential>();
+            var configuration = new KeyVaultConfiguration("https://my-secrets.vault.azure.net");
+            var cacheConfiguration = new CacheConfiguration();
+            
+            // Act
+            builder.ConfigureSecretStore((config, stores) => stores.AddAzureKeyVault(credential, configuration, cacheConfiguration));
+
+            // Assert
+            using (IHost host = builder.Build())
+            {
+                Assert.NotNull(host.Services.GetRequiredService<ISecretProvider>());
+            }
+        }
+        
+        [Fact]
+        public void AddAzureKeyVaultSdk_WithValidArguments_CreatesProvider()
+        {
+            // Arrange
+            var builder = new HostBuilder();
+            var credential = Mock.Of<TokenCredential>();
+            var configuration = new KeyVaultConfiguration("https://my-secrets.vault.azure.net");
+            
+            // Act
+            builder.ConfigureSecretStore((config, stores) =>
+            {
+                stores.AddAzureKeyVault(
+                    credential,
+                    configuration,
+                    options => options.TrackDependency = true,
+                    "Azure Key Vault",
+                    name => "Arcus." + name,
+                    allowCaching: true);
+            });
+
+            // Assert
+            using (IHost host = builder.Build())
+            {
+                Assert.NotNull(host.Services.GetRequiredService<ISecretProvider>());
+            }
+        }
+        
+        [Fact]
+        public void AddAzureKeyVaultSdk_WithCachingWithValidArguments_CreatesProvider()
+        {
+            // Arrange
+            var builder = new HostBuilder();
+            var credential = Mock.Of<TokenCredential>();
+            var configuration = new KeyVaultConfiguration("https://my-secrets.vault.azure.net");
+            var cacheConfiguration = new CacheConfiguration();
+            
+            // Act
+            builder.ConfigureSecretStore((config, stores) =>
+            {
+                stores.AddAzureKeyVault(
+                    credential,
+                    configuration,
+                    cacheConfiguration,
+                    options => options.TrackDependency = true,
+                    "Azure Key Vault",
+                    name => "Arcus." + name);
+            });
+
+            // Assert
+            using (IHost host = builder.Build())
+            {
+                Assert.NotNull(host.Services.GetRequiredService<ISecretProvider>());
+            }
         }
     }
 }


### PR DESCRIPTION
Provide a simplified version of each of the new SDK method overloads with only the caching as an additional option.
This lets consumers choose for a less complicated option when using the new SDK approach.

Closes #219 