### PR TITLE
fix: use correct namespace for versioned secret extensions

### DIFF
--- a/src/Arcus.Security.Core/Extensions/ISecretProviderExtensions.Deprecated.cs
+++ b/src/Arcus.Security.Core/Extensions/ISecretProviderExtensions.Deprecated.cs
@@ -4,8 +4,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using GuardNet;
 
-// ReSharper disable once CheckNamespace
-namespace Arcus.Security.Core
+namespace Arcus.Security.Core.Extensions
 {
     /// <summary>
     /// Extensions on the <see cref="ISecretProvider"/> to retrieve several secret values based on configured allowed versions.
@@ -25,6 +24,7 @@ namespace Arcus.Security.Core
         /// <exception cref="ArgumentException">The <paramref name="secretName"/> must not be empty</exception>
         /// <exception cref="ArgumentNullException">The <paramref name="secretName"/> must not be null</exception>
         /// <exception cref="SecretNotFoundException">The secret was not found, using the given name</exception>
+        [Obsolete("Use the " + nameof(Core.ISecretProviderExtensions.GetRawSecretsAsync) + " extension instead")]
         public static async Task<IEnumerable<string>> GetRawSecretsAsync(this ISecretProvider secretProvider, string secretName)
         {
             Guard.NotNullOrWhitespace(secretName, nameof(secretName), "Requires a non-blank secret name to look up the secret");
@@ -51,6 +51,7 @@ namespace Arcus.Security.Core
         /// <exception cref="ArgumentException">The <paramref name="secretName"/> must not be empty</exception>
         /// <exception cref="ArgumentNullException">The <paramref name="secretName"/> must not be null</exception>
         /// <exception cref="SecretNotFoundException">The secret was not found, using the given name</exception>
+        [Obsolete("Use the " + nameof(Core.ISecretProviderExtensions.GetSecretsAsync) + " extension instead")]
         public static async Task<IEnumerable<Secret>> GetSecretsAsync(this ISecretProvider secretProvider, string secretName)
         {
             Guard.NotNullOrWhitespace(secretName, nameof(secretName), "Requires a non-blank secret name to look up the secret");

--- a/src/Arcus.Security.Tests.Unit/Core/VersionedSecretTests.cs
+++ b/src/Arcus.Security.Tests.Unit/Core/VersionedSecretTests.cs
@@ -5,7 +5,6 @@ using System.Linq;
 using System.Threading.Tasks;
 using Arcus.Security.Core;
 using Arcus.Security.Core.Caching;
-using Arcus.Security.Core.Extensions;
 using Arcus.Security.Tests.Unit.Core.Stubs;
 using Microsoft.AspNetCore.DataProtection;
 using Microsoft.Extensions.DependencyInjection;


### PR DESCRIPTION
Use the `Arcus.Security.Core` namespace so that consumers discover these extensions quicker.

Closes #364