### PR TITLE
chore: update with az keyvault as default package

### DIFF
--- a/build/nuget-release.yml
+++ b/build/nuget-release.yml
@@ -118,8 +118,8 @@ stages:
             parameters:
               repositoryName: 'arcus-azure/arcus.security'
               releaseNotes: |
-                Install new version via [NuGet](https://www.nuget.org/packages/Arcus.Security.All/$(Build.BuildNumber))
+                Install new version via [NuGet](https://www.nuget.org/packages/Arcus.Security.Providers.AzureKeyVault/$(Build.BuildNumber))
                 ```shell
-                PM > Install-Package Arcus.Security.All --Version $(Build.BuildNumber)
+                PM > Install-Package Arcus.Security.Providers.AzureKeyVault --Version $(Build.BuildNumber)
                 ```
           - template: nuget/publish-official-package.yml@templates


### PR DESCRIPTION
Since we stepped off from the `Arcus.Security.All` package, let's use a different 'default' package in the release notes.