### PR TITLE
docs: redirect from v1.5.0 old auth az key vault

### DIFF
--- a/docs/versioned_docs/version-v1.5.0/features/auth/azure-key-vault.md
+++ b/docs/versioned_docs/version-v1.5.0/features/auth/azure-key-vault.md
@@ -1,0 +1,10 @@
+---
+title: "Authentication with Azure Key Vault"
+layout: default
+---
+
+# Authentication with Azure Key Vault
+
+The authentication mechanisms page is moved towards an [dedicated page](../secret-store/provider/key-vault) that explains how the Azure Key Vault can be added as a secret provider to the secret store.
+
+More information in the secret store can be found [here](../secret-store/).


### PR DESCRIPTION
We already created a dedicated page for redirecting the old Azure Key Vault authentication page towards the secret store and the Azure Key Vault secret provider, but we didn't do this for the v1.5.0 release.

Closes #262