### PR TITLE
Feature - add Azure Key Vault secret store overloads w/o Managed Identity clientId

### DIFF
--- a/src/Arcus.Security.Providers.AzureKeyVault/Extensions/SecretStoreBuilderExtensions.cs
+++ b/src/Arcus.Security.Providers.AzureKeyVault/Extensions/SecretStoreBuilderExtensions.cs
@@ -377,6 +377,27 @@ namespace Microsoft.Extensions.Hosting
         /// </summary>
         /// <param name="builder">The builder to create the secret store.</param>
         /// <param name="rawVaultUri">The Uri of the Azure Key Vault you want to connect to.</param>
+        ///     The optional client id to authenticate for a user assigned managed identity.
+        ///     More information on user assigned managed identities can be found here: https://docs.microsoft.com/en-us/azure/active-directory/managed-identities-azure-resources/overview#how-a-user-assigned-managed-identity-works-with-an-azure-vm</param>
+        /// <param name="allowCaching">The flag to indicate whether to include caching during secret retrieval in Azure key vault.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="builder"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="rawVaultUri"/> is blank.</exception>
+        public static SecretStoreBuilder AddAzureKeyVaultWithManagedIdentity(
+            this SecretStoreBuilder builder,
+            string rawVaultUri,
+            bool allowCaching = false)
+        {
+            Guard.NotNull(builder, nameof(builder), "Requires a secret store builder to add the Azure Key Vault secret provider");
+            Guard.NotNullOrWhitespace(rawVaultUri, nameof(rawVaultUri), "Requires a non-blank URI of the Azure Key Vault instance to add the secret provider to the secret store");
+
+            return AddAzureKeyVaultWithManagedIdentity(builder, rawVaultUri, clientId: null, allowCaching: allowCaching);
+        }
+        
+        /// <summary>
+        /// Adds Azure Key Vault as a secret source which uses Managed Identity authentication.
+        /// </summary>
+        /// <param name="builder">The builder to create the secret store.</param>
+        /// <param name="rawVaultUri">The Uri of the Azure Key Vault you want to connect to.</param>
         /// <param name="clientId">
         ///     The optional client id to authenticate for a user assigned managed identity.
         ///     More information on user assigned managed identities can be found here: https://docs.microsoft.com/en-us/azure/active-directory/managed-identities-azure-resources/overview#how-a-user-assigned-managed-identity-works-with-an-azure-vm</param>
@@ -399,6 +420,38 @@ namespace Microsoft.Extensions.Hosting
                 configureOptions: null,
                 name: null,
                 mutateSecretName: null,
+                allowCaching: allowCaching);
+        }
+
+        /// <summary>
+        /// Adds Azure Key Vault as a secret source which uses Managed Identity authentication.
+        /// </summary>
+        /// <param name="builder">The builder to create the secret store.</param>
+        /// <param name="rawVaultUri">The Uri of the Azure Key Vault you want to connect to.</param>
+        /// <param name="allowCaching">The flag to indicate whether to include caching during secret retrieval in Azure key vault.</param>
+        /// <param name="configureOptions">The optional additional options to configure the Azure Key Vault secret source.</param>
+        /// <param name="name">The unique name to register this Azure Key Vault provider in the secret store.</param>
+        /// <param name="mutateSecretName">The optional function to mutate the secret name before looking it up.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="builder"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="rawVaultUri"/> is blank.</exception>
+        public static SecretStoreBuilder AddAzureKeyVaultWithManagedIdentity(
+            this SecretStoreBuilder builder,
+            string rawVaultUri,
+            Action<KeyVaultOptions> configureOptions,
+            string name,
+            Func<string, string> mutateSecretName,
+            bool allowCaching = false)
+        {
+            Guard.NotNull(builder, nameof(builder), "Requires a secret store builder to add the Azure Key Vault secret provider");
+            Guard.NotNullOrWhitespace(rawVaultUri, nameof(rawVaultUri), "Requires a non-blank URI of the Azure Key Vault instance to add the secret provider to the secret store");
+
+            return AddAzureKeyVaultWithManagedIdentity(
+                builder,
+                rawVaultUri,
+                clientId: null,
+                configureOptions: configureOptions,
+                name: name,
+                mutateSecretName: mutateSecretName,
                 allowCaching: allowCaching);
         }
 
@@ -505,6 +558,29 @@ namespace Microsoft.Extensions.Hosting
         /// </summary>
         /// <param name="builder">The builder to create the secret store.</param>
         /// <param name="rawVaultUri">The Uri of the Azure Key Vault you want to connect to.</param>
