### PR TITLE
fix: Improve the obsolete-warning regarding default caching

### DIFF
--- a/src/Arcus.Security.Providers.AzureKeyVault/Extensions/SecretStoreBuilderExtensions.cs
+++ b/src/Arcus.Security.Providers.AzureKeyVault/Extensions/SecretStoreBuilderExtensions.cs
@@ -384,7 +384,7 @@ namespace Microsoft.Extensions.Hosting
         /// <param name="allowCaching">The flag to indicate whether to include caching during secret retrieval in Azure key vault.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="builder"/> is <c>null</c>.</exception>
         /// <exception cref="ArgumentException">Thrown when the <paramref name="rawVaultUri"/> is blank.</exception>
-        [Obsolete("Use the " + nameof(AddAzureKeyVaultWithManagedIdentity) + " method overload with " + nameof(CacheConfiguration.Default) + " instead to allow default caching")]
+        [Obsolete("Use the " + nameof(AddAzureKeyVaultWithManagedIdentity) + " method overload and pass CacheConfiguration.Default as parameter for the cacheConfiguration to allow default caching")]
         public static SecretStoreBuilder AddAzureKeyVaultWithManagedIdentity(
             this SecretStoreBuilder builder,
             string rawVaultUri,
@@ -395,7 +395,7 @@ namespace Microsoft.Extensions.Hosting
 
             return AddAzureKeyVaultWithManagedIdentity(builder, rawVaultUri, clientId: null, allowCaching: allowCaching);
         }
-        
+
         /// <summary>
         /// Adds Azure Key Vault as a secret source which uses Managed Identity authentication.
         /// </summary>
@@ -407,7 +407,7 @@ namespace Microsoft.Extensions.Hosting
         /// <param name="allowCaching">The flag to indicate whether to include caching during secret retrieval in Azure key vault.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="builder"/> is <c>null</c>.</exception>
         /// <exception cref="ArgumentException">Thrown when the <paramref name="rawVaultUri"/> is blank.</exception>
