### PR TITLE
Fix - check raw secret result before passing allong in environment variable secret provider

### DIFF
--- a/src/Arcus.Security.Core/Providers/EnvironmentVariableSecretProvider.cs
+++ b/src/Arcus.Security.Core/Providers/EnvironmentVariableSecretProvider.cs
@@ -42,6 +42,11 @@ namespace Arcus.Security.Core.Providers
             Guard.NotNullOrWhitespace(secretName, nameof(secretName), "Requires a non-blank secret name to look up the environment secret");
             
             string secretValue = await GetRawSecretAsync(secretName);
+            if (secretValue is null)
+            {
+                return null;
+            }
+
             return new Secret(secretValue);
         }
 

--- a/src/Arcus.Security.Tests.Unit/Core/EnvironmentVariableSecretProviderTests.cs
+++ b/src/Arcus.Security.Tests.Unit/Core/EnvironmentVariableSecretProviderTests.cs
@@ -281,6 +281,19 @@ namespace Arcus.Security.Tests.Unit.Core
             Assert.ThrowsAny<ArgumentException>(() => builder.Build());
         }
 
+        [Fact]
+        public async Task GetSecret_WithoutSecretResult_ReturnsNull()
+        {
+            // Arrange
+            var provider = new EnvironmentVariableSecretProvider();
+            
+            // Act
+            Secret result = await provider.GetSecretAsync($"random-not-found-secret-{Guid.NewGuid()}");
+            
+            // Assert
+            Assert.Null(result);
+        }
+
         [Theory]
         [InlineData(null)]
         [InlineData("")]


### PR DESCRIPTION
The `EnvironmentVariableSecretProvider` didn't take into account that the delegated `.GetRawSecretAsync` could return `null`. The secret store itself was handling such an exception (it was an `ArgumentException`) but this was not a correct implementation.