+        /// <param name="cacheConfiguration">The configuration to control how the caching will be done.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="builder"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="rawVaultUri"/> is blank.</exception>
+        public static SecretStoreBuilder AddAzureKeyVaultWithManagedIdentity(
+            this SecretStoreBuilder builder,
+            string rawVaultUri,
+            ICacheConfiguration cacheConfiguration)
+        {
+            Guard.NotNull(builder, nameof(builder), "Requires a secret store builder to add the Azure Key Vault secret provider");
+            Guard.NotNullOrWhitespace(rawVaultUri, nameof(rawVaultUri), "Requires a non-blank URI of the Azure Key Vault instance to add the secret provider to the secret store");
+
+            return AddAzureKeyVaultWithManagedIdentity(
+                builder,
+                rawVaultUri,
+                cacheConfiguration,
+                clientId: null);
+        }
+        
+        /// <summary>
+        /// Adds Azure Key Vault as a secret source which uses Managed Identity authentication.
+        /// </summary>
+        /// <param name="builder">The builder to create the secret store.</param>
+        /// <param name="rawVaultUri">The Uri of the Azure Key Vault you want to connect to.</param>
         /// <param name="clientId">
         ///     The optional client id to authenticate for a user assigned managed identity.
         ///     More information on user assigned managed identities can be found here: https://docs.microsoft.com/en-us/azure/active-directory/managed-identities-azure-resources/overview#how-a-user-assigned-managed-identity-works-with-an-azure-vm</param>
@@ -528,6 +604,38 @@ namespace Microsoft.Extensions.Hosting
                 configureOptions: null,
                 name: null,
                 mutateSecretName: null);
+        }
+        
+        /// <summary>
+        /// Adds Azure Key Vault as a secret source which uses Managed Identity authentication.
+        /// </summary>
+        /// <param name="builder">The builder to create the secret store.</param>
+        /// <param name="rawVaultUri">The Uri of the Azure Key Vault you want to connect to.</param>
+        /// <param name="cacheConfiguration">The configuration to control how the caching will be done.</param>
+        /// <param name="configureOptions">The optional additional options to configure the Azure Key Vault secret source.</param>
+        /// <param name="name">The unique name to register this Azure Key Vault provider in the secret store.</param>
+        /// <param name="mutateSecretName">The optional function to mutate the secret name before looking it up.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="builder"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="rawVaultUri"/> is blank.</exception>
+        public static SecretStoreBuilder AddAzureKeyVaultWithManagedIdentity(
+            this SecretStoreBuilder builder,
+            string rawVaultUri,
+            ICacheConfiguration cacheConfiguration,
+            Action<KeyVaultOptions> configureOptions,
+            string name,
+            Func<string, string> mutateSecretName)
+        {
+            Guard.NotNull(builder, nameof(builder), "Requires a secret store builder to add the Azure Key Vault secret provider");
+            Guard.NotNullOrWhitespace(rawVaultUri, nameof(rawVaultUri), "Requires a non-blank URI of the Azure Key Vault instance to add the secret provider to the secret store");
+
+            return AddAzureKeyVaultWithManagedIdentity(
+                builder,
+                rawVaultUri,
+                cacheConfiguration,
+                clientId: null,
+                configureOptions: configureOptions,
+                name: name,
+                mutateSecretName: mutateSecretName);
         }
 
         /// <summary>

--- a/src/Arcus.Security.Tests.Unit/KeyVault/Extensions/SecretStoreBuilderExtensionsTests.cs
+++ b/src/Arcus.Security.Tests.Unit/KeyVault/Extensions/SecretStoreBuilderExtensionsTests.cs
@@ -536,6 +536,22 @@ namespace Arcus.Security.Tests.Unit.KeyVault.Extensions
             // Assert
             Assert.ThrowsAny<ArgumentException>(() => builder.Build());
         }
+       
+        [Theory]
+        [ClassData(typeof(Blanks))]
+        public void AddAzureKeyVaultWithManagedIdentitySimple_WithoutVaultUriWithoutClientId_Throws(string vaultUri)
+        {
+            // Arrange
+            var builder = new HostBuilder();
+
+            // Act
+            builder.ConfigureSecretStore(
+                (config, stores) => stores.AddAzureKeyVaultWithManagedIdentity(vaultUri));
+
+            // Assert
+            Assert.ThrowsAny<ArgumentException>(() => builder.Build());
+        }
+
         
         [Theory]
         [ClassData(typeof(Blanks))]
@@ -547,6 +563,22 @@ namespace Arcus.Security.Tests.Unit.KeyVault.Extensions
             // Act
             builder.ConfigureSecretStore(
                 (config, stores) => stores.AddAzureKeyVaultWithManagedIdentity(vaultUri, "client-id"));
+
+            // Assert
+            Assert.ThrowsAny<ArgumentException>(() => builder.Build());
+        }
+        
+        [Theory]
+        [ClassData(typeof(Blanks))]
+        public void AddAzureKeyVaultWithManagedIdentitySimpleCacheConfiguration_WithoutVaultUriWithoutClientId_Throws(string vaultUri)
+        {
+            // Arrange
+            var builder = new HostBuilder();
+            var cacheConfiguration = new CacheConfiguration();
+            
+            // Act
+            builder.ConfigureSecretStore(
+                (config, stores) => stores.AddAzureKeyVaultWithManagedIdentity(vaultUri, cacheConfiguration));
 
             // Assert
             Assert.ThrowsAny<ArgumentException>(() => builder.Build());
@@ -583,6 +615,21 @@ namespace Arcus.Security.Tests.Unit.KeyVault.Extensions
             // Assert
             Assert.ThrowsAny<ArgumentException>(() => builder.Build());
         }
