### PR TITLE
Feature - update to Arcus.Observability v2.0

### DIFF
--- a/src/Arcus.Security.Core/Arcus.Security.Core.csproj
+++ b/src/Arcus.Security.Core/Arcus.Security.Core.csproj
@@ -17,15 +17,19 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="2.2.0" />
+  </ItemGroup>
 
+  <ItemGroup Condition="'$(TargetFramework)' != 'netstandard2.0'">
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="3.1.8" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="3.1.8" />
+  </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Arcus.Observability.Telemetry.Core" Version="1.0.0" />
+    <PackageReference Include="Arcus.Observability.Telemetry.Core" Version="2.0.0" />
     <PackageReference Include="Guard.Net" Version="1.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="3.1.8" />
-    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="3.1.8" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="3.1.8" />
-    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="3.1.8" />
   </ItemGroup>
 
 </Project>

--- a/src/Arcus.Security.Core/Arcus.Security.Core.csproj
+++ b/src/Arcus.Security.Core/Arcus.Security.Core.csproj
@@ -17,17 +17,9 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
-    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="2.2.0" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' != 'netstandard2.0'">
+  <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="3.1.8" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="3.1.8" />
-  </ItemGroup>
-
-  <ItemGroup>
     <PackageReference Include="Arcus.Observability.Telemetry.Core" Version="2.0.0" />
     <PackageReference Include="Guard.Net" Version="1.2.0" />
   </ItemGroup>

--- a/src/Arcus.Security.Providers.UserSecrets/Arcus.Security.Providers.UserSecrets.csproj
+++ b/src/Arcus.Security.Providers.UserSecrets/Arcus.Security.Providers.UserSecrets.csproj
@@ -18,7 +18,11 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="2.2.8" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' != 'netstandard2.0'">
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="3.1.8" />
   </ItemGroup>
 


### PR DESCRIPTION
Updates to new version v2.0 of Arcus.Observability packae + making sure that we use the same package dependency strategy as the Observability library.

Closes #190 