### PR TITLE
fix: use verbose logging in secret store

### DIFF
--- a/src/Arcus.Security.Core/CompositeSecretProvider.cs
+++ b/src/Arcus.Security.Core/CompositeSecretProvider.cs
@@ -420,7 +420,7 @@ namespace Arcus.Security.Core
                 }
             }
 
-            _logger.LogInformation("Found secret with name '{SecretName}'", secretName);
+            _logger.LogTrace("Found secret with name '{SecretName}'", secretName);
         }
 
         private bool IsCriticalException(Exception exceptionCandidate)

--- a/src/Arcus.Security.Core/Providers/MutatedSecretNameSecretProvider.cs
+++ b/src/Arcus.Security.Core/Providers/MutatedSecretNameSecretProvider.cs
@@ -147,7 +147,7 @@ namespace Arcus.Security.Core.Providers
             {
                 Logger.LogTrace("Start mutating secret name '{SecretName}'...", secretName);
                 string mutateSecretName = _mutateSecretName(secretName);
-                Logger.LogInformation("Secret name '{OriginalSecretName}' mutated to '{MutatedSecretName}'", secretName, mutateSecretName);
+                Logger.LogTrace("Secret name '{OriginalSecretName}' mutated to '{MutatedSecretName}'", secretName, mutateSecretName);
 
                 return mutateSecretName;
             }

--- a/src/Arcus.Security.Providers.AzureKeyVault/Authentication/CertificateBasedAuthentication.cs
+++ b/src/Arcus.Security.Providers.AzureKeyVault/Authentication/CertificateBasedAuthentication.cs
@@ -59,7 +59,7 @@ namespace Arcus.Security.Providers.AzureKeyVault.Authentication
         {
             _logger.LogTrace("Start authenticating with certificate to the Azure Key Vault...");
             IKeyVaultClient client = new KeyVaultClient(AuthenticationCallbackAsync);
-            _logger.LogInformation("Authenticated with certificate to the Azure Key Vault");
+            _logger.LogTrace("Authenticated with certificate to the Azure Key Vault");
 
             return Task.FromResult(client);
         }

--- a/src/Arcus.Security.Providers.AzureKeyVault/Authentication/ManagedServiceIdentityAuthentication.cs
+++ b/src/Arcus.Security.Providers.AzureKeyVault/Authentication/ManagedServiceIdentityAuthentication.cs
@@ -59,7 +59,7 @@ namespace Arcus.Security.Providers.AzureKeyVault.Authentication
         {
             _logger.LogTrace("Start authenticating with managed service identity to the Azure Key Vault...");
             IKeyVaultClient keyVaultClient = AuthenticateClient();
-            _logger.LogInformation("Authenticated with managed service identity to the Azure Key Vault");
+            _logger.LogTrace("Authenticated with managed service identity to the Azure Key Vault");
 
             return Task.FromResult(keyVaultClient);
         }

--- a/src/Arcus.Security.Providers.AzureKeyVault/Authentication/ServicePrincipalAuthentication.cs
+++ b/src/Arcus.Security.Providers.AzureKeyVault/Authentication/ServicePrincipalAuthentication.cs
@@ -59,7 +59,7 @@ namespace Arcus.Security.Providers.AzureKeyVault.Authentication
         {
             _logger.LogTrace("Start authenticating with service principal to Azure Key Vault...");
             IKeyVaultClient keyVaultClient = new KeyVaultClient(GetTokenAsync);
-            _logger.LogInformation("Authenticated with service principal to Azure Key Vault");
+            _logger.LogTrace("Authenticated with service principal to Azure Key Vault");
 
             return Task.FromResult(keyVaultClient);
         }

--- a/src/Arcus.Security.Providers.AzureKeyVault/Extensions/SecretStoreBuilderExtensions.cs
+++ b/src/Arcus.Security.Providers.AzureKeyVault/Extensions/SecretStoreBuilderExtensions.cs
@@ -377,8 +377,6 @@ namespace Microsoft.Extensions.Hosting
         /// </summary>
         /// <param name="builder">The builder to create the secret store.</param>
         /// <param name="rawVaultUri">The Uri of the Azure Key Vault you want to connect to.</param>
