### PR TITLE
Feature - use secret source name within security logging

### DIFF
--- a/src/Arcus.Security.Core/CompositeSecretProvider.cs
+++ b/src/Arcus.Security.Core/CompositeSecretProvider.cs
@@ -361,11 +361,13 @@ namespace Arcus.Security.Core
         {
             if (_auditingOptions.EmitSecurityEvents)
             {
-                _logger.LogSecurityEvent("Get Secret", new Dictionary<string, object>
+                var telemetryContext = new Dictionary<string, object>
                 {
                     ["SecretName"] = secretName,
-                    ["SecretProvider"] = source.SecretProvider.GetType().Name
-                }); 
+                    ["SecretProvider"] = source.Options.Name ?? source.SecretProvider.GetType().Name
+                };
+
+                _logger.LogSecurityEvent("Get Secret", telemetryContext);
             }
 
             Task<T> resultAsync = callRegisteredProvider(source);

--- a/src/Arcus.Security.Core/CompositeSecretProvider.cs
+++ b/src/Arcus.Security.Core/CompositeSecretProvider.cs
@@ -361,13 +361,11 @@ namespace Arcus.Security.Core
         {
             if (_auditingOptions.EmitSecurityEvents)
             {
-                var telemetryContext = new Dictionary<string, object>
+                _logger.LogSecurityEvent("Get Secret", new Dictionary<string, object>
                 {
                     ["SecretName"] = secretName,
                     ["SecretProvider"] = source.Options.Name ?? source.SecretProvider.GetType().Name
-                };
-
-                _logger.LogSecurityEvent("Get Secret", telemetryContext);
+                });
             }
 
             Task<T> resultAsync = callRegisteredProvider(source);

--- a/src/Arcus.Security.Core/CompositeSecretProvider.cs
+++ b/src/Arcus.Security.Core/CompositeSecretProvider.cs
@@ -174,7 +174,7 @@ namespace Arcus.Security.Core
         private SecretStoreSource GetSecretSource(string name)
         {
             IEnumerable<SecretStoreSource> matchingProviders =
-                _secretProviders.Where(provider => provider.Options.Name == name);
+                _secretProviders.Where(provider => provider.Options?.Name == name);
 
             int count = matchingProviders.Count();
             if (count is 0)
@@ -364,7 +364,7 @@ namespace Arcus.Security.Core
                 _logger.LogSecurityEvent("Get Secret", new Dictionary<string, object>
                 {
                     ["SecretName"] = secretName,
-                    ["SecretProvider"] = source.Options.Name ?? source.SecretProvider.GetType().Name
+                    ["SecretProvider"] = source.Options?.Name ?? source.SecretProvider.GetType().Name
                 });
             }
 

--- a/src/Arcus.Security.Core/SecretStoreBuilder.cs
+++ b/src/Arcus.Security.Core/SecretStoreBuilder.cs
@@ -251,7 +251,7 @@ namespace Microsoft.Extensions.Hosting
         private void EnsureUniqueSecretProviderNames()
         {
             IEnumerable<string> secretProvidersWithDuplicateNames =
-                SecretStoreSources.GroupBy(source => source.Options.Name)
+                SecretStoreSources.GroupBy(source => source.Options?.Name)
                                   .Where(group => @group.Key != null && @group.Count() > 1)
                                   .Select(group => @group.Key);
 

--- a/src/Arcus.Security.Core/SecretStoreSource.cs
+++ b/src/Arcus.Security.Core/SecretStoreSource.cs
@@ -115,7 +115,7 @@ namespace Arcus.Security.Core
         /// <summary>
         /// Gets the configured options for the registration of the <see cref="ISecretProvider"/> in the secret store.
         /// </summary>
-        internal SecretProviderOptions Options { get; }
+        internal SecretProviderOptions Options { get; } = new SecretProviderOptions();
 
         /// <summary>
         /// Ensure that the <see cref="SecretProvider"/> and the <see cref="CachedSecretProvider"/> are initialized

--- a/src/Arcus.Security.Core/SecretStoreSource.cs
+++ b/src/Arcus.Security.Core/SecretStoreSource.cs
@@ -162,7 +162,7 @@ namespace Arcus.Security.Core
                     ?? NullLogger<SecretStoreBuilder>.Instance;
                 
                 logger.LogError(exception, 
-                    "Failed to create an {Name} '{SecretProviderType}' using the provided lazy initialization in the secret store", Options.Name, nameof(ISecretProvider));
+                    "Failed to create an {Name} '{SecretProviderType}' using the provided lazy initialization in the secret store", Options?.Name, nameof(ISecretProvider));
 
                 throw;
             }


### PR DESCRIPTION
Since #204 we allow secret provider registrations to include a name that represents the secret source. This name can be used when we log a security even for the secret store.