### PR TITLE
chore: ignore packaging warnings

### DIFF
--- a/src/Arcus.Security.All/Arcus.Security.All.csproj
+++ b/src/Arcus.Security.All/Arcus.Security.All.csproj
@@ -15,6 +15,7 @@
     <PackageId>Arcus.Security.All</PackageId>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>NU5125;NU5048</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Arcus.Security.AzureFunctions/Arcus.Security.AzureFunctions.csproj
+++ b/src/Arcus.Security.AzureFunctions/Arcus.Security.AzureFunctions.csproj
@@ -15,8 +15,8 @@
     <PackageId>Arcus.Security.AzureFunctions</PackageId>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>NU5125;NU5048</NoWarn>
   </PropertyGroup>
-
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="1.1.0" />

--- a/src/Arcus.Security.Core/Arcus.Security.Core.csproj
+++ b/src/Arcus.Security.Core/Arcus.Security.Core.csproj
@@ -15,6 +15,7 @@
     <PackageId>Arcus.Security.Core</PackageId>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>NU5125;NU5048</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Arcus.Security.Providers.AzureKeyVault/Arcus.Security.Providers.AzureKeyVault.csproj
+++ b/src/Arcus.Security.Providers.AzureKeyVault/Arcus.Security.Providers.AzureKeyVault.csproj
@@ -16,6 +16,7 @@
     <PackageId>Arcus.Security.Providers.AzureKeyVault</PackageId>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>NU5125;NU5048</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Arcus.Security.Providers.CommandLine/Arcus.Security.Providers.CommandLine.csproj
+++ b/src/Arcus.Security.Providers.CommandLine/Arcus.Security.Providers.CommandLine.csproj
@@ -16,6 +16,7 @@
     <PackageId>Arcus.Security.Providers.CommandLine</PackageId>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>NU5125;NU5048</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Arcus.Security.Providers.DockerSecrets/Arcus.Security.Providers.DockerSecrets.csproj
+++ b/src/Arcus.Security.Providers.DockerSecrets/Arcus.Security.Providers.DockerSecrets.csproj
@@ -16,6 +16,7 @@
     <PackageId>Arcus.Security.Providers.DockerSecrets</PackageId>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>NU5125;NU5048</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Arcus.Security.Providers.HashiCorp/Arcus.Security.Providers.HashiCorp.csproj
+++ b/src/Arcus.Security.Providers.HashiCorp/Arcus.Security.Providers.HashiCorp.csproj
@@ -16,6 +16,7 @@
     <PackageId>Arcus.Security.Providers.HashiCorp</PackageId>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>NU5125;NU5048</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Arcus.Security.Providers.UserSecrets/Arcus.Security.Providers.UserSecrets.csproj
+++ b/src/Arcus.Security.Providers.UserSecrets/Arcus.Security.Providers.UserSecrets.csproj
@@ -16,6 +16,7 @@
     <PackageId>Arcus.Security.Providers.UserSecrets</PackageId>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>NU5125;NU5048</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Let's ignore the NuGet packaging warnings about the licensing and package URL's which are obsolete.