-        ///     The optional client id to authenticate for a user assigned managed identity.
-        ///     More information on user assigned managed identities can be found here: https://docs.microsoft.com/en-us/azure/active-directory/managed-identities-azure-resources/overview#how-a-user-assigned-managed-identity-works-with-an-azure-vm</param>
         /// <param name="allowCaching">The flag to indicate whether to include caching during secret retrieval in Azure key vault.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="builder"/> is <c>null</c>.</exception>
         /// <exception cref="ArgumentException">Thrown when the <paramref name="rawVaultUri"/> is blank.</exception>

--- a/src/Arcus.Security.Providers.AzureKeyVault/KeyVaultSecretProvider.cs
+++ b/src/Arcus.Security.Providers.AzureKeyVault/KeyVaultSecretProvider.cs
@@ -50,7 +50,9 @@ namespace Arcus.Security.Providers.AzureKeyVault
         /// </summary>
         protected readonly Regex SecretNameRegex = new Regex(SecretNamePattern, RegexOptions.Compiled);
 
+#pragma warning disable 618
         private readonly IKeyVaultAuthentication _authentication;
+#pragma warning restore 618
         private readonly SecretClient _secretClient;
         private readonly KeyVaultOptions _options;
         private readonly bool _isUsingAzureSdk;
@@ -66,7 +68,7 @@ namespace Arcus.Security.Providers.AzureKeyVault
         /// <param name="vaultConfiguration">Configuration related to the Azure Key Vault instance to use</param>
         /// <exception cref="ArgumentNullException">The <paramref name="authentication"/> cannot be <c>null</c>.</exception>
         /// <exception cref="ArgumentNullException">The <paramref name="vaultConfiguration"/> cannot be <c>null</c>.</exception>
