### PR TITLE
chore: correct marking az keyvault secret name obsolete

### DIFF
--- a/src/Arcus.Security.Providers.AzureKeyVault/KeyVaultCachedSecretProvider.cs
+++ b/src/Arcus.Security.Providers.AzureKeyVault/KeyVaultCachedSecretProvider.cs
@@ -20,6 +20,7 @@ namespace Arcus.Security.Providers.AzureKeyVault
         /// <summary>
         /// Gets the regular expression that can check if the Azure Key Vault URI matches the <see cref="KeyVaultSecretProvider.SecretNamePattern"/>. (See https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#objects-identifiers-and-versioning).
         /// </summary>
+        [Obsolete("Will be removed in v2.0")]
         protected readonly Regex SecretNameRegex = new Regex(KeyVaultSecretProvider.SecretNamePattern, RegexOptions.Compiled);
 
         /// <summary>
@@ -81,7 +82,6 @@ namespace Arcus.Security.Providers.AzureKeyVault
         {
             Guard.NotNullOrWhitespace(secretName, nameof(secretName), "Requires a non-blank secret name to request a secret in Azure Key Vault");
             Guard.NotNullOrWhitespace(secretValue, nameof(secretValue), "Requires a non-blank secret value to store a secret in Azure Key Vault");
-            Guard.For<FormatException>(() => !SecretNameRegex.IsMatch(secretName), "Requires a secret name in the correct format to request a secret in Azure Key Vault, see https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#objects-identifiers-and-versioning");
 
             Secret secret = await _secretProvider.StoreSecretAsync(secretName, secretValue);
             MemoryCache.Set(secretName, secret, CacheEntry);

--- a/src/Arcus.Security.Providers.AzureKeyVault/KeyVaultSecretProvider.cs
+++ b/src/Arcus.Security.Providers.AzureKeyVault/KeyVaultSecretProvider.cs
@@ -39,6 +39,7 @@ namespace Arcus.Security.Providers.AzureKeyVault
         /// <summary>
         /// Gets the pattern which a Azure Key Vault secret name should match against. (See https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#objects-identifiers-and-versioning).
         /// </summary>
+        [Obsolete("Will be removed in v2.0")]
         internal const string SecretNamePattern = "^[a-zA-Z][a-zA-Z0-9\\-]{0,126}$";
 
         /// <summary>

--- a/src/Arcus.Security.Providers.AzureKeyVault/KeyVaultSecretProvider.cs
+++ b/src/Arcus.Security.Providers.AzureKeyVault/KeyVaultSecretProvider.cs
@@ -28,7 +28,6 @@ namespace Arcus.Security.Providers.AzureKeyVault
         /// <summary>
         /// Gets the name of the dependency that can be used to track the Azure Key Vault resource in Application Insights.
         /// </summary>
-        [Obsolete("Will be removed in v2.0")]
         protected const string DependencyName = "Azure key vault";
 
         /// <summary>


### PR DESCRIPTION
In previous PR, https://github.com/arcus-azure/arcus.security/pull/324, we marked the dependency name as obsolete, while this was not correct. Only the regular expressions and the patterns should be marked as obsolete.

Relates to #317