-        [Obsolete("Use the " + nameof(AddAzureKeyVaultWithManagedIdentity) + " method overload with " + nameof(CacheConfiguration.Default) + " instead to allow default caching")]
+        [Obsolete("Use the " + nameof(AddAzureKeyVaultWithManagedIdentity) + " method overload and pass CacheConfiguration.Default as parameter for the cacheConfiguration to allow default caching")]
         public static SecretStoreBuilder AddAzureKeyVaultWithManagedIdentity(
             this SecretStoreBuilder builder,
             string rawVaultUri,
@@ -438,7 +438,7 @@ namespace Microsoft.Extensions.Hosting
         /// <param name="mutateSecretName">The optional function to mutate the secret name before looking it up.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="builder"/> is <c>null</c>.</exception>
         /// <exception cref="ArgumentException">Thrown when the <paramref name="rawVaultUri"/> is blank.</exception>
-        [Obsolete("Use the " + nameof(AddAzureKeyVaultWithManagedIdentity) + " method overload with " + nameof(CacheConfiguration.Default) + " instead to allow default caching")]
+        [Obsolete("Use the " + nameof(AddAzureKeyVaultWithManagedIdentity) + " method overload and pass CacheConfiguration.Default as parameter for the cacheConfiguration to allow default caching")]
         public static SecretStoreBuilder AddAzureKeyVaultWithManagedIdentity(
             this SecretStoreBuilder builder,
             string rawVaultUri,
@@ -474,7 +474,7 @@ namespace Microsoft.Extensions.Hosting
         /// <param name="mutateSecretName">The optional function to mutate the secret name before looking it up.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="builder"/> is <c>null</c>.</exception>
         /// <exception cref="ArgumentException">Thrown when the <paramref name="rawVaultUri"/> is blank.</exception>
-        [Obsolete("Use the " + nameof(AddAzureKeyVaultWithManagedIdentity) + " method overload with " + nameof(CacheConfiguration.Default) + " instead to allow default caching")]
+        [Obsolete("Use the " + nameof(AddAzureKeyVaultWithManagedIdentity) + " method overload and pass CacheConfiguration.Default as parameter for the cacheConfiguration to allow default caching")]
         public static SecretStoreBuilder AddAzureKeyVaultWithManagedIdentity(
             this SecretStoreBuilder builder,
             string rawVaultUri,

--- a/src/Arcus.Security.Providers.AzureKeyVault/Extensions/SecretStoreBuilderExtensions.cs
+++ b/src/Arcus.Security.Providers.AzureKeyVault/Extensions/SecretStoreBuilderExtensions.cs
@@ -100,7 +100,7 @@ namespace Microsoft.Extensions.Hosting
         /// <param name="allowCaching">The flag to indicate whether to include caching during secret retrieval in Azure key vault.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="builder"/> or <paramref name="certificate"/> is <c>null</c>.</exception>
         /// <exception cref="ArgumentException">Thrown when the <paramref name="rawVaultUri"/> or <paramref name="clientId"/> is blank.</exception>
-        [Obsolete("Use the " + nameof(AddAzureKeyVaultWithCertificate) + " method overload with " + nameof(CacheConfiguration.Default) + " instead to allow default caching")]
+        [Obsolete("Use the " + nameof(AddAzureKeyVaultWithCertificate) + " method overload and pass " + nameof(CacheConfiguration) + "." + nameof(CacheConfiguration.Default) + " as parameter for the cacheConfiguration to allow default caching")]
         public static SecretStoreBuilder AddAzureKeyVaultWithCertificate(
             this SecretStoreBuilder builder,
             string rawVaultUri,
@@ -141,7 +141,7 @@ namespace Microsoft.Extensions.Hosting
         /// <param name="mutateSecretName">The optional function to mutate the secret name before looking it up.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="builder"/> or <paramref name="certificate"/> is <c>null</c>.</exception>
         /// <exception cref="ArgumentException">Thrown when the <paramref name="rawVaultUri"/> or <paramref name="clientId"/> is blank.</exception>
-        [Obsolete("Use the " + nameof(AddAzureKeyVaultWithCertificate) + " method overload with " + nameof(CacheConfiguration.Default) + " instead to allow default caching")]
+        [Obsolete("Use the " + nameof(AddAzureKeyVaultWithCertificate) + " method overload with " + nameof(CacheConfiguration) + "." + nameof(CacheConfiguration.Default) + " instead to allow default caching")]
         public static SecretStoreBuilder AddAzureKeyVaultWithCertificate(
             this SecretStoreBuilder builder,
             string rawVaultUri,
@@ -407,7 +407,7 @@ namespace Microsoft.Extensions.Hosting
         /// <param name="allowCaching">The flag to indicate whether to include caching during secret retrieval in Azure key vault.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="builder"/> is <c>null</c>.</exception>
         /// <exception cref="ArgumentException">Thrown when the <paramref name="rawVaultUri"/> is blank.</exception>
-        [Obsolete("Use the " + nameof(AddAzureKeyVaultWithManagedIdentity) + " method overload and pass CacheConfiguration.Default as parameter for the cacheConfiguration to allow default caching")]
+        [Obsolete("Use the " + nameof(AddAzureKeyVaultWithManagedIdentity) + " method overload and pass " + nameof(CacheConfiguration) + "." + nameof(CacheConfiguration.Default) + " as parameter for the cacheConfiguration to allow default caching")]
         public static SecretStoreBuilder AddAzureKeyVaultWithManagedIdentity(
             this SecretStoreBuilder builder,
             string rawVaultUri,
@@ -438,7 +438,7 @@ namespace Microsoft.Extensions.Hosting
         /// <param name="mutateSecretName">The optional function to mutate the secret name before looking it up.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="builder"/> is <c>null</c>.</exception>
         /// <exception cref="ArgumentException">Thrown when the <paramref name="rawVaultUri"/> is blank.</exception>
-        [Obsolete("Use the " + nameof(AddAzureKeyVaultWithManagedIdentity) + " method overload and pass CacheConfiguration.Default as parameter for the cacheConfiguration to allow default caching")]
+        [Obsolete("Use the " + nameof(AddAzureKeyVaultWithManagedIdentity) + " method overload and pass " + nameof(CacheConfiguration) + "." + nameof(CacheConfiguration.Default) + " as parameter for the cacheConfiguration to allow default caching")]
         public static SecretStoreBuilder AddAzureKeyVaultWithManagedIdentity(
             this SecretStoreBuilder builder,
             string rawVaultUri,
@@ -474,7 +474,7 @@ namespace Microsoft.Extensions.Hosting
         /// <param name="mutateSecretName">The optional function to mutate the secret name before looking it up.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="builder"/> is <c>null</c>.</exception>
         /// <exception cref="ArgumentException">Thrown when the <paramref name="rawVaultUri"/> is blank.</exception>
-        [Obsolete("Use the " + nameof(AddAzureKeyVaultWithManagedIdentity) + " method overload and pass CacheConfiguration.Default as parameter for the cacheConfiguration to allow default caching")]
+        [Obsolete("Use the " + nameof(AddAzureKeyVaultWithManagedIdentity) + " method overload and pass " + nameof(CacheConfiguration) + "." + nameof(CacheConfiguration.Default) + " as parameter for the cacheConfiguration to allow default caching")]
         public static SecretStoreBuilder AddAzureKeyVaultWithManagedIdentity(
             this SecretStoreBuilder builder,
             string rawVaultUri,
@@ -757,7 +757,7 @@ namespace Microsoft.Extensions.Hosting
         /// <param name="allowCaching">The flag to indicate whether to include caching during secret retrieval in Azure key vault.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="builder"/> is <c>null</c>.</exception>
         /// <exception cref="ArgumentException">Thrown when the <paramref name="rawVaultUri"/>, <paramref name="clientId"/>, or <paramref name="clientKey"/> is blank.</exception>
-        [Obsolete("Use the " + nameof(AddAzureKeyVaultWithServicePrincipal) + " method overload with " + nameof(CacheConfiguration.Default) + " instead to allow default caching")]
+        [Obsolete("Use the " + nameof(AddAzureKeyVaultWithServicePrincipal) + " method overload and pass " + nameof(CacheConfiguration) + "." + nameof(CacheConfiguration.Default) + " as parameter for the cacheConfiguration to allow default caching")]
         public static SecretStoreBuilder AddAzureKeyVaultWithServicePrincipal(
             this SecretStoreBuilder builder,
             string rawVaultUri,
@@ -798,7 +798,7 @@ namespace Microsoft.Extensions.Hosting
         /// <param name="mutateSecretName">The optional function to mutate the secret name before looking it up.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="builder"/> is <c>null</c>.</exception>
         /// <exception cref="ArgumentException">Thrown when the <paramref name="rawVaultUri"/>, <paramref name="clientId"/>, or <paramref name="clientKey"/> is blank.</exception>
-        [Obsolete("Use the " + nameof(AddAzureKeyVaultWithServicePrincipal) + " method overload with " + nameof(CacheConfiguration.Default) + " instead to allow default caching")]
+        [Obsolete("Use the " + nameof(AddAzureKeyVaultWithServicePrincipal) + " method overload and pass " + nameof(CacheConfiguration) + "." + nameof(CacheConfiguration.Default) + " as parameter for the cacheConfiguration to allow default caching")]
         public static SecretStoreBuilder AddAzureKeyVaultWithServicePrincipal(
             this SecretStoreBuilder builder,
             string rawVaultUri,

--- a/src/Arcus.Security.Providers.AzureKeyVault/Extensions/SecretStoreBuilderExtensions.cs
+++ b/src/Arcus.Security.Providers.AzureKeyVault/Extensions/SecretStoreBuilderExtensions.cs
@@ -384,7 +384,7 @@ namespace Microsoft.Extensions.Hosting
         /// <param name="allowCaching">The flag to indicate whether to include caching during secret retrieval in Azure key vault.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="builder"/> is <c>null</c>.</exception>
         /// <exception cref="ArgumentException">Thrown when the <paramref name="rawVaultUri"/> is blank.</exception>
-        [Obsolete("Use the " + nameof(AddAzureKeyVaultWithManagedIdentity) + " method overload and pass CacheConfiguration.Default as parameter for the cacheConfiguration to allow default caching")]
+        [Obsolete("Use the " + nameof(AddAzureKeyVaultWithManagedIdentity) + " method overload and pass " + nameof(CacheConfiguration) + "." + nameof(CacheConfiguration.Default) + " as parameter for the cacheConfiguration to allow default caching")]
         public static SecretStoreBuilder AddAzureKeyVaultWithManagedIdentity(
             this SecretStoreBuilder builder,
             string rawVaultUri,


### PR DESCRIPTION
The warning message that was displayed to developers when they used the obsolete version of `AddAzureKeyVaultWithManagedServiceIdentity` was displayed as:

> Use the AddAzureKeyVaultWithServicePrincipal method overload with Default instead to allow default caching.

Seems like the `nameof(CacheConfiguration.Default)` just gets translated to `Default` and this is a bit confusing.