### PR TITLE
Fix - use Microsoft.Extensions.* 3.1.8 packages for UserSecrets

### DIFF
--- a/src/Arcus.Security.Providers.UserSecrets/Arcus.Security.Providers.UserSecrets.csproj
+++ b/src/Arcus.Security.Providers.UserSecrets/Arcus.Security.Providers.UserSecrets.csproj
@@ -18,11 +18,7 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
-    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="2.2.8" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' != 'netstandard2.0'">
+  <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="3.1.8" />
   </ItemGroup>
 


### PR DESCRIPTION
Was a project that still was using the 'old' packages for .NET Core 2.2 support. Updated so it's the same as the other projects in this solution.