### PR TITLE
feat: add command line secret provider

### DIFF
--- a/docs/preview/features/secret-store/index.md
+++ b/docs/preview/features/secret-store/index.md
@@ -21,6 +21,8 @@ Several built in secret providers available in the package.
 And several additional providers in seperate packages.
 
 * [Azure Key Vault](./../../features/secret-store/provider/key-vault)
+* [Command line](./../../features/secret-store/provider/cmd-line)
+* [Docker secrets](./../../features/secret-store/provider/docker-secrets)
 * [HashiCorp](./../../features/secret-store//provider/hashicorp-vault)
 * [User Secrets](./../../features/secret-store/provider/user-secrets)
 

--- a/docs/preview/features/secret-store/provider/cmd-line.md
+++ b/docs/preview/features/secret-store/provider/cmd-line.md
@@ -1,0 +1,51 @@
+---
+title: "Command line secret provider"
+layout: default
+---
+
+# Command line secret provider
+The command line secret provider transforms all your command line arguments in application secrets.
+
+## Installation
+Adding command line arguments into the secret store requires following package:
+
+```shell
+PM > Install-Package Arcus.Security.Providers.CommandLine
+```
+
+## Configuration
+After installing the package, the addtional extensions becomes available when building the secret store.
+
+```csharp
+using Arcus.Security.Core;
+using Microsoft.Extensions.Hosting;
+
+public class Program
+{
+    public static void Main(string[] args)
+    {
+        CreateHostBuilder(args).Build().Run();
+    }
+
+    public static IHostBuilder CreateHostBuilder(string[] args)
+    {    
+        return Host.CreateDefaultBuilder(args)
+                   .ConfigureSecretStore((context, config, builder) =>
+                   {
+                       // Uses the passed-in command line arguments as secrets in the secret store.
+                       builder.AddCommandLine(args);
+
+                       // Uses the passed-in command lien arguments, using underscores and capitals for secret name structure.
+                       // Example - When looking up Queue.Name it will be changed to ARCUS_QUEUE_NAME.
+                       builder.AddCommandLine(args, mutateSecretName: secretName => secretName.Replace(".", "_").ToUppder());
+
+                       // Providing an unique name to this secret provider so it can be looked up later.
+                       // See: "Retrieve a specific secret provider from the secret store"
+                       builder.AddCommandLine(args, name: "CommandLine");
+                    })
+                    .ConfigureWebHostDefaults(webBuilder => webBuilder.UseStartup<Startup>());
+    }
+}
+```
+
+[&larr; back](/)

--- a/src/Arcus.Security.Providers.CommandLine/Arcus.Security.Providers.CommandLine.csproj
+++ b/src/Arcus.Security.Providers.CommandLine/Arcus.Security.Providers.CommandLine.csproj
@@ -1,0 +1,29 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <Authors>Arcus</Authors>
+    <Description>Provides support for command line arguments with Arcus Secret Store</Description>
+    <Copyright>Copyright (c) Arcus</Copyright>
+    <PackageLicenseUrl>https://github.com/arcus-azure/arcus.security/blob/master/LICENSE</PackageLicenseUrl>
+    <PackageProjectUrl>https://github.com/arcus-azure/arcus.security</PackageProjectUrl>
+    <PackageIconUrl>https://raw.githubusercontent.com/arcus-azure/arcus/master/media/arcus.png</PackageIconUrl>
+    <RepositoryUrl>https://github.com/arcus-azure/arcus.security</RepositoryUrl>
+    <RepositoryType>Git</RepositoryType>
+    <PackageTags>CommandLine;Cmd;Console</PackageTags>
+    <AssemblyName>Arcus.Security.Providers.CommandLine</AssemblyName>
+    <RootNamespace>Arcus.Security.Providers.CommandLine</RootNamespace>
+    <PackageId>Arcus.Security.Providers.CommandLine</PackageId>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="3.1.8" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Arcus.Security.Core\Arcus.Security.Core.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Arcus.Security.Providers.CommandLine/CommandLineSecretProvider.cs
+++ b/src/Arcus.Security.Providers.CommandLine/CommandLineSecretProvider.cs
@@ -1,0 +1,66 @@
+﻿using System;
+using System.Threading.Tasks;
+using Arcus.Security.Core;
+using GuardNet;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Configuration.CommandLine;
+
+namespace Arcus.Security.Providers.CommandLine
+{
+    /// <summary>
+    /// Represents an <see cref="ISecretProvider"/> implementation that provides the command line arguments as secrets to the secret store.
+    /// </summary>
+    public class CommandLineSecretProvider : ISecretProvider
+    {
+        private readonly CommandLineConfigurationProvider _configurationProvider;
+        
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CommandLineSecretProvider"/> class.
+        /// </summary>
+        /// <param name="configurationProvider">The command line <see cref="IConfigurationProvider"/> to load the command arguments as secrets.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="configurationProvider"/> is <c>null</c>.</exception>
+        public CommandLineSecretProvider(CommandLineConfigurationProvider configurationProvider)
+        {
+            Guard.NotNull(configurationProvider, nameof(configurationProvider), "Requires a command line configuration provider instance to load the command arguments as secrets");
+            _configurationProvider = configurationProvider;
+        }
+
+        /// <summary>
+        /// Retrieves the secret value, based on the given name
+        /// </summary>
+        /// <param name="secretName">The name of the secret key</param>
+        /// <returns>Returns a <see cref="Secret"/> that contains the secret key</returns>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="secretName"/> is blank.</exception>
+        public async Task<Secret> GetSecretAsync(string secretName)
+        {
+            Guard.NotNullOrWhitespace(secretName, nameof(secretName), "Requires a non-blank secret name to look up the command line argument secret");
+            
+            string secretValue = await GetRawSecretAsync(secretName);
+            if (secretValue is null)
+            {
+                return null;
+            }
+
+            return new Secret(secretValue);
+
+        }
+
+        /// <summary>
+        /// Retrieves the secret value, based on the given name
+        /// </summary>
+        /// <param name="secretName">The name of the secret key</param>
+        /// <returns>Returns the secret key.</returns>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="secretName"/> is blank.</exception>
+        public Task<string> GetRawSecretAsync(string secretName)
+        {
+            Guard.NotNullOrWhitespace(secretName, nameof(secretName), "Requires a non-blank secret name to look up the command line argument secret");
+            
+            if (_configurationProvider.TryGet(secretName, out string secretValue))
+            {
+                return Task.FromResult(secretValue);
+            }
+            
+            return Task.FromResult<string>(null);
+        }
+    }
+}

--- a/src/Arcus.Security.Providers.CommandLine/CommandLineSecretProvider.cs
+++ b/src/Arcus.Security.Providers.CommandLine/CommandLineSecretProvider.cs
@@ -42,7 +42,6 @@ namespace Arcus.Security.Providers.CommandLine
             }
 
             return new Secret(secretValue);
