### PR TITLE
Feature - support subset of secret providers in secret store

### DIFF
--- a/docs/preview/features/secret-store/named-secret-providers.md
+++ b/docs/preview/features/secret-store/named-secret-providers.md
@@ -7,9 +7,9 @@ layout: default
 
 The default workings of the secret store, is that a set of secret providers are registered and the consumer gets access to all of secrets provided by using `ISecretProvider`.
 
-In some cases, you may want to retrieve a specific secret provider from the store because that secret provider has some functionality that the other providers don't have.
+In some cases, you may want to retrieve a specific secret provider or a subset of secret providers from the store because that secret provider has some functionality that the other providers don't have.
 
-In those cases, you can register your secret provider with a unique name so that, in a later stage, you can retrieve back your named provider.
+In those cases, you can register your secret provider(s) with a name so that, in a later stage, you can retrieve back your named provider(s).
 
 ## Registering a named secret provider
 
@@ -22,8 +22,6 @@ First, the secret provider has to be registered with a unique name.
     stores.AddEnvironmentVariables(..., name: "environment-variables");
 })
 ```
-
-⚠ The name of the registered secret providers should be unique; otherwise, an exception will be thrown when you try to access the `GetProvider` or `GetCachedProvider`.
 
 ## Retrieving a named secret provider
 
@@ -38,18 +36,104 @@ using Arcus.Security.Core.Providers;
 
 namespace Application
 {
-
     [ApiController]
     public class OrderController : ControllerBase
     {
         public class OrderController(ISecretStore secretStore)
         {
              // Gets the `ISecretProvider` with the matched name (with either using the `ISecretProvider` as return type or your own generic type).
+             // ⚠ The name of the registered secret providers should be unique when retrieving the concrete secret provider; 
+             //         otherwise, an exception will be thrown when you try to access the `GetProvider<>` or `GetCachedProvider<>`.
              var secretprovider = secretStore.GetProvider<EnvironmentVariableSecretProvider>("environment-variables");
 
              // Gets the `ICachedSecretProvider` with the matched name (with either using the `ICachedSecretProvider` as return type or your own generic type).
              // Mark that this only works when the secret provider was regisered as a cached secret provider.
              ICachedSecretProvider cachedSecretProvider = secretStore.GetCachedProvider("your-cached-secret-provider");
+        }
+    }
+}
+```
+
+## Retrieving a subset of named secret providers
+
+At some times, you may want to retrieve a subset of secret providers. This is especially useful when you want to control the external secret providers based application-specific settings.
+
+Let's consider this secret store setup:
+
+```csharp
+using Microsoft.Extensions.DependencyInjection;
+
+public static class Program
+{
+    public static void Main(string[] args)
+    {
+        return CreateDefaultBuilder(args).Build().Run();
+    }
+
+    private static IHostBuilder CreateDefaultBuilder(string[] args)
+    {
+        return Host.CreateDefaultBuilder(args)
+                   .ConfigureAppConfiguration(builder => builder.AddCommandLine(args))
+                   .ConfigureSecretStore((config, stores) =>
+                   {
+                        stores.AddEnvironmentVariables();
+
+                        stores.AddAzureKeyVaultWithManagedIdentity("https://admin.vault.azure.net");
+
+                        stores.AddAzureKeyVaultWIthManagedIdentity("https://user.vault.azure.net");
+                   });
+    }
+}
+```
+
+Imagine that you actually want some parts of the application to only have access to the Azure Key Vault `admin` plus the environment variables, and other parts only the Azure Key Vault `user` plus the environment variables.
+This can be used for authorization restrictions, performance-wise to limit the external calls...
+
+This problem can also be fixed by adding the same name to the required subset. Let's use "Admin Secrets" and "User Secrets" as our names:
+
+```csharp
+using Microsoft.Extensions.DependencyInjection;
+
+public static class Program
+{
+    public static void Main(string[] args)
+    {
+        return CreateDefaultBuilder(args).Build().Run();
+    }
+
+    private static IHostBuilder CreateDefaultBuilder(string[] args)
+    {
+        return Host.CreateDefaultBuilder(args)
+                   .ConfigureAppConfiguration(builder => builder.AddCommandLine(args))
+                   .ConfigureSecretStore((config, stores) =>
+                   {
+                        stores.AddEnvironmentVariables(configureOptions: options => options.Name = "Admin Secrets")
+                              .AddAzureKeyVaultWithManagedIdentity("https://admin.vault.azure.net", configureOptions: options => options.Name = "Admin Secrets");
+                        
+                        stores.AddEnvironmentVariables(configureOptions: options => options.Name = "User Secrets")
+                              .AddAzureKeyVaultWIthManagedIdentity("https://user.vault.azure.net", configureOptions: options => options.Name = "User Secrets");
+                   });
+    }
+}
+```
+
+Within the application, you can now use either subset of the secret store by calling the correct configured name:
+
+```csharp
+using Arcus.Security.Core;
+
+namespace Application
+{
+    [ApiController]
+    public class OrderController : ControllerBase
+    {
+        public class OrderController(ISecretStore secretStore)
+        {
+            // Combines the environment variables + Azure Key Vault 'admin'
+            ISecretProvider adminSecretProvider = secretStore.GetProvider("Admin Secrets");
+
+            // Combines the environment variables + Azure Key Vault 'user'
+            ISecretProvider userSecretProvider = secretStore.GetProvider("User Secrets");
         }
     }
 }

--- a/docs/preview/features/secret-store/named-secret-providers.md
+++ b/docs/preview/features/secret-store/named-secret-providers.md
@@ -9,7 +9,7 @@ The default workings of the secret store, is that a set of secret providers are 
 
 In some cases, you may want to retrieve a specific secret provider or a subset of secret providers from the store because that secret provider has some functionality that the other providers don't have.
 
-In those cases, you can register your secret provider(s) with a name so that, in a later stage, you can retrieve back your named provider(s).
+In those cases, you can register your secret provider(s) with a name so that, in a later stage, you can retrieve your named provider(s).
 
 ## Registering a named secret provider
 

--- a/src/Arcus.Security.Core/CompositeSecretProvider.cs
+++ b/src/Arcus.Security.Core/CompositeSecretProvider.cs
@@ -113,7 +113,7 @@ namespace Arcus.Security.Core
                 throw new InvalidOperationException(
                     $"Cannot cast registered {nameof(ISecretProvider)} with name '{name}' to type '{typeof(TSecretProvider).Name}' " +
                     $"because multiple secret providers were registered with the name '{name}', " +
-                    $"use the non-generic '{nameof (GetProvider})' to retrieve them");
+                    $"use the non-generic '{nameof(GetProvider)}' to retrieve them");
             }
 
             throw new InvalidCastException(

--- a/src/Arcus.Security.Core/CompositeSecretProvider.cs
+++ b/src/Arcus.Security.Core/CompositeSecretProvider.cs
@@ -204,7 +204,7 @@ namespace Arcus.Security.Core
             {
                 return subsetSecretStore.Value;
             }
-            
+
             throw new KeyNotFoundException(
                 $"Could not retrieve the named {nameof(ISecretProvider)} because no secret provider was registered with the name '{name}'");
         }

--- a/src/Arcus.Security.Core/CompositeSecretProvider.cs
+++ b/src/Arcus.Security.Core/CompositeSecretProvider.cs
@@ -112,7 +112,8 @@ namespace Arcus.Security.Core
             {
                 throw new InvalidOperationException(
                     $"Cannot cast registered {nameof(ISecretProvider)} with name '{name}' to type '{typeof(TSecretProvider).Name}' " +
-                    $"because multiple secret providers were registered with the name '{name}'");
+                    $"because multiple secret providers were registered with the name '{name}', " +
+                    $"use the non-generic '{nameof (GetProvider})' to retrieve them");
             }
 
             throw new InvalidCastException(
@@ -163,7 +164,8 @@ namespace Arcus.Security.Core
             {
                 throw new InvalidOperationException(
                     $"Cannot cast registered {nameof(ICachedSecretProvider)} with name '{name}' to type '{typeof(TCachedSecretProvider).Name}' " +
-                    $"because multiple secret providers were registered with the name '{name}'");
+                    $"because multiple secret providers were registered with the name '{name}', " +
+                    $"use the non-generic '{nameof(GetCachedProvider)}' to retrieve them");
             }
 
             throw new InvalidCastException(

--- a/src/Arcus.Security.Core/CompositeSecretProvider.cs
+++ b/src/Arcus.Security.Core/CompositeSecretProvider.cs
@@ -20,6 +20,7 @@ namespace Arcus.Security.Core
         private readonly IEnumerable<SecretStoreSource> _secretProviders;
         private readonly IEnumerable<CriticalExceptionFilter> _criticalExceptionFilters;
         private readonly SecretStoreAuditingOptions _auditingOptions;
+        private readonly IDictionary<string, Lazy<ISecretProvider>> _groupedSecretStores;
         private readonly ILogger _logger;
 
         /// <summary>
@@ -47,6 +48,9 @@ namespace Arcus.Security.Core
             _criticalExceptionFilters = criticalExceptionFilters;
             _auditingOptions = auditingOptions;
             _logger = logger ?? NullLogger<CompositeSecretProvider>.Instance;
+
+            _groupedSecretStores = CreateGroupedSecretProviders(secretProviderSources, criticalExceptionFilters, auditingOptions, logger);
+            HasCachedSecretProviders = _secretProviders.Any(provider => provider.CachedSecretProvider != null);
         }
 
         /// <summary>
@@ -64,6 +68,11 @@ namespace Arcus.Security.Core
             : this(secretProviderSources, criticalExceptionFilters, auditingOptions, NullLogger<CompositeSecretProvider>.Instance)
         {
         }
+
+        /// <summary>
+        /// Gets the flag indicating whether or not this secret store has any <see cref="ICachedSecretProvider"/> registrations.
+        /// </summary>
+        private bool HasCachedSecretProviders { get; }
 
         /// <summary>
         /// Gets the cache-configuration for this instance.
@@ -86,11 +95,9 @@ namespace Arcus.Security.Core
         /// <param name="name">The name that was used to register the <see cref="ISecretProvider"/> in the secret store.</param>
         /// <typeparam name="TSecretProvider">The concrete <see cref="ISecretProvider"/> type.</typeparam>
         /// <exception cref="ArgumentException">Thrown when the <paramref name="name"/> is blank.</exception>
-        /// <exception cref="KeyNotFoundException">
-        ///     Thrown when there was no <see cref="ISecretProvider"/> found in the secret store with the given <paramref name="name"/>,
-        ///     or there were multiple <see cref="ISecretProvider"/> instances registered with the same name.
-        /// </exception>
+        /// <exception cref="KeyNotFoundException">Thrown when there was no <see cref="ISecretProvider"/> found in the secret store with the given <paramref name="name"/>.</exception>
         /// <exception cref="InvalidCastException">Thrown when the registered <see cref="ISecretProvider"/> cannot be cast to the specific <typeparamref name="TSecretProvider"/>.</exception>
+        /// <exception cref="InvalidOperationException">Thrown when multiple <see cref="ISecretProvider"/> were registered with the same name.</exception>
         public TSecretProvider GetProvider<TSecretProvider>(string name) where TSecretProvider : ISecretProvider
         {
             Guard.NotNullOrWhitespace(name, nameof(name), "Requires a non-blank name to retrieve the registered named secret provider");
@@ -100,8 +107,16 @@ namespace Arcus.Security.Core
             {
                 return concreteProvider;
             }
+            
+            if (provider is CompositeSecretProvider)
+            {
+                throw new InvalidOperationException(
+                    $"Cannot cast registered {nameof(ISecretProvider)} with name '{name}' to type '{typeof(TSecretProvider).Name}' " +
+                    $"because multiple secret providers were registered with the name '{name}'");
+            }
 
-            throw new InvalidCastException($"Cannot cast registered {nameof(ISecretProvider)} with name '{name}' to type '{typeof(TSecretProvider).Name}'");
+            throw new InvalidCastException(
+                $"Cannot cast registered {nameof(ISecretProvider)} with name '{name}' to type '{typeof(TSecretProvider).Name}'");
         }
 
         /// <summary>
@@ -109,16 +124,13 @@ namespace Arcus.Security.Core
         /// </summary>
         /// <param name="name">The name that was used to register the <see cref="ISecretProvider"/> in the secret store.</param>
         /// <exception cref="ArgumentException">Thrown when the <paramref name="name"/> is blank.</exception>
-        /// <exception cref="KeyNotFoundException">
-        ///     Thrown when there was no <see cref="ISecretProvider"/> found in the secret store with the given <paramref name="name"/>,
-        ///     or there were multiple <see cref="ISecretProvider"/> instances registered with the same name.
-        /// </exception>
+        /// <exception cref="KeyNotFoundException">Thrown when there was no <see cref="ISecretProvider"/> found in the secret store with the given <paramref name="name"/>.</exception>
         public ISecretProvider GetProvider(string name)
         {
             Guard.NotNullOrWhitespace(name, nameof(name), "Requires a non-blank name to retrieve the registered named secret provider");
 
-            SecretStoreSource source = GetSecretSource(name);
-            return source.SecretProvider;
+            ISecretProvider subset = GetSingleOrSubsetSecretProvider(name);
+            return subset;
         }
 
         /// <summary>
@@ -127,15 +139,19 @@ namespace Arcus.Security.Core
         /// <param name="name">The name that was used to register the <see cref="ICachedSecretProvider"/> in the secret store.</param>
         /// <typeparam name="TCachedSecretProvider">The concrete <see cref="ICachedSecretProvider"/> type.</typeparam>
         /// <exception cref="ArgumentException">Thrown when the <paramref name="name"/> is blank.</exception>
-        /// <exception cref="KeyNotFoundException">
-        ///     Thrown when there was no <see cref="ICachedSecretProvider"/> found in the secret store with the given <paramref name="name"/>,
-        ///     or there were multiple <see cref="ICachedSecretProvider"/> instances registered with the same name.
+        /// <exception cref="KeyNotFoundException">Thrown when there was no <see cref="ICachedSecretProvider"/> found in the secret store with the given <paramref name="name"/>.</exception>
+        /// <exception cref="NotSupportedException">
+        ///     Thrown when their was either none of the registered secret providers are registered as <see cref="ICachedSecretProvider"/> instances
+        ///     or there was an <see cref="ISecretProvider"/> registered but not with caching.
         /// </exception>
-        /// <exception cref="NotSupportedException">Thrown when there was an <see cref="ICachedSecretProvider"/> registered but not with caching.</exception>
         /// <exception cref="InvalidCastException">Thrown when the registered <see cref="ICachedSecretProvider"/> cannot be cast to the specific <typeparamref name="TCachedSecretProvider"/>.</exception>
+        /// <exception cref="InvalidOperationException">Thrown when multiple <see cref="ICachedSecretProvider"/> were registered with the same name.</exception>
         public TCachedSecretProvider GetCachedProvider<TCachedSecretProvider>(string name) where TCachedSecretProvider : ICachedSecretProvider
         {
             Guard.NotNullOrWhitespace(name, nameof(name), "Requires a non-blank name to retrieve the registered named secret provider");
+            Guard.For<NotSupportedException>(
+                () => !HasCachedSecretProviders, 
+                $"Cannot use cached secret store operation because none of the secret providers in the secret store were registered as cached secret providers ({nameof(ICachedSecretProvider)})");
 
             ICachedSecretProvider provider = GetCachedProvider(name);
             if (provider is TCachedSecretProvider concreteProvider)
@@ -143,7 +159,15 @@ namespace Arcus.Security.Core
                 return concreteProvider;
             }
 
-            throw new InvalidCastException($"Cannot cast registered {nameof(ICachedSecretProvider)} with name '{name}' to type '{typeof(TCachedSecretProvider).Name}'");
+            if (provider is CompositeSecretProvider)
+            {
+                throw new InvalidOperationException(
+                    $"Cannot cast registered {nameof(ICachedSecretProvider)} with name '{name}' to type '{typeof(TCachedSecretProvider).Name}' " +
+                    $"because multiple secret providers were registered with the name '{name}'");
+            }
+
+            throw new InvalidCastException(
+                $"Cannot cast registered {nameof(ICachedSecretProvider)} with name '{name}' to type '{typeof(TCachedSecretProvider).Name}'");
         }
 
         /// <summary>
@@ -151,46 +175,38 @@ namespace Arcus.Security.Core
         /// </summary>
         /// <param name="name">The name that was used to register the <see cref="ICachedSecretProvider"/> in the secret store.</param>
         /// <exception cref="ArgumentException">Thrown when the <paramref name="name"/> is blank.</exception>
-        /// <exception cref="KeyNotFoundException">
-        ///     Thrown when there was no <see cref="ICachedSecretProvider"/> found in the secret store with the given <paramref name="name"/>,
-        ///     or there were multiple <see cref="ICachedSecretProvider"/> instances registered with the same name.
+        /// <exception cref="KeyNotFoundException">Thrown when there was no <see cref="ICachedSecretProvider"/> found in the secret store with the given <paramref name="name"/>.</exception>
+        /// <exception cref="NotSupportedException">
+        ///     Thrown when their was either none of the registered secret providers are registered as <see cref="ICachedSecretProvider"/> instances
+        ///     or there was an <see cref="ISecretProvider"/> registered but not with caching.
         /// </exception>
-        /// <exception cref="NotSupportedException">Thrown when there was an <see cref="ISecretProvider"/> registered but not with caching.</exception>
         public ICachedSecretProvider GetCachedProvider(string name)
         {
             Guard.NotNullOrWhitespace(name, nameof(name), "Requires a non-blank name to retrieve the registered named secret provider");
-
-            SecretStoreSource source = GetSecretSource(name);
-            if (source.CachedSecretProvider is null)
+            Guard.For<NotSupportedException>(
+                () => !HasCachedSecretProviders, 
+                $"Cannot use cached secret store operation because none of the secret providers in the secret store were registered as cached secret providers ({nameof(ICachedSecretProvider)})");
+            
+            ISecretProvider source = GetSingleOrSubsetSecretProvider(name);
+            if (source is ICachedSecretProvider cachedSource)
             {
-                throw new NotSupportedException(
-                    $"Found a registered {nameof(ISecretProvider)} with the name '{name}' in the secret store, but was not configured for caching. "
-                    + $"Please use the {nameof(GetProvider)} instead or configure the registered provider with caching");
+                return cachedSource;
             }
 
-            return source.CachedSecretProvider;
+            throw new NotSupportedException(
+                $"Found a registered {nameof(ISecretProvider)} with the name '{name}' in the secret store, but was not configured for caching. "
+                + $"Please use the {nameof(GetProvider)} instead or configure the registered provider with caching");
         }
 
-        private SecretStoreSource GetSecretSource(string name)
+        private ISecretProvider GetSingleOrSubsetSecretProvider(string name)
         {
-            IEnumerable<SecretStoreSource> matchingProviders =
-                _secretProviders.Where(provider => provider.Options?.Name == name);
-
-            int count = matchingProviders.Count();
-            if (count is 0)
+            if (_groupedSecretStores.TryGetValue(name, out Lazy<ISecretProvider> subsetSecretStore))
             {
-                throw new KeyNotFoundException(
-                    $"Could not retrieve the named {nameof(ISecretProvider)} because no provider was registered with the name '{name}'");
+                return subsetSecretStore.Value;
             }
-
-            if (count > 1)
-            {
-                throw new KeyNotFoundException(
-                    $"Could not retrieve the named {nameof(ISecretProvider)} because more than one provider was registered with the name '{name}'");
-            }
-
-            SecretStoreSource firstProvider = matchingProviders.First();
-            return firstProvider;
+            
+            throw new KeyNotFoundException(
+                $"Could not retrieve the named {nameof(ISecretProvider)} because no secret provider was registered with the name '{name}'");
         }
 
         /// <summary>
@@ -238,6 +254,7 @@ namespace Arcus.Security.Core
         /// <exception cref="ArgumentException">The name must not be empty</exception>
         /// <exception cref="ArgumentNullException">The name must not be null</exception>
         /// <exception cref="SecretNotFoundException">The secret was not found, using the given name</exception>
+        /// <exception cref="NotSupportedException">Thrown when none of the registered secret providers are registered as <see cref="ICachedSecretProvider"/> instances.</exception>
         public async Task<string> GetRawSecretAsync(string secretName, bool ignoreCache)
         {
             Guard.NotNullOrWhitespace(secretName, nameof(secretName), "Requires a non-blank secret name to look up the secret");
@@ -257,6 +274,7 @@ namespace Arcus.Security.Core
         /// <exception cref="ArgumentException">The name must not be empty</exception>
         /// <exception cref="ArgumentNullException">The name must not be null</exception>
         /// <exception cref="SecretNotFoundException">The secret was not found, using the given name</exception>
+        /// <exception cref="NotSupportedException">Thrown when none of the registered secret providers are registered as <see cref="ICachedSecretProvider"/> instances.</exception>
         public async Task<Secret> GetSecretAsync(string secretName, bool ignoreCache)
         {
             Guard.NotNullOrWhitespace(secretName, nameof(secretName), "Requires a non-blank secret name to look up the secret");
@@ -293,7 +311,11 @@ namespace Arcus.Security.Core
             string secretName,
             Func<SecretStoreSource, Task<T>> callRegisteredProvider) where T : class
         {
-            return await  WithSecretStoreAsync(secretName, async source =>
+            Guard.For<NotSupportedException>(
+                () => !HasCachedSecretProviders, 
+                $"Cannot use cached secret store operation because none of the secret providers in the secret store were registered as cached secret providers ({nameof(ICachedSecretProvider)})");
+
+            return await WithSecretStoreAsync(secretName, async source =>
             {
                 if (source.CachedSecretProvider is null)
                 {
@@ -346,8 +368,9 @@ namespace Arcus.Security.Core
         {
             if (!_secretProviders.Any())
             {
-                _logger.LogError("No secret providers are configured in the secret store to retrieve the secret from, please configure at least one secret provider with the '{Extension}' extension in the startup of your application",
-                                 nameof(IHostBuilderExtensions.ConfigureSecretStore));
+                _logger.LogError(
+                    "No secret providers are configured in the secret store to retrieve the secret from, please configure at least one secret provider with the '{Extension}' extension in the startup of your application",
+                    nameof(IHostBuilderExtensions.ConfigureSecretStore));
 
                 var noRegisteredException = new KeyNotFoundException("No secret providers are configured to retrieve the secret from");
                 throw new SecretNotFoundException(secretName, noRegisteredException);
@@ -413,8 +436,9 @@ namespace Arcus.Security.Core
         {
             if (!criticalExceptions.Any())
             {
-                _logger.LogError("None of the configured {Count} configured secret providers was able to retrieve the requested secret with name '{SecretName}'",
-                                 _secretProviders.Count(), secretName);
+                _logger.LogError(
+                    "None of the configured {Count} configured secret providers was able to retrieve the requested secret with name '{SecretName}'",
+                    _secretProviders.Count(), secretName);
 
                 var noneFoundException = new KeyNotFoundException($"None of the {_secretProviders.Count()} configured secret providers was able to retrieve the requested secret with name '{secretName}'");
                 return new SecretNotFoundException(secretName, noneFoundException);
@@ -428,6 +452,30 @@ namespace Arcus.Security.Core
             return new AggregateException(
                 $"None of the configured secret providers was able to retrieve the secret with name '{secretName}' while {criticalExceptions.Count()} critical exceptions were thrown",
                 criticalExceptions);
+        }
+
+        private static IDictionary<string, Lazy<ISecretProvider>> CreateGroupedSecretProviders(
+            IEnumerable<SecretStoreSource> secretProviders,
+            IEnumerable<CriticalExceptionFilter> criticalExceptionFilters,
+            SecretStoreAuditingOptions auditingOptions,
+            ILogger<CompositeSecretProvider> logger)
+        {
+            return secretProviders
+                   .Where(source => source.Options.Name != null)
+                   .GroupBy(source => source.Options.Name)
+                   .ToDictionary(group => group.Key, group =>
+                   {
+                       return new Lazy<ISecretProvider>(() =>
+                       {
+                           if (group.Count() == 1)
+                           {
+                               SecretStoreSource source = group.First();
+                               return source.CachedSecretProvider ?? source.SecretProvider;
+                           }
+
+                           return new CompositeSecretProvider(group, criticalExceptionFilters, auditingOptions, logger);
+                       });
+                   });
         }
     }
 }

--- a/src/Arcus.Security.Core/ISecretStore.cs
+++ b/src/Arcus.Security.Core/ISecretStore.cs
@@ -48,7 +48,7 @@ namespace Arcus.Security.Core
         /// <exception cref="ArgumentException">Thrown when the <paramref name="name"/> is blank.</exception>
         /// <exception cref="KeyNotFoundException">Thrown when there was no <see cref="ICachedSecretProvider"/> found in the secret store with the given <paramref name="name"/>.</exception>
         /// <exception cref="NotSupportedException">
-        ///     Thrown when their was either none of the registered secret providers are registered as <see cref="ICachedSecretProvider"/> instances
+        ///     Thrown when none of the registered secret providers are registered as <see cref="ICachedSecretProvider"/> instances
         ///     or there was an <see cref="ISecretProvider"/> registered but not with caching.
         /// </exception>
         /// <exception cref="InvalidCastException">Thrown when the registered <see cref="ICachedSecretProvider"/> cannot be cast to the specific <typeparamref name="TCachedSecretProvider"/>.</exception>

--- a/src/Arcus.Security.Core/ISecretStore.cs
+++ b/src/Arcus.Security.Core/ISecretStore.cs
@@ -14,10 +14,7 @@ namespace Arcus.Security.Core
         /// </summary>
         /// <param name="name">The name that was used to register the <see cref="ISecretProvider"/> in the secret store.</param>
         /// <exception cref="ArgumentException">Thrown when the <paramref name="name"/> is blank.</exception>
-        /// <exception cref="KeyNotFoundException">
-        ///     Thrown when there was no <see cref="ISecretProvider"/> found in the secret store with the given <paramref name="name"/>,
-        ///     or there were multiple <see cref="ISecretProvider"/> instances registered with the same name.
-        /// </exception>
+        /// <exception cref="KeyNotFoundException">Thrown when there was no <see cref="ISecretProvider"/> found in the secret store with the given <paramref name="name"/>.</exception>
         ISecretProvider GetProvider(string name);
 
         /// <summary>
@@ -26,11 +23,9 @@ namespace Arcus.Security.Core
         /// <param name="name">The name that was used to register the <see cref="ISecretProvider"/> in the secret store.</param>
         /// <typeparam name="TSecretProvider">The concrete <see cref="ISecretProvider"/> type.</typeparam>
         /// <exception cref="ArgumentException">Thrown when the <paramref name="name"/> is blank.</exception>
-        /// <exception cref="KeyNotFoundException">
-        ///     Thrown when there was no <see cref="ISecretProvider"/> found in the secret store with the given <paramref name="name"/>,
-        ///     or there were multiple <see cref="ISecretProvider"/> instances registered with the same name.
-        /// </exception>
+        /// <exception cref="KeyNotFoundException">Thrown when there was no <see cref="ISecretProvider"/> found in the secret store with the given <paramref name="name"/>.</exception>
         /// <exception cref="InvalidCastException">Thrown when the registered <see cref="ISecretProvider"/> cannot be cast to the specific <typeparamref name="TSecretProvider"/>.</exception>
+        /// <exception cref="InvalidOperationException">Thrown when multiple <see cref="ISecretProvider"/> were registered with the same name.</exception>
         TSecretProvider GetProvider<TSecretProvider>(string name) where TSecretProvider : ISecretProvider;
 
         /// <summary>
@@ -38,11 +33,11 @@ namespace Arcus.Security.Core
         /// </summary>
         /// <param name="name">The name that was used to register the <see cref="ICachedSecretProvider"/> in the secret store.</param>
         /// <exception cref="ArgumentException">Thrown when the <paramref name="name"/> is blank.</exception>
-        /// <exception cref="KeyNotFoundException">
-        ///     Thrown when there was no <see cref="ICachedSecretProvider"/> found in the secret store with the given <paramref name="name"/>,
-        ///     or there were multiple <see cref="ICachedSecretProvider"/> instances registered with the same name.
+        /// <exception cref="KeyNotFoundException">Thrown when there was no <see cref="ICachedSecretProvider"/> found in the secret store with the given <paramref name="name"/>.</exception>
+        /// <exception cref="NotSupportedException">
+        ///     Thrown when their was either none of the registered secret providers are registered as <see cref="ICachedSecretProvider"/> instances
+        ///     or there was an <see cref="ISecretProvider"/> registered but not with caching.
         /// </exception>
-        /// <exception cref="NotSupportedException">Thrown when there was an <see cref="ISecretProvider"/> registered but not with caching.</exception>
         ICachedSecretProvider GetCachedProvider(string name);
 
         /// <summary>
@@ -51,12 +46,13 @@ namespace Arcus.Security.Core
         /// <param name="name">The name that was used to register the <see cref="ICachedSecretProvider"/> in the secret store.</param>
         /// <typeparam name="TCachedSecretProvider">The concrete <see cref="ICachedSecretProvider"/> type.</typeparam>
         /// <exception cref="ArgumentException">Thrown when the <paramref name="name"/> is blank.</exception>
-        /// <exception cref="KeyNotFoundException">
-        ///     Thrown when there was no <see cref="ICachedSecretProvider"/> found in the secret store with the given <paramref name="name"/>,
-        ///     or there were multiple <see cref="ICachedSecretProvider"/> instances registered with the same name.
+        /// <exception cref="KeyNotFoundException">Thrown when there was no <see cref="ICachedSecretProvider"/> found in the secret store with the given <paramref name="name"/>.</exception>
+        /// <exception cref="NotSupportedException">
+        ///     Thrown when their was either none of the registered secret providers are registered as <see cref="ICachedSecretProvider"/> instances
+        ///     or there was an <see cref="ISecretProvider"/> registered but not with caching.
         /// </exception>
-        /// <exception cref="NotSupportedException">Thrown when there was an <see cref="ICachedSecretProvider"/> registered but not with caching.</exception>
         /// <exception cref="InvalidCastException">Thrown when the registered <see cref="ICachedSecretProvider"/> cannot be cast to the specific <typeparamref name="TCachedSecretProvider"/>.</exception>
+        /// <exception cref="InvalidOperationException">Thrown when multiple <see cref="ICachedSecretProvider"/> were registered with the same name.</exception>
         TCachedSecretProvider GetCachedProvider<TCachedSecretProvider>(string name) where TCachedSecretProvider : ICachedSecretProvider;
     }
 }

--- a/src/Arcus.Security.Core/SecretStoreBuilder.cs
+++ b/src/Arcus.Security.Core/SecretStoreBuilder.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
-using System.Linq;
 using Arcus.Security.Core;
 using Arcus.Security.Core.Caching;
 using Arcus.Security.Core.Providers;
@@ -210,8 +209,6 @@ namespace Microsoft.Extensions.Hosting
         /// <exception cref="InvalidOperationException">Thrown when one or more <see cref="ISecretProvider"/> was registered with the same name.</exception>
         internal void RegisterSecretStore()
         {
-            EnsureUniqueSecretProviderNames();
-
             foreach (SecretStoreSource source in SecretStoreSources)
             {
                 if (source is null)
@@ -246,21 +243,6 @@ namespace Microsoft.Extensions.Hosting
             Services.TryAddSingleton<ICachedSecretProvider, CompositeSecretProvider>();
             Services.TryAddSingleton<ISecretProvider>(serviceProvider => serviceProvider.GetRequiredService<ICachedSecretProvider>());
             Services.TryAddSingleton<ISecretStore>(serviceProvider => (CompositeSecretProvider) serviceProvider.GetRequiredService<ICachedSecretProvider>());
-        }
-
-        private void EnsureUniqueSecretProviderNames()
-        {
-            IEnumerable<string> secretProvidersWithDuplicateNames =
-                SecretStoreSources.GroupBy(source => source.Options?.Name)
-                                  .Where(group => @group.Key != null && @group.Count() > 1)
-                                  .Select(group => @group.Key);
-
-            if (secretProvidersWithDuplicateNames.Any())
-            {
-                string duplicateNames = String.Join(", ", secretProvidersWithDuplicateNames);
-                throw new InvalidOperationException(
-                    $"Cannot set up secret store because one or more {nameof(ISecretProvider)} was registered with the same name: {duplicateNames}");
-            }
         }
 
         private static SecretStoreSource CreateMutatedSecretSource(

--- a/src/Arcus.Security.Tests.Unit/Core/Extensions/IServiceCollectionExtensionsTests.cs
+++ b/src/Arcus.Security.Tests.Unit/Core/Extensions/IServiceCollectionExtensionsTests.cs
@@ -174,7 +174,7 @@ namespace Arcus.Security.Tests.Unit.Core.Extensions
             // Assert
             IServiceProvider serviceProvider = services.BuildServiceProvider();
             var provider = serviceProvider.GetRequiredService<ICachedSecretProvider>();
-            await Assert.ThrowsAsync<SecretNotFoundException>(() => provider.InvalidateSecretAsync(secretKey));
+            await Assert.ThrowsAsync<NotSupportedException>(() => provider.InvalidateSecretAsync(secretKey));
         }
 
         [Fact]


### PR DESCRIPTION
Add support for registering multiple `ISecretProvider` implementations with the same name so they are combined in a subset upon retrieval.

Closes #237