+        
+        [Theory]
+        [ClassData(typeof(Blanks))]
+        public void AddAzureKeyVaultWithManagedIdentity_WithBlankVaultUriWithoutClientId_Throws(string vaultUri)
+        {
+            // Arrange
+            var builder = new HostBuilder();
+
+            // Act
+            builder.ConfigureSecretStore(
+                (config, stores) => stores.AddAzureKeyVaultWithManagedIdentity(vaultUri, configureOptions: null, name: null, mutateSecretName: null));
+
+            // Assert
+            Assert.ThrowsAny<ArgumentException>(() => builder.Build());
+        }
 
         [Theory]
         [ClassData(typeof(Blanks))]
@@ -601,6 +648,22 @@ namespace Arcus.Security.Tests.Unit.KeyVault.Extensions
 
         [Theory]
         [ClassData(typeof(Blanks))]
+        public void AddAzureKeyVaultWithManagedIdentity_WithCachingWithBlankVaultUriWithoutClientId_Throws(string vaultUri)
+        {
+            // Arrange
+            var builder = new HostBuilder();
+            var cacheConfiguration = Mock.Of<ICacheConfiguration>();
+
+            // Act
+            builder.ConfigureSecretStore(
+                (config, stores) => stores.AddAzureKeyVaultWithManagedIdentity(vaultUri, cacheConfiguration: cacheConfiguration, configureOptions: null, name: null, mutateSecretName: null));
+
+            // Assert
+            Assert.ThrowsAny<ArgumentException>(() => builder.Build());
+        }
+        
+        [Theory]
+        [ClassData(typeof(Blanks))]
         public void AddAzureKeyVaultWithManagedIdentity_WithCachingWithBlankVaultUri_Throws(string vaultUri)
         {
             // Arrange
@@ -616,6 +679,30 @@ namespace Arcus.Security.Tests.Unit.KeyVault.Extensions
         }
         
         [Fact]
+        public void AddAzureKeyVaultWithManagedIdentity_WithValidArgumentsWithoutClientId_CreatesProvider()
+        {
+            // Arrange
+            var builder = new HostBuilder();
+            
+            // Act
+            builder.ConfigureSecretStore(
+                (config, stores) =>
+                {
+                    stores.AddAzureKeyVaultWithManagedIdentity(
+                        GenerateVaultUri(),
+                        configureOptions: options => options.TrackDependency = true,
+                        name: "Azure Key Vault",
+                        mutateSecretName: name => name.Replace(":", "."));
+                });
+
+            // Assert
+            using (IHost host = builder.Build())
+            {
+                Assert.NotNull(host.Services.GetRequiredService<ISecretProvider>());
+            }
+        }
+        
+        [Fact]
         public void AddAzureKeyVaultWithManagedIdentity_WithValidArguments_CreatesProvider()
         {
             // Arrange
@@ -628,6 +715,32 @@ namespace Arcus.Security.Tests.Unit.KeyVault.Extensions
                     stores.AddAzureKeyVaultWithManagedIdentity(
                         GenerateVaultUri(),
                         "client-id",
+                        configureOptions: options => options.TrackDependency = true,
+                        name: "Azure Key Vault",
+                        mutateSecretName: name => name.Replace(":", "."));
+                });
+
+            // Assert
+            using (IHost host = builder.Build())
+            {
+                Assert.NotNull(host.Services.GetRequiredService<ISecretProvider>());
+            }
+        }
+        
+        [Fact]
+        public void AddAzureKeyVaultWithManagedIdentityWithCacheConfiguration_WithValidArgumentsWithoutClientId_CreatesProvider()
+        {
+            // Arrange
+            var builder = new HostBuilder();
+            var cacheConfiguration = new CacheConfiguration();
+            
+            // Act
+            builder.ConfigureSecretStore(
+                (config, stores) =>
+                {
+                    stores.AddAzureKeyVaultWithManagedIdentity(
+                        GenerateVaultUri(),
+                        cacheConfiguration: cacheConfiguration,
                         configureOptions: options => options.TrackDependency = true,
                         name: "Azure Key Vault",
                         mutateSecretName: name => name.Replace(":", "."));

--- a/src/Arcus.Security.Tests.Unit/KeyVault/Extensions/SecretStoreBuilderExtensionsTests.cs
+++ b/src/Arcus.Security.Tests.Unit/KeyVault/Extensions/SecretStoreBuilderExtensionsTests.cs
@@ -552,7 +552,6 @@ namespace Arcus.Security.Tests.Unit.KeyVault.Extensions
             Assert.ThrowsAny<ArgumentException>(() => builder.Build());
         }
 
-        
         [Theory]
         [ClassData(typeof(Blanks))]
         public void AddAzureKeyVaultWithManagedIdentitySimple_WithoutVaultUri_Throws(string vaultUri)


### PR DESCRIPTION
Adds some extra overloads for the Azure Key Vault secret provider in the secret store to authenticate with Managed Identity without a `clientId`.

Closes #230 