-        [Obsolete("Use the constructor without the " + nameof(IKeyVaultAuthentication) + " but with the Azure SDK " + nameof(TokenCredential) + " instead")]
+        [Obsolete("Use the constructor without the with the Azure SDK " + nameof(TokenCredential) + " instead")]
         public KeyVaultSecretProvider(IKeyVaultAuthentication authentication, IKeyVaultConfiguration vaultConfiguration)
             : this(authentication, vaultConfiguration, new KeyVaultOptions(), NullLogger<KeyVaultSecretProvider>.Instance)
         {
@@ -81,7 +83,7 @@ namespace Arcus.Security.Providers.AzureKeyVault
         /// <param name="logger">The logger to write diagnostic trace messages during the interaction with the Azure Key Vault.</param>
         /// <exception cref="ArgumentNullException">The <paramref name="authentication"/> cannot be <c>null</c>.</exception>
         /// <exception cref="ArgumentNullException">The <paramref name="vaultConfiguration"/> cannot be <c>null</c>.</exception>
-        [Obsolete("Use the constructor without the " + nameof(IKeyVaultAuthentication) + " but with the Azure SDK " + nameof(TokenCredential) + " instead")]
+        [Obsolete("Use the constructor without with the Azure SDK " + nameof(TokenCredential) + " instead")]
         public KeyVaultSecretProvider(IKeyVaultAuthentication authentication, IKeyVaultConfiguration vaultConfiguration, KeyVaultOptions options, ILogger<KeyVaultSecretProvider> logger)
         {
             Guard.NotNull(vaultConfiguration, nameof(vaultConfiguration), "Requires a Azure Key Vault configuration to setup the secret provider");

--- a/src/Arcus.Security.Tests.Integration/Arcus.Security.Tests.Integration.csproj
+++ b/src/Arcus.Security.Tests.Integration/Arcus.Security.Tests.Integration.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
     <IsPackable>false</IsPackable>
+    <NoWarn>CS0618</NoWarn>
   </PropertyGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
     <FrameworkReference Include="Microsoft.AspNetCore.App" />

--- a/src/Arcus.Security.Tests.Integration/DockerSecrets/SecretStoreBuilderExtensionTests.cs
+++ b/src/Arcus.Security.Tests.Integration/DockerSecrets/SecretStoreBuilderExtensionTests.cs
@@ -10,7 +10,7 @@ using Xunit.Abstractions;
 
 namespace Arcus.Security.Tests.Integration.DockerSecrets
 {
-    public class SecretStoreBuilderExtensionTests : IntegrationTest, IDisposable
+    public class SecretStoreBuilderExtensionTests : IntegrationTest
     {
         private readonly string _secretLocation = Path.Combine(Path.GetTempPath(), "dockersecretstests");
 
@@ -77,9 +77,12 @@ namespace Arcus.Security.Tests.Integration.DockerSecrets
             await File.WriteAllTextAsync(Path.Combine(_secretLocation, secretKey), secretValue);
         }
 
-        /// <summary>Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.</summary>
-        public void Dispose()
+        /// <summary>
+        /// Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.
+        /// </summary>
+        protected override void Dispose(bool disposing)
         {
+            base.Dispose(disposing);
             Directory.Delete(_secretLocation, true);
         }
     }

--- a/src/Arcus.Security.Tests.Integration/IntegrationTest.cs
+++ b/src/Arcus.Security.Tests.Integration/IntegrationTest.cs
@@ -1,19 +1,18 @@
 ﻿using System;
 using Arcus.Security.Tests.Core.Stubs;
 using Arcus.Security.Tests.Integration.Fixture;
-using Arcus.Testing.Logging;
 using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.Logging;
 using Serilog;
 using Serilog.Configuration;
 using Serilog.Core;
-using Serilog.Extensions.Logging;
 using Xunit.Abstractions;
 
 namespace Arcus.Security.Tests.Integration
 {
     public class IntegrationTest : IDisposable
     {
+        private bool _disposed;
+        
         protected TestConfig Configuration { get; }
         protected Logger Logger { get; }
         protected InMemoryLogSink InMemoryLogSink { get; }
@@ -36,6 +35,21 @@ namespace Arcus.Security.Tests.Integration
         /// Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.
         /// </summary>
         public void Dispose()
+        {
+            if (_disposed)
+            {
+                return;
+            }
+            
+            Dispose(true);
+            
+            _disposed = true;
+        }
+        
+        /// <summary>
+        /// Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.
+        /// </summary> 
+        protected virtual void Dispose(bool disposing)
         {
             Logger.Dispose();
         }

--- a/src/Arcus.Security.Tests.Unit/Arcus.Security.Tests.Unit.csproj
+++ b/src/Arcus.Security.Tests.Unit/Arcus.Security.Tests.Unit.csproj
@@ -2,8 +2,8 @@
 
   <PropertyGroup>
     <TargetFrameworks>netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
-
     <IsPackable>false</IsPackable>
+    <NoWarn>CS0618</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Arcus.Security.Tests.Unit/Core/Extensions/IServiceCollectionExtensionsTests.cs
+++ b/src/Arcus.Security.Tests.Unit/Core/Extensions/IServiceCollectionExtensionsTests.cs
@@ -183,7 +183,8 @@ namespace Arcus.Security.Tests.Unit.Core.Extensions
             // Arrange
             var services = new ServiceCollection();
             var spyLogger = new SpyLogger();
-            services.AddLogging(logging => logging.AddProvider(new TestLoggerProvider(spyLogger)));
+            services.AddLogging(logging => logging.SetMinimumLevel(LogLevel.Trace)
+                                                  .AddProvider(new TestLoggerProvider(spyLogger)));
 
             const string secretName = "MySecret";
             var stubProvider = new InMemorySecretProvider((secretName, $"secret-{Guid.NewGuid()}"));


### PR DESCRIPTION
Use only verbose logging in the secret store so the consumers don't get overloaded with 'noise' from the library.

Plus killed the warnings ⚔️ 🐉 .

Closes #269 