### PR TITLE
chore: upgrade to net6.0

### DIFF
--- a/build/variables/build.yml
+++ b/build/variables/build.yml
@@ -1,6 +1,6 @@
 variables:
-  DotNet.Sdk.Version: '3.1.201'
+  DotNet.Sdk.Version: '6.0.100'
   # Backwards compatible .NET SDK version
-  DotNet.Sdk.VersionBC: '2.2.105'
+  DotNet.Sdk.VersionBC: '3.1.201'
   Project: 'Arcus.Security'
   Vm.Image: 'ubuntu-latest'

--- a/src/Arcus.Security.All/Arcus.Security.All.csproj
+++ b/src/Arcus.Security.All/Arcus.Security.All.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
     <Authors>Arcus</Authors>
     <Company>Arcus</Company>
     <Description>Metapackage that provides you with all the capabilities of Arcus Security.</Description>

--- a/src/Arcus.Security.AzureFunctions/Arcus.Security.AzureFunctions.csproj
+++ b/src/Arcus.Security.AzureFunctions/Arcus.Security.AzureFunctions.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1</TargetFrameworks>
     <Authors>Arcus</Authors>
     <Company>Arcus</Company>
     <Description>Contains Azure Functions core functionality for Arcus Security</Description>

--- a/src/Arcus.Security.Core/Arcus.Security.Core.csproj
+++ b/src/Arcus.Security.Core/Arcus.Security.Core.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1;netcoreapp3.1;net6.0</TargetFrameworks>
     <Authors>Arcus</Authors>
     <Company>Arcus</Company>
     <Description>Contains core functionality for Arcus.Security</Description>

--- a/src/Arcus.Security.Providers.AzureKeyVault/Arcus.Security.Providers.AzureKeyVault.csproj
+++ b/src/Arcus.Security.Providers.AzureKeyVault/Arcus.Security.Providers.AzureKeyVault.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1;netcoreapp3.1;net6.0</TargetFrameworks>
     <Authors>Arcus</Authors>
     <Description>Provides support for Azure Key Vault</Description>
     <Copyright>Copyright (c) Arcus</Copyright>

--- a/src/Arcus.Security.Providers.CommandLine/Arcus.Security.Providers.CommandLine.csproj
+++ b/src/Arcus.Security.Providers.CommandLine/Arcus.Security.Providers.CommandLine.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1</TargetFrameworks>
     <Authors>Arcus</Authors>
     <Description>Provides support for command line arguments with Arcus Secret Store</Description>
     <Copyright>Copyright (c) Arcus</Copyright>

--- a/src/Arcus.Security.Providers.DockerSecrets/Arcus.Security.Providers.DockerSecrets.csproj
+++ b/src/Arcus.Security.Providers.DockerSecrets/Arcus.Security.Providers.DockerSecrets.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1</TargetFrameworks>
     <Authors>Arcus</Authors>
     <Description>Provides support for Docker Secrets</Description>
     <Copyright>Copyright (c) Arcus</Copyright>

--- a/src/Arcus.Security.Providers.HashiCorp/Arcus.Security.Providers.HashiCorp.csproj
+++ b/src/Arcus.Security.Providers.HashiCorp/Arcus.Security.Providers.HashiCorp.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1</TargetFrameworks>
     <Authors>Arcus</Authors>
     <Description>Provides support for HashiCorp</Description>
     <Copyright>Copyright (c) Arcus</Copyright>

--- a/src/Arcus.Security.Providers.UserSecrets/Arcus.Security.Providers.UserSecrets.csproj
+++ b/src/Arcus.Security.Providers.UserSecrets/Arcus.Security.Providers.UserSecrets.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1;netcoreapp3.1;net6.0</TargetFrameworks>
     <Authors>Arcus</Authors>
     <Description>Provides support for User Secrets with Arcus Secret Store</Description>
     <Copyright>Copyright (c) Arcus</Copyright>

--- a/src/Arcus.Security.Tests.Core/Arcus.Security.Tests.Core.csproj
+++ b/src/Arcus.Security.Tests.Core/Arcus.Security.Tests.Core.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Arcus.Security.Tests.Integration/Arcus.Security.Tests.Integration.csproj
+++ b/src/Arcus.Security.Tests.Integration/Arcus.Security.Tests.Integration.csproj
@@ -5,17 +5,8 @@
     <IsPackable>false</IsPackable>
     <NoWarn>CS0618</NoWarn>
   </PropertyGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
-    <FrameworkReference Include="Microsoft.AspNetCore.App" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' != 'netcoreapp3.1'">
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="2.2.0" />
-  </ItemGroup>
   <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights" Version="1.0.0" />
     <PackageReference Include="Guard.Net" Version="1.2.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />

--- a/src/Arcus.Security.Tests.Integration/Arcus.Security.Tests.Integration.csproj
+++ b/src/Arcus.Security.Tests.Integration/Arcus.Security.Tests.Integration.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net6.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <NoWarn>CS0618</NoWarn>
   </PropertyGroup>

--- a/src/Arcus.Security.Tests.Unit/Arcus.Security.Tests.Unit.csproj
+++ b/src/Arcus.Security.Tests.Unit/Arcus.Security.Tests.Unit.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>netcoreapp3.1;net6.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <NoWarn>CS0618</NoWarn>
   </PropertyGroup>

--- a/src/Arcus.Security.Tests.Unit/Arcus.Security.Tests.Unit.csproj
+++ b/src/Arcus.Security.Tests.Unit/Arcus.Security.Tests.Unit.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1;net6.0</TargetFramework>
+    <TargetFrameworks>netcoreapp3.1;net6.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <NoWarn>CS0618</NoWarn>
   </PropertyGroup>


### PR DESCRIPTION
Add .NET 6 as target framework on the available projects.

Relates to https://github.com/arcus-azure/arcus/issues/106