-
         }
 
         /// <summary>
@@ -59,7 +58,7 @@ namespace Arcus.Security.Providers.CommandLine
             {
                 return Task.FromResult(secretValue);
             }
-            
+
             return Task.FromResult<string>(null);
         }
     }

--- a/src/Arcus.Security.Providers.CommandLine/Extensions/SecretStoreBuilderExtensions.cs
+++ b/src/Arcus.Security.Providers.CommandLine/Extensions/SecretStoreBuilderExtensions.cs
@@ -1,0 +1,82 @@
+﻿using System;
+using Arcus.Security.Providers.CommandLine;
+using GuardNet;
+using Microsoft.Extensions.Configuration.CommandLine;
+
+// ReSharper disable once CheckNamespace
+namespace Microsoft.Extensions.Hosting
+{
+    /// <summary>
+    /// Provides a series of extensions to add the command line types to the secret store.
+    /// </summary>
+    public static class SecretStoreBuilderExtensions
+    {
+        /// <summary>
+        /// Adds command line arguments as secrets to the secret store.
+        /// </summary>
+        /// <param name="builder">The secret store to add the command line arguments to.</param>
+        /// <param name="arguments">The command line arguments that will be considered secrets.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="builder"/> or <paramref name="arguments"/> is <c>null</c>.</exception>
+        public static SecretStoreBuilder AddCommandLine(this SecretStoreBuilder builder, string[] arguments)
+        {
+            Guard.NotNull(builder, nameof(builder), "Requires a secret store builder to add the command line arguments as secrets to the secret store");
+            Guard.NotNull(arguments, nameof(arguments), "Requires a set of command line arguments to be set as secret in the secret store");
+
+            return AddCommandLine(builder, arguments, name: null);
+        }
+
+        /// <summary>
+        /// Adds command line arguments as secrets to the secret store.
+        /// </summary>
+        /// <param name="builder">The secret store to add the command line arguments to.</param>
+        /// <param name="arguments">The command line arguments that will be considered secrets.</param>
+        /// <param name="name">The unique name to register this provider in the secret store.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="builder"/> or <paramref name="arguments"/> is <c>null</c>.</exception>
+        public static SecretStoreBuilder AddCommandLine(this SecretStoreBuilder builder, string[] arguments, string name)
+        {
+            Guard.NotNull(builder, nameof(builder), "Requires a secret store builder to add the command line arguments as secrets to the secret store");
+            Guard.NotNull(arguments, nameof(arguments), "Requires a set of command line arguments to be set as secret in the secret store");
+
+            return AddCommandLine(builder, arguments, name, mutateSecretName: null);
+        }
+
+        /// <summary>
+        /// Adds command line arguments as secrets to the secret store.
+        /// </summary>
+        /// <param name="builder">The secret store to add the command line arguments to.</param>
+        /// <param name="arguments">The command line arguments that will be considered secrets.</param>
+        /// <param name="mutateSecretName">The function to mutate the secret name before looking it up.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="builder"/> or <paramref name="arguments"/> is <c>null</c>.</exception>
+        public static SecretStoreBuilder AddCommandLine(this SecretStoreBuilder builder, string[] arguments, Func<string, string> mutateSecretName)
+        {
+            Guard.NotNull(builder, nameof(builder), "Requires a secret store builder to add the command line arguments as secrets to the secret store");
+            Guard.NotNull(arguments, nameof(arguments), "Requires a set of command line arguments to be set as secret in the secret store");
+
+            return AddCommandLine(builder, arguments, name: null, mutateSecretName: mutateSecretName);
+        }
+
+        /// <summary>
+        /// Adds command line arguments as secrets to the secret store.
+        /// </summary>
+        /// <param name="builder">The secret store to add the command line arguments to.</param>
+        /// <param name="arguments">The command line arguments that will be considered secrets.</param>
+        /// <param name="name">The unique name to register this provider in the secret store.</param>
+        /// <param name="mutateSecretName">The function to mutate the secret name before looking it up.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="builder"/> or <paramref name="arguments"/> is <c>null</c>.</exception>
+        public static SecretStoreBuilder AddCommandLine(this SecretStoreBuilder builder, string[] arguments, string name, Func<string, string> mutateSecretName)
+        {
+            Guard.NotNull(builder, nameof(builder), "Requires a secret store builder to add the command line arguments as secrets to the secret store");
+            Guard.NotNull(arguments, nameof(arguments), "Requires a set of command line arguments to be set as secret in the secret store");
+            
+            var configProvider = new CommandLineConfigurationProvider(arguments);
+            configProvider.Load();
+            
+            var secretProvider = new CommandLineSecretProvider(configProvider);
+            return builder.AddProvider(secretProvider, options =>
+            {
+                options.Name = name;
+                options.MutateSecretName = mutateSecretName;
+            });
+        }
+    }
+}

