### PR TITLE
🚧 Feature - use default `CacheConfiguration` instead of `allowCaching`

### DIFF
--- a/docs/preview/features/secret-store/provider/key-vault.md
+++ b/docs/preview/features/secret-store/provider/key-vault.md
@@ -17,6 +17,7 @@ PM > Install-Package Arcus.Security.Providers.AzureKeyVault
 After installing the package, the addtional extensions becomes available when building the secret store.
 
 ```csharp
+using Arcus.Security.Core.Caching.Configuration;
 using Microsoft.Extensions.Hosting;
 
 public class Program
@@ -48,7 +49,7 @@ public class Program
                         builder.AddAzureKeyVault(vaultAuthentication, vaultConfiguration);
 
                         // Adding a default cached variant of the Azure Key Vault provider (default: 5 min caching).
-                        builder.AddAzureKeyVaultWithManagedIdentity(keyVaultUri, allowCaching: true);
+                        builder.AddAzureKeyVaultWithManagedIdentity(keyVaultUri, cacheConfiguration: CacheConfiguration.Default);
 
                         // Assing a configurable cached variant of the Azure Key Vault provider.
                         var cacheConfiguration = new CacheConfiguration(TimeSpan.FromMinutes(1));

--- a/src/Arcus.Security.Core/Caching/CachedSecretProvider.cs
+++ b/src/Arcus.Security.Core/Caching/CachedSecretProvider.cs
@@ -52,7 +52,7 @@ namespace Arcus.Security.Core.Caching
         /// Creating a new CachedSecretProvider with a standard generated MemoryCache and default TimeSpan of 5 minutes
         /// </summary>
         public CachedSecretProvider(ISecretProvider secretProvider) :
-            this(secretProvider, new CacheConfiguration(), new MemoryCache(new MemoryCacheOptions()))
+            this(secretProvider, CacheConfiguration.Default, new MemoryCache(new MemoryCacheOptions()))
         {
         }
 

--- a/src/Arcus.Security.Core/Caching/Configuration/CacheConfiguration.cs
+++ b/src/Arcus.Security.Core/Caching/Configuration/CacheConfiguration.cs
@@ -9,28 +9,32 @@ namespace Arcus.Security.Core.Caching.Configuration
     public class CacheConfiguration : ICacheConfiguration
     {
         /// <summary>
-        ///     Duration for which an entry should be cached
+        /// Initializes a new instance of the <see cref="CacheConfiguration"/> class with default cache entry of 5 minutes.
         /// </summary>
-        public TimeSpan Duration { get; }
+        public CacheConfiguration() : this(TimeSpan.FromMinutes(5))
+        {
+        }
 
         /// <summary>
-        ///     Constructor
+        /// Initializes a new instance of the <see cref="CacheConfiguration"/> class.
         /// </summary>
-        /// <param name="duration">Duration for which an entry should be cached</param>
-        /// <exception cref="ArgumentException">Exception thrown when default timespan is specified as cache duration</exception>
+        /// <param name="duration">The duration for which an entry should be cached.</param>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown when the <paramref name="duration"/> is outside the bounds of a valid cache duration.</exception>
         public CacheConfiguration(TimeSpan duration)
         {
-            Guard.For<ArgumentException>(() => duration <= default(TimeSpan), "Caching duration should be a positive interval");
+            Guard.For<ArgumentOutOfRangeException>(() => duration <= default(TimeSpan), "Requires a caching duration of a positive time interval");
 
             Duration = duration;
         }
 
         /// <summary>
-        ///     Constructor with default cache entry of 5 minutes
+        /// Gets the default <see cref="ICacheConfiguration"/> that takes in 5 minutes as default cache duration.
         /// </summary>
-        public CacheConfiguration()
-        {
-            Duration = TimeSpan.FromMinutes(5);
-        }
+        public static ICacheConfiguration Default { get; } = new CacheConfiguration();
+
+        /// <summary>
+        /// Gets the duration for which an entry should be cached.
+        /// </summary>
+        public TimeSpan Duration { get; }
     }
 }

--- a/src/Arcus.Security.Core/Caching/Configuration/ICacheConfiguration.cs
+++ b/src/Arcus.Security.Core/Caching/Configuration/ICacheConfiguration.cs
@@ -8,7 +8,7 @@ namespace Arcus.Security.Core.Caching.Configuration
     public interface ICacheConfiguration
     {
         /// <summary>
-        ///     Duration for which an entry should be cached
+        /// Gets the duration for which an entry should be cached.
         /// </summary>
         TimeSpan Duration { get; }
     }

--- a/src/Arcus.Security.Core/Caching/SecretProviderCachingExtensions.cs
+++ b/src/Arcus.Security.Core/Caching/SecretProviderCachingExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using Arcus.Security.Core.Caching.Configuration;
+using GuardNet;
 using Microsoft.Extensions.Caching.Memory;
 
 namespace Arcus.Security.Core.Caching
@@ -23,8 +24,14 @@ namespace Arcus.Security.Core.Caching
         ///     <see cref="MemoryCache" /> instance
         /// </param>
         /// <returns>A secret provider that caches values</returns>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="secretProvider"/> or <paramref name="memoryCache"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown when the <paramref name="cachingDuration"/> is outside the bounds of a valid cache duration.</exception>
         public static ICachedSecretProvider WithCaching(this ISecretProvider secretProvider, TimeSpan cachingDuration, IMemoryCache memoryCache)
         {
+            Guard.NotNull(secretProvider, nameof(secretProvider), "Requires a secret provider to create a cached version");
+            Guard.For<ArgumentOutOfRangeException>(() => cachingDuration <= default(TimeSpan), "Requires a caching duration of a positive time interval");
+            Guard.NotNull(memoryCache, nameof(memoryCache), "Requires a memory cache to store the cached results");
+            
             return new CachedSecretProvider(secretProvider, new CacheConfiguration(cachingDuration), memoryCache);
         }
 
@@ -38,8 +45,13 @@ namespace Arcus.Security.Core.Caching
         /// </param>
         /// <param name="cachingDuration">The duration to cache secrets in memory</param>
         /// <returns>A secret provider that caches values</returns>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="secretProvider"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown when the <paramref name="cachingDuration"/> is outside the bounds of a valid cache duration.</exception>
         public static ICachedSecretProvider WithCaching(this ISecretProvider secretProvider, TimeSpan cachingDuration)
         {
+            Guard.NotNull(secretProvider, nameof(secretProvider), "Requires a secret provider to create a cached version");
+            Guard.For<ArgumentOutOfRangeException>(() => cachingDuration <= default(TimeSpan), "Requires a caching duration of a positive time interval");
+
             return new CachedSecretProvider(secretProvider, new CacheConfiguration(cachingDuration));
         }
 
@@ -52,8 +64,11 @@ namespace Arcus.Security.Core.Caching
         ///     not cached
         /// </param>
         /// <returns>A secret provider that caches values</returns>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="secretProvider"/> is <c>null</c>.</exception>
         public static ICachedSecretProvider WithCaching(this ISecretProvider secretProvider)
         {
+            Guard.NotNull(secretProvider, nameof(secretProvider), "Requires a secret provider to create a cached version");
+
             return new CachedSecretProvider(secretProvider);
         }
     }

--- a/src/Arcus.Security.Providers.AzureKeyVault/Extensions/SecretStoreBuilderExtensions.cs
+++ b/src/Arcus.Security.Providers.AzureKeyVault/Extensions/SecretStoreBuilderExtensions.cs
@@ -2,8 +2,6 @@
 using System.Net;
 using System.Security.Authentication;
 using System.Security.Cryptography.X509Certificates;
-using Arcus.Security.Core;
-using Arcus.Security.Core.Caching;
 using Arcus.Security.Core.Caching.Configuration;
 using Arcus.Security.Providers.AzureKeyVault;
 using Arcus.Security.Providers.AzureKeyVault.Authentication;
@@ -102,6 +100,7 @@ namespace Microsoft.Extensions.Hosting
         /// <param name="allowCaching">The flag to indicate whether to include caching during secret retrieval in Azure key vault.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="builder"/> or <paramref name="certificate"/> is <c>null</c>.</exception>
         /// <exception cref="ArgumentException">Thrown when the <paramref name="rawVaultUri"/> or <paramref name="clientId"/> is blank.</exception>
+        [Obsolete("Use the " + nameof(AddAzureKeyVaultWithCertificate) + " method overload with " + nameof(CacheConfiguration.Default) + " instead to allow default caching")]
         public static SecretStoreBuilder AddAzureKeyVaultWithCertificate(
             this SecretStoreBuilder builder,
             string rawVaultUri,
@@ -142,6 +141,7 @@ namespace Microsoft.Extensions.Hosting
         /// <param name="mutateSecretName">The optional function to mutate the secret name before looking it up.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="builder"/> or <paramref name="certificate"/> is <c>null</c>.</exception>
         /// <exception cref="ArgumentException">Thrown when the <paramref name="rawVaultUri"/> or <paramref name="clientId"/> is blank.</exception>
+        [Obsolete("Use the " + nameof(AddAzureKeyVaultWithCertificate) + " method overload with " + nameof(CacheConfiguration.Default) + " instead to allow default caching")]
         public static SecretStoreBuilder AddAzureKeyVaultWithCertificate(
             this SecretStoreBuilder builder,
             string rawVaultUri,
@@ -242,7 +242,7 @@ namespace Microsoft.Extensions.Hosting
         /// <param name="tenantId">The Azure Active Directory tenant (directory) ID of the client or application.</param>
         /// <param name="clientId">The identifier of the application requesting the authentication token.</param>
         /// <param name="certificate">The certificate that is used as credential.</param>
-        /// <param name="cacheConfiguration">The configuration to control how the caching will be done.</param>
+        /// <param name="cacheConfiguration">The configuration to control how the caching will be done, use the <see cref="CacheConfiguration.Default"/> for default caching.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="builder"/> or <paramref name="certificate"/> is <c>null</c>.</exception>
         /// <exception cref="ArgumentException">Thrown when the <paramref name="rawVaultUri"/> or <paramref name="clientId"/> is blank.</exception>
         public static SecretStoreBuilder AddAzureKeyVaultWithCertificate(
@@ -279,7 +279,7 @@ namespace Microsoft.Extensions.Hosting
         /// <param name="tenantId">The Azure Active Directory tenant (directory) ID of the client or application.</param>
         /// <param name="clientId">The identifier of the application requesting the authentication token.</param>
         /// <param name="certificate">The certificate that is used as credential.</param>
-        /// <param name="cacheConfiguration">The configuration to control how the caching will be done.</param>
+        /// <param name="cacheConfiguration">The configuration to control how the caching will be done, use the <see cref="CacheConfiguration.Default"/> for default caching.</param>
         /// <param name="configureOptions">The optional additional options to configure the Azure Key Vault secret source.</param>
         /// <param name="name">The unique name to register this Azure Key Vault provider in the secret store.</param>
         /// <param name="mutateSecretName">The optional function to mutate the secret name before looking it up.</param>
@@ -382,6 +382,7 @@ namespace Microsoft.Extensions.Hosting
         /// <param name="allowCaching">The flag to indicate whether to include caching during secret retrieval in Azure key vault.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="builder"/> is <c>null</c>.</exception>
         /// <exception cref="ArgumentException">Thrown when the <paramref name="rawVaultUri"/> is blank.</exception>
+        [Obsolete("Use the " + nameof(AddAzureKeyVaultWithManagedIdentity) + " method overload with " + nameof(CacheConfiguration.Default) + " instead to allow default caching")]
         public static SecretStoreBuilder AddAzureKeyVaultWithManagedIdentity(
             this SecretStoreBuilder builder,
             string rawVaultUri,
@@ -404,6 +405,7 @@ namespace Microsoft.Extensions.Hosting
         /// <param name="allowCaching">The flag to indicate whether to include caching during secret retrieval in Azure key vault.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="builder"/> is <c>null</c>.</exception>
         /// <exception cref="ArgumentException">Thrown when the <paramref name="rawVaultUri"/> is blank.</exception>
+        [Obsolete("Use the " + nameof(AddAzureKeyVaultWithManagedIdentity) + " method overload with " + nameof(CacheConfiguration.Default) + " instead to allow default caching")]
         public static SecretStoreBuilder AddAzureKeyVaultWithManagedIdentity(
             this SecretStoreBuilder builder,
             string rawVaultUri,
@@ -434,6 +436,7 @@ namespace Microsoft.Extensions.Hosting
         /// <param name="mutateSecretName">The optional function to mutate the secret name before looking it up.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="builder"/> is <c>null</c>.</exception>
         /// <exception cref="ArgumentException">Thrown when the <paramref name="rawVaultUri"/> is blank.</exception>
+        [Obsolete("Use the " + nameof(AddAzureKeyVaultWithManagedIdentity) + " method overload with " + nameof(CacheConfiguration.Default) + " instead to allow default caching")]
         public static SecretStoreBuilder AddAzureKeyVaultWithManagedIdentity(
             this SecretStoreBuilder builder,
             string rawVaultUri,
@@ -469,6 +472,7 @@ namespace Microsoft.Extensions.Hosting
         /// <param name="mutateSecretName">The optional function to mutate the secret name before looking it up.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="builder"/> is <c>null</c>.</exception>
         /// <exception cref="ArgumentException">Thrown when the <paramref name="rawVaultUri"/> is blank.</exception>
+        [Obsolete("Use the " + nameof(AddAzureKeyVaultWithManagedIdentity) + " method overload with " + nameof(CacheConfiguration.Default) + " instead to allow default caching")]
         public static SecretStoreBuilder AddAzureKeyVaultWithManagedIdentity(
             this SecretStoreBuilder builder,
             string rawVaultUri,
@@ -520,7 +524,7 @@ namespace Microsoft.Extensions.Hosting
         /// </summary>
         /// <param name="builder">The builder to create the secret store.</param>
         /// <param name="rawVaultUri">The Uri of the Azure Key Vault you want to connect to.</param>
-        /// <param name="cacheConfiguration">The configuration to control how the caching will be done.</param>
+        /// <param name="cacheConfiguration">The configuration to control how the caching will be done, use the <see cref="CacheConfiguration.Default"/> for default caching.</param>
         /// <param name="connectionString">The connection string to use to authenticate, if applicable.</param>
         /// <param name="azureADInstance">The azure AD instance to use to authenticate, if applicable.</param>
         /// <param name="mutateSecretName">The optional function to mutate the secret name before looking it up.</param>
@@ -558,7 +562,7 @@ namespace Microsoft.Extensions.Hosting
         /// </summary>
         /// <param name="builder">The builder to create the secret store.</param>
         /// <param name="rawVaultUri">The Uri of the Azure Key Vault you want to connect to.</param>
-        /// <param name="cacheConfiguration">The configuration to control how the caching will be done.</param>
+        /// <param name="cacheConfiguration">The configuration to control how the caching will be done, use the <see cref="CacheConfiguration.Default"/> for default caching.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="builder"/> is <c>null</c>.</exception>
         /// <exception cref="ArgumentException">Thrown when the <paramref name="rawVaultUri"/> is blank.</exception>
         public static SecretStoreBuilder AddAzureKeyVaultWithManagedIdentity(
@@ -584,7 +588,7 @@ namespace Microsoft.Extensions.Hosting
         /// <param name="clientId">
         ///     The optional client id to authenticate for a user assigned managed identity.
         ///     More information on user assigned managed identities can be found here: https://docs.microsoft.com/en-us/azure/active-directory/managed-identities-azure-resources/overview#how-a-user-assigned-managed-identity-works-with-an-azure-vm</param>
-        /// <param name="cacheConfiguration">The configuration to control how the caching will be done.</param>
+        /// <param name="cacheConfiguration">The configuration to control how the caching will be done, use the <see cref="CacheConfiguration.Default"/> for default caching.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="builder"/> is <c>null</c>.</exception>
         /// <exception cref="ArgumentException">Thrown when the <paramref name="rawVaultUri"/> is blank.</exception>
         public static SecretStoreBuilder AddAzureKeyVaultWithManagedIdentity(
@@ -611,7 +615,7 @@ namespace Microsoft.Extensions.Hosting
         /// </summary>
         /// <param name="builder">The builder to create the secret store.</param>
         /// <param name="rawVaultUri">The Uri of the Azure Key Vault you want to connect to.</param>
-        /// <param name="cacheConfiguration">The configuration to control how the caching will be done.</param>
+        /// <param name="cacheConfiguration">The configuration to control how the caching will be done, use the <see cref="CacheConfiguration.Default"/> for default caching.</param>
         /// <param name="configureOptions">The optional additional options to configure the Azure Key Vault secret source.</param>
         /// <param name="name">The unique name to register this Azure Key Vault provider in the secret store.</param>
         /// <param name="mutateSecretName">The optional function to mutate the secret name before looking it up.</param>
@@ -646,7 +650,7 @@ namespace Microsoft.Extensions.Hosting
         /// <param name="clientId">
         ///     The optional client id to authenticate for a user assigned managed identity.
         ///     More information on user assigned managed identities can be found here: https://docs.microsoft.com/en-us/azure/active-directory/managed-identities-azure-resources/overview#how-a-user-assigned-managed-identity-works-with-an-azure-vm</param>
-        /// <param name="cacheConfiguration">The configuration to control how the caching will be done.</param>
+        /// <param name="cacheConfiguration">The configuration to control how the caching will be done, use the <see cref="CacheConfiguration.Default"/> for default caching.</param>
         /// <param name="configureOptions">The optional additional options to configure the Azure Key Vault secret source.</param>
         /// <param name="name">The unique name to register this Azure Key Vault provider in the secret store.</param>
         /// <param name="mutateSecretName">The optional function to mutate the secret name before looking it up.</param>
@@ -751,6 +755,7 @@ namespace Microsoft.Extensions.Hosting
         /// <param name="allowCaching">The flag to indicate whether to include caching during secret retrieval in Azure key vault.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="builder"/> is <c>null</c>.</exception>
         /// <exception cref="ArgumentException">Thrown when the <paramref name="rawVaultUri"/>, <paramref name="clientId"/>, or <paramref name="clientKey"/> is blank.</exception>
+        [Obsolete("Use the " + nameof(AddAzureKeyVaultWithServicePrincipal) + " method overload with " + nameof(CacheConfiguration.Default) + " instead to allow default caching")]
         public static SecretStoreBuilder AddAzureKeyVaultWithServicePrincipal(
             this SecretStoreBuilder builder,
             string rawVaultUri,
@@ -791,6 +796,7 @@ namespace Microsoft.Extensions.Hosting
         /// <param name="mutateSecretName">The optional function to mutate the secret name before looking it up.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="builder"/> is <c>null</c>.</exception>
         /// <exception cref="ArgumentException">Thrown when the <paramref name="rawVaultUri"/>, <paramref name="clientId"/>, or <paramref name="clientKey"/> is blank.</exception>
+        [Obsolete("Use the " + nameof(AddAzureKeyVaultWithServicePrincipal) + " method overload with " + nameof(CacheConfiguration.Default) + " instead to allow default caching")]
         public static SecretStoreBuilder AddAzureKeyVaultWithServicePrincipal(
             this SecretStoreBuilder builder,
             string rawVaultUri,
@@ -892,7 +898,7 @@ namespace Microsoft.Extensions.Hosting
         /// <param name="tenantId">The Azure Active Directory tenant (directory) Id of the service principal.</param>
         /// <param name="clientId">The ClientId of the service principal, used to connect to Azure Key Vault</param>
         /// <param name="clientKey">The Secret ClientKey of the service principal, used to connect to Azure Key Vault</param>
-        /// <param name="cacheConfiguration">The configuration to control how the caching will be done.</param>
+        /// <param name="cacheConfiguration">The configuration to control how the caching will be done, use the <see cref="CacheConfiguration.Default"/> for default caching.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="builder"/> is <c>null</c>.</exception>
         /// <exception cref="ArgumentException">Thrown when the <paramref name="rawVaultUri"/>, <paramref name="clientId"/>, or <paramref name="clientKey"/> is blank.</exception>
         public static SecretStoreBuilder AddAzureKeyVaultWithServicePrincipal(
@@ -929,7 +935,7 @@ namespace Microsoft.Extensions.Hosting
         /// <param name="tenantId">The Azure Active Directory tenant (directory) Id of the service principal.</param>
         /// <param name="clientId">The ClientId of the service principal, used to connect to Azure Key Vault</param>
         /// <param name="clientKey">The Secret ClientKey of the service principal, used to connect to Azure Key Vault</param>
-        /// <param name="cacheConfiguration">The configuration to control how the caching will be done.</param>
+        /// <param name="cacheConfiguration">The configuration to control how the caching will be done, use the <see cref="CacheConfiguration.Default"/> for default caching.</param>
         /// <param name="configureOptions">The optional additional options to configure the Azure Key Vault secret source.</param>
         /// <param name="name">The unique name to register this Azure Key Vault provider in the secret store.</param>
         /// <param name="mutateSecretName">The optional function to mutate the secret name before looking it up.</param>
@@ -1066,7 +1072,7 @@ namespace Microsoft.Extensions.Hosting
             Func<string, string> mutateSecretName = null,
             Action<KeyVaultOptions> configureOptions = null)
         {
-            ICacheConfiguration cacheConfiguration = allowCaching ? new CacheConfiguration() : null;
+            ICacheConfiguration cacheConfiguration = allowCaching ? CacheConfiguration.Default : null;
             return AddAzureKeyVault(builder, createAuthentication, configuration, cacheConfiguration, mutateSecretName, configureOptions);
         }
 
@@ -1119,6 +1125,7 @@ namespace Microsoft.Extensions.Hosting
         /// <param name="configuration">The configuration related to the Azure Key Vault instance to use.</param>
         /// <param name="allowCaching">The flag to indicate whether to include caching during secret retrieval in Azure key vault.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="builder"/>, <paramref name="tokenCredential"/>, or <paramref name="configuration"/> is <c>null</c>.</exception>
+        [Obsolete("Use the " + nameof(AddAzureKeyVault) + " method overload with " + nameof(CacheConfiguration.Default) + " instead to allow default caching")]
         public static SecretStoreBuilder AddAzureKeyVault(
             this SecretStoreBuilder builder,
             TokenCredential tokenCredential,
@@ -1150,6 +1157,7 @@ namespace Microsoft.Extensions.Hosting
         /// <param name="name">The unique name to register this Azure Key Vault provider in the secret store.</param>
         /// <param name="mutateSecretName">The optional function to mutate the secret name before looking it up.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="builder"/>, <paramref name="tokenCredential"/>, or <paramref name="configuration"/> is <c>null</c>.</exception>
+        [Obsolete("Use the " + nameof(AddAzureKeyVault) + " method overload with " + nameof(CacheConfiguration.Default) + " instead to allow default caching")]
         public static SecretStoreBuilder AddAzureKeyVault(
             this SecretStoreBuilder builder,
             TokenCredential tokenCredential,
@@ -1163,7 +1171,7 @@ namespace Microsoft.Extensions.Hosting
             Guard.NotNull(tokenCredential, nameof(tokenCredential), "Requires an Azure Key Vault authentication instance to add the secret provider to the secret store");
             Guard.NotNull(configuration, nameof(configuration), "Requires an Azure Key Vault configuration instance to add the secret provider to the secret store");
 
-            ICacheConfiguration cacheConfiguration = allowCaching ? new CacheConfiguration() : null;
+            ICacheConfiguration cacheConfiguration = allowCaching ? CacheConfiguration.Default : null;
             return AddAzureKeyVault(builder, tokenCredential, configuration, cacheConfiguration, configureOptions, name, mutateSecretName);
         }
 
@@ -1173,7 +1181,7 @@ namespace Microsoft.Extensions.Hosting
         /// <param name="builder">The builder to create the secret store.</param>
         /// <param name="tokenCredential">The requested authentication type for connecting to the Azure Key Vault instance.</param>
         /// <param name="configuration">The configuration related to the Azure Key Vault instance to use.</param>
-        /// <param name="cacheConfiguration">The configuration to control how the caching will be done.</param>
+        /// <param name="cacheConfiguration">The configuration to control how the caching will be done, use the <see cref="CacheConfiguration.Default"/> for default caching.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="builder"/>, <paramref name="tokenCredential"/>, or <paramref name="configuration"/> is <c>null</c>.</exception>
         public static SecretStoreBuilder AddAzureKeyVault(
             this SecretStoreBuilder builder,
@@ -1201,7 +1209,7 @@ namespace Microsoft.Extensions.Hosting
         /// <param name="builder">The builder to create the secret store.</param>
         /// <param name="tokenCredential">The requested authentication type for connecting to the Azure Key Vault instance.</param>
         /// <param name="configuration">The configuration related to the Azure Key Vault instance to use.</param>
-        /// <param name="cacheConfiguration">The configuration to control how the caching will be done.</param>
+        /// <param name="cacheConfiguration">The configuration to control how the caching will be done, use the <see cref="CacheConfiguration.Default"/> for default caching.</param>
         /// <param name="configureOptions">The optional additional options to configure the Azure Key Vault secret source.</param>
         /// <param name="name">The unique name to register this Azure Key Vault provider in the secret store.</param>
         /// <param name="mutateSecretName">The optional function to mutate the secret name before looking it up.</param>


### PR DESCRIPTION
Use the `CacheConfiguration.Default` instead of `allowCaching` in the secret store overloads to add Azure Key Vault as a secret provider to the secret store.

Closes #239 