### PR TITLE
Feature - use '.AddSecretStore' in Azure Functions secret store extension

### DIFF
--- a/src/Arcus.Security.AzureFunctions/Extensions/IFunctionHostBuilderExtensions.cs
+++ b/src/Arcus.Security.AzureFunctions/Extensions/IFunctionHostBuilderExtensions.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using Arcus.Security.Core;
 using GuardNet;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 
 // ReSharper disable once CheckNamespace
@@ -22,10 +23,7 @@ namespace Microsoft.Azure.Functions.Extensions.DependencyInjection
             Guard.NotNull(functionsHostBuilder, nameof(functionsHostBuilder));
             Guard.NotNull(configureSecretStores, nameof(configureSecretStores));
 
-            var builder = new SecretStoreBuilder(functionsHostBuilder.Services);
-            configureSecretStores(builder);
-            builder.RegisterSecretStore();
-
+            functionsHostBuilder.Services.AddSecretStore(configureSecretStores);
             return functionsHostBuilder;
         }
     }

--- a/src/Arcus.Security.AzureFunctions/Extensions/IFunctionHostBuilderExtensions.cs
+++ b/src/Arcus.Security.AzureFunctions/Extensions/IFunctionHostBuilderExtensions.cs
@@ -18,10 +18,11 @@ namespace Microsoft.Azure.Functions.Extensions.DependencyInjection
         /// </summary>
         /// <param name="functionsHostBuilder">The builder to append the secret store configuration to.</param>
         /// <param name="configureSecretStores">The customization of the different target secret store sources to include in the final <see cref="ISecretProvider"/>.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="functionsHostBuilder"/> or <paramref name="configureSecretStores"/> is <c>null</c>.</exception>
         public static IFunctionsHostBuilder ConfigureSecretStore(this IFunctionsHostBuilder functionsHostBuilder, Action<SecretStoreBuilder> configureSecretStores)
         {
-            Guard.NotNull(functionsHostBuilder, nameof(functionsHostBuilder));
-            Guard.NotNull(configureSecretStores, nameof(configureSecretStores));
+            Guard.NotNull(functionsHostBuilder, nameof(functionsHostBuilder), "Requires a functions host builder to add the secret store");
+            Guard.NotNull(configureSecretStores, nameof(configureSecretStores), "Requires a function to configure the secret store with potential secret providers");
 
             functionsHostBuilder.Services.AddSecretStore(configureSecretStores);
             return functionsHostBuilder;

--- a/src/Arcus.Security.Core/InternalsVisibleTo.cs
+++ b/src/Arcus.Security.Core/InternalsVisibleTo.cs
@@ -1,3 +1,0 @@
-﻿using System.Runtime.CompilerServices;
-
-[assembly: InternalsVisibleTo("Arcus.Security.AzureFunctions")]


### PR DESCRIPTION
Because of #215  , we are now able to use the `.AddSecretStore` directly on an `IServiceCollection` instance.
This can be used within the Azure Function extension too so we don't have to expose internal functionality.