--- a/src/Arcus.Security.Tests.Unit/Arcus.Security.Tests.Unit.csproj
+++ b/src/Arcus.Security.Tests.Unit/Arcus.Security.Tests.Unit.csproj
@@ -20,6 +20,7 @@
   <ItemGroup>
     <ProjectReference Include="..\Arcus.Security.AzureFunctions\Arcus.Security.AzureFunctions.csproj" />
     <ProjectReference Include="..\Arcus.Security.Providers.AzureKeyVault\Arcus.Security.Providers.AzureKeyVault.csproj" />
+    <ProjectReference Include="..\Arcus.Security.Providers.CommandLine\Arcus.Security.Providers.CommandLine.csproj" />
     <ProjectReference Include="..\Arcus.Security.Providers.DockerSecrets\Arcus.Security.Providers.DockerSecrets.csproj" />
     <ProjectReference Include="..\Arcus.Security.Providers.HashiCorp\Arcus.Security.Providers.HashiCorp.csproj" />
     <ProjectReference Include="..\Arcus.Security.Providers.UserSecrets\Arcus.Security.Providers.UserSecrets.csproj" />

--- a/src/Arcus.Security.Tests.Unit/CommandLine/CommandLineSecretProviderTests.cs
+++ b/src/Arcus.Security.Tests.Unit/CommandLine/CommandLineSecretProviderTests.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using Arcus.Security.Providers.CommandLine;
+using Xunit;
+
+namespace Arcus.Security.Tests.Unit.CommandLine
+{
+    public class CommandLineSecretProviderTests
+    {
+        [Fact]
+        public void CreateProvider_WithoutConfigurationProvider_Fails()
+        {
+            Assert.ThrowsAny<ArgumentException>(
+                () => new CommandLineSecretProvider(configurationProvider: null));
+        }
+    }
+}

--- a/src/Arcus.Security.Tests.Unit/CommandLine/SecretStoreBuilderExtensionsTests.cs
+++ b/src/Arcus.Security.Tests.Unit/CommandLine/SecretStoreBuilderExtensionsTests.cs
@@ -1,0 +1,94 @@
+﻿using System;
+using System.Threading.Tasks;
+using Arcus.Security.Core;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Xunit;
+
+namespace Arcus.Security.Tests.Unit.CommandLine
+{
+    public class SecretStoreBuilderExtensionsTests
+    {
+        [Fact]
+        public async Task AddCommandLine_WithArguments_Succeeds()
+        {
+            // Arrange
+            string secretName = "MySecret", expected = "P@ssw0rd";
+            var arguments = new[] {$"--{secretName}={expected}"};
+            var builder = new HostBuilder();
+            
+            // Act
+            builder.ConfigureSecretStore((config, stores) => stores.AddCommandLine(arguments));
+
+            // Assert
+            using (IHost host = builder.Build())
+            {
+                var provider = host.Services.GetRequiredService<ISecretProvider>();
+                string actual = await provider.GetRawSecretAsync(secretName);
+                
+                Assert.Equal(expected, actual);
+            }
+        }
+        
+        [Fact]
+        public void AddCommandLine_WithoutArguments_Fails()
+        {
+            // Arrange
+            var builder = new HostBuilder();
+            
+            // Act
+            builder.ConfigureSecretStore((config, stores) => stores.AddCommandLine(arguments: null));
+            
+            // Assert
+            Assert.ThrowsAny<ArgumentException>(() => builder.Build());
+        }
+
+        [Fact]
+        public void AddCommandLine_WithNameWithoutArguments_Fails()
+        {
+            // Arrange
+            var builder = new HostBuilder();
+            
+            // Act
+            builder.ConfigureSecretStore((config, stores) => stores.AddCommandLine(arguments: null, name: "Command line"));
+            
+            // Assert
+            Assert.ThrowsAny<ArgumentException>(() => builder.Build());
+        }
+        
+        [Fact]
+        public void AddCommandLine_WithMutateSecretWithoutArguments_Fails()
+        {
+            // Arrange
+            var builder = new HostBuilder();
+            
+            // Act
+            builder.ConfigureSecretStore((config, stores) =>
+            {
+                stores.AddCommandLine(arguments: null, mutateSecretName: secretName => secretName);
+            });
+            
+            // Assert
+            Assert.ThrowsAny<ArgumentException>(() => builder.Build());
+        }
+        
+        [Fact]
+        public void AddCommandLine_WithNameWithMutateSecretWithoutArguments_Fails()
+        {
+            // Arrange
+            var builder = new HostBuilder();
+            
+            // Act
+            builder.ConfigureSecretStore((config, stores) =>
+            {
+                stores.AddCommandLine(
+                    arguments: null,
+                    name: "Command line",
+                    mutateSecretName: secretName => secretName);
+            });
+            
+            // Assert
+            Assert.ThrowsAny<ArgumentException>(() => builder.Build());
+        }
+    }
+}

--- a/src/Arcus.Security.sln
+++ b/src/Arcus.Security.sln
@@ -27,6 +27,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Arcus.Security.Providers.Ha
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Arcus.Security.Providers.DockerSecrets", "Arcus.Security.Providers.DockerSecrets\Arcus.Security.Providers.DockerSecrets.csproj", "{EBCA7E71-5F09-43B3-BC44-73B1980477C7}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Arcus.Security.Providers.CommandLine", "Arcus.Security.Providers.CommandLine\Arcus.Security.Providers.CommandLine.csproj", "{D6749062-90BB-4828-86ED-FD8F89ACE8AB}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -73,6 +75,10 @@ Global
 		{EBCA7E71-5F09-43B3-BC44-73B1980477C7}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{EBCA7E71-5F09-43B3-BC44-73B1980477C7}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{EBCA7E71-5F09-43B3-BC44-73B1980477C7}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D6749062-90BB-4828-86ED-FD8F89ACE8AB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D6749062-90BB-4828-86ED-FD8F89ACE8AB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D6749062-90BB-4828-86ED-FD8F89ACE8AB}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D6749062-90BB-4828-86ED-FD8F89ACE8AB}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -85,6 +91,7 @@ Global
 		{BF7F5713-6566-452A-B1F9-C8DA3AB1EB85} = {DD66B1E8-3676-4C13-8C37-AEA80E1C21B7}
 		{2C4BCF60-7D87-404A-827A-A52CAC431D63} = {DD66B1E8-3676-4C13-8C37-AEA80E1C21B7}
 		{EBCA7E71-5F09-43B3-BC44-73B1980477C7} = {DD66B1E8-3676-4C13-8C37-AEA80E1C21B7}
+		{D6749062-90BB-4828-86ED-FD8F89ACE8AB} = {DD66B1E8-3676-4C13-8C37-AEA80E1C21B7}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {D3310D31-C37D-47F4-A6D3-325EE3806698}


### PR DESCRIPTION
Adds a new secret provider that takes in command line arguments and includes them into the secret store.

Closes #240 