### PR TITLE
fix: use Arcus NuGet version ranges

### DIFF
--- a/src/Arcus.Security.Core/Arcus.Security.Core.csproj
+++ b/src/Arcus.Security.Core/Arcus.Security.Core.csproj
@@ -18,9 +18,9 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Arcus.Observability.Telemetry.Core" Version="[2.0.0,3.0.0)" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="3.1.8" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="3.1.8" />
-    <PackageReference Include="Arcus.Observability.Telemetry.Core" Version="2.0.0" />
     <PackageReference Include="Guard.Net" Version="1.2.0" />
   </ItemGroup>
 


### PR DESCRIPTION
Let's use NuGet version ranges when referencing our Arcus packages so we can more easily reference multiple Arcus packages in the same project.

Relates to https://github.com/arcus-azure/arcus/issues/129