### PR TITLE
fix: use `ubuntu-latest` for build vm image

### DIFF
--- a/build/ci-build.yml
+++ b/build/ci-build.yml
@@ -39,7 +39,7 @@ stages:
     jobs:
       - job: Compile
         pool:
-          vmImage: 'ubuntu-16.04'
+          vmImage: 'ubuntu-latest'
         steps:
           - template: 'nuget/determine-pr-version.yml@templates'
             parameters:
@@ -72,7 +72,7 @@ stages:
       - job: UnitTests
         displayName: 'Run unit tests'
         pool:
-          vmImage: 'ubuntu-16.04'
+          vmImage: 'ubuntu-latest'
         steps:
           - task: DownloadPipelineArtifact@2
             displayName: 'Download build artifacts'
@@ -97,7 +97,7 @@ stages:
       - job: IntegrationTests
         displayName: 'Run integration tests'
         pool:
-          vmImage: 'ubuntu-16.04'
+          vmImage: 'ubuntu-latest'
         steps:
           - task: DownloadPipelineArtifact@2
             displayName: 'Download build artifacts'
@@ -129,7 +129,7 @@ stages:
       - job: PushToMyGet
         displayName: 'Push to MyGet'
         pool:
-          vmImage: 'ubuntu-16.04'
+          vmImage: 'ubuntu-latest'
         steps:
           - task: DownloadPipelineArtifact@2
             displayName: 'Download build artifacts'

--- a/build/ci-build.yml
+++ b/build/ci-build.yml
@@ -39,7 +39,7 @@ stages:
     jobs:
       - job: Compile
         pool:
-          vmImage: 'ubuntu-latest'
+          vmImage: $(Vm.Image)
         steps:
           - template: 'nuget/determine-pr-version.yml@templates'
             parameters:
@@ -72,7 +72,7 @@ stages:
       - job: UnitTests
         displayName: 'Run unit tests'
         pool:
-          vmImage: 'ubuntu-latest'
+          vmImage: $(Vm.Image)
         steps:
           - task: DownloadPipelineArtifact@2
             displayName: 'Download build artifacts'
@@ -97,7 +97,7 @@ stages:
       - job: IntegrationTests
         displayName: 'Run integration tests'
         pool:
-          vmImage: 'ubuntu-latest'
+          vmImage: $(Vm.Image)
         steps:
           - task: DownloadPipelineArtifact@2
             displayName: 'Download build artifacts'
@@ -129,7 +129,7 @@ stages:
       - job: PushToMyGet
         displayName: 'Push to MyGet'
         pool:
-          vmImage: 'ubuntu-latest'
+          vmImage: $(Vm.Image)
         steps:
           - task: DownloadPipelineArtifact@2
             displayName: 'Download build artifacts'

--- a/build/nuget-release.yml
+++ b/build/nuget-release.yml
@@ -28,7 +28,7 @@ stages:
     jobs:
       - job: Compile
         pool:
-          vmImage: 'ubuntu-latest'
+          vmImage: $(Vm.Image)
         steps:
           - task: UseDotNet@2
             displayName: 'Import .NET Core SDK ($(DotNet.Sdk.VersionBC))'
@@ -58,7 +58,7 @@ stages:
       - job: UnitTests
         displayName: 'Run unit tests'
         pool:
-          vmImage: 'ubuntu-latest'
+          vmImage: $(Vm.Image)
         steps:
           - task: DownloadPipelineArtifact@2
             displayName: 'Download build artifacts'
@@ -83,7 +83,7 @@ stages:
       - job: IntegrationTests
         displayName: 'Run integration tests'
         pool:
-          vmImage: 'ubuntu-latest'
+          vmImage: $(Vm.Image)
         steps:
           - task: DownloadPipelineArtifact@2
             displayName: 'Download build artifacts'
@@ -113,7 +113,7 @@ stages:
       - job: PushToNuGet
         displayName: 'Push to NuGet.org'
         pool:
-          vmImage: 'ubuntu-latest'
+          vmImage: $(Vm.Image)
         steps:
           - task: DownloadPipelineArtifact@2
             displayName: 'Download build artifacts'

--- a/build/nuget-release.yml
+++ b/build/nuget-release.yml
@@ -28,7 +28,7 @@ stages:
     jobs:
       - job: Compile
         pool:
-          vmImage: 'ubuntu-16.04'
+          vmImage: 'ubuntu-latest'
         steps:
           - task: UseDotNet@2
             displayName: 'Import .NET Core SDK ($(DotNet.Sdk.VersionBC))'
@@ -58,7 +58,7 @@ stages:
       - job: UnitTests
         displayName: 'Run unit tests'
         pool:
-          vmImage: 'ubuntu-16.04'
+          vmImage: 'ubuntu-latest'
         steps:
           - task: DownloadPipelineArtifact@2
             displayName: 'Download build artifacts'
@@ -83,7 +83,7 @@ stages:
       - job: IntegrationTests
         displayName: 'Run integration tests'
         pool:
-          vmImage: 'ubuntu-16.04'
+          vmImage: 'ubuntu-latest'
         steps:
           - task: DownloadPipelineArtifact@2
             displayName: 'Download build artifacts'
@@ -113,7 +113,7 @@ stages:
       - job: PushToNuGet
         displayName: 'Push to NuGet.org'
         pool:
-          vmImage: 'ubuntu-16.04'
+          vmImage: 'ubuntu-latest'
         steps:
           - task: DownloadPipelineArtifact@2
             displayName: 'Download build artifacts'

--- a/build/variables/build.yml
+++ b/build/variables/build.yml
@@ -3,3 +3,4 @@ variables:
   # Backwards compatible .NET SDK version
   DotNet.Sdk.VersionBC: '2.2.105'
   Project: 'Arcus.Security'
+  Vm.Image: 'ubuntu-latest'


### PR DESCRIPTION
Make sure that we use the latest Ubuntu version to build our library.

Relates to https://github.com/arcus-azure/arcus/issues/144