### PR TITLE
feat: sync secret retrieval via secret store

### DIFF
--- a/docs/preview/03-Features/secret-store/provider/cmd-line.md
+++ b/docs/preview/03-Features/secret-store/provider/cmd-line.md
@@ -6,6 +6,8 @@ layout: default
 # Command line secret provider
 The command line secret provider transforms all your command line arguments in application secrets.
 
+⚡ Supports [synchronous secret retrieval](../../secrets/general.md). 
+
 ## Installation
 Adding command line arguments into the secret store requires following package:
 

--- a/docs/preview/03-Features/secret-store/provider/configuration.md
+++ b/docs/preview/03-Features/secret-store/provider/configuration.md
@@ -6,7 +6,9 @@ layout: default
 # Configuration secret provider
 Configuration secret provider brings you all registered configuration providers of .NET Core by using `IConfiguration` to your application.
 
-> :warning: When using configuration secret provider, it will look for secrets in all configuration sources which is not secure. This provider should only be used for development.
+⚡ Supports [synchronous secret retrieval](../../secrets/general.md).
+
+> ⚠ When using configuration secret provider, it will look for secrets in all configuration sources which is not secure. This provider should only be used for development.
 
 ## Installation
 The configuration secret provider is built-in as part of the package [Arcus.Security.Core](https://www.nuget.org/packages/Arcus.Security.Core).

--- a/docs/preview/03-Features/secret-store/provider/docker-secrets.md
+++ b/docs/preview/03-Features/secret-store/provider/docker-secrets.md
@@ -9,6 +9,8 @@ The Docker secrets secret provider provides access to those secrets via the secr
 
 This secret provider offers functionality which is equivalent to the _KeyPerFile_ Configuration Provider, but instead of adding the secrets to the Configuration, this secret provider allows access to the Docker Secrets via the _ISecretProvider_ interface.
 
+⚡ Supports [synchronous secret retrieval](../../secrets/general.md).
+
 ## Installation
 Adding secrets from the User Secrets manager into the secret store requires following package:
 

--- a/docs/preview/03-Features/secret-store/provider/environment-variables.md
+++ b/docs/preview/03-Features/secret-store/provider/environment-variables.md
@@ -6,6 +6,8 @@ layout: default
 # Environment variables secret provider
 Environment variable secret provider brings environment variables as secrets to your application.
 
+⚡ Supports [synchronous secret retrieval](../../secrets/general.md).
+
 ## Installation
 The environment variable secret provider is built-in as part of the package [Arcus.Security.Core](https://www.nuget.org/packages/Arcus.Security.Core).
 

--- a/docs/preview/03-Features/secret-store/provider/hashicorp-vault.md
+++ b/docs/preview/03-Features/secret-store/provider/hashicorp-vault.md
@@ -6,6 +6,8 @@ layout: default
 # HashiCorp Vault secret provider
 HashiCorp Vault secret provider brings secrets from the KeyValue secret engine to your application.
 
+⛔ Does not support [synchronous secret retrieval](../../secrets/general.md).
+
 ## Installation
 Adding secrets from HashiCorp Vault into the secret store requires following package:
 

--- a/docs/preview/03-Features/secret-store/provider/key-vault.md
+++ b/docs/preview/03-Features/secret-store/provider/key-vault.md
@@ -6,6 +6,8 @@ layout: default
 # Azure Key Vault secret provider
 Azure Key Vault secret provider brings secrets from Azure Key Vault to your application.
 
+⚡ Supports [synchronous secret retrieval](../../secrets/general.md).
+
 ## Installation
 Adding secrets from Azure Key Vault into the secret store requires following package:
 

--- a/docs/preview/03-Features/secret-store/provider/user-secrets.md
+++ b/docs/preview/03-Features/secret-store/provider/user-secrets.md
@@ -6,7 +6,9 @@ layout: default
 # User Secrets manager secret provider
 User Secrets secret provider brings local secrets during development to your application.
 
-> :warning: When using User Secrets secret provider, it will look for secrets on the local disk which is not secure. This provider should only be used for development.
+⚡ Supports [synchronous secret retrieval](../../secrets/general.md).
+
+> ⚠ When using User Secrets secret provider, it will look for secrets on the local disk which is not secure. This provider should only be used for development.
 
 ## Installation
 Adding secrets from the User Secrets manager into the secret store requires following package:

--- a/docs/preview/03-Features/secrets/general.md
+++ b/docs/preview/03-Features/secrets/general.md
@@ -16,13 +16,40 @@ string secretVersion = secret.Version;
 DateTimeOffset? expirationDate = secret.Expires;
 ```
 
-# Raw secrets
+## Raw secrets
 In some scenarios you'd like to just get the secret value directly without any metadata.
 This is possible by calling the `...Raw...` variants on the `ISecretProvider` implementations.
 
 ```csharp
 string secretValue = await secretProvider.GetRawSecretAsync("EventGrid-AuthKey");
 ```
+
+## Synchronous secrets
+In some scenarios you'd like to retrieve secrets synchronously. A common situation is when you want to register a dependent service into the dependency container that requires a secret, but since such a container only registers instances or synchronous functions, there is no easy way to retrieve a secret asynchronously.
+
+Almost all built-in secret providers we provide support synchronous secret retrieval, only the [HashiCorp Vault secret provider](../secret-store/provider/hashicorp-vault.md) does not support this.
+
+Retrieving synchronous secrets can be done via either using the `ISyncSecretProvider` alternative interface, or by calling the `GetSecret` extensions on an `ISecretProvider` implementation.
+
+```csharp
+var services = new ServiceCollection();
+services.AddSingleton(serviceProvider =>
+{
+    // #1 injecting the `ISyncSecretProvider`:
+    var syncSecretProvider = serviceProvider.GetRequiredService<ISyncSecretProvider>();
+    Secret secret = synSecretProvider.GetSecret("EventGrid-AuthKey");
+    string secretValue = syncSecretProvider.GetRawSecret("EventGrid-AuthKey");
+
+    // #2 calling `GetSecret` or `GetRawSecret` extension on `ISecretProvider`:
+    var secretProvider = serviceProvider.GetRequiredService<ISecretProvider>();
+    Secret secret = secretProvider.GetSecret("EventGrid-AuthKey");
+    string secretProvider = secretProvider.GetRawSecret("EventGrid-AuthKey");
+
+    return new MyDependentService(secretValue);
+});
+```
+
+⚠ Make sure that you only call the `GetSecret` and `GetRawSecret` extension on `ISecretProvider` implementations that also implement the `ISyncSecretProvider` interface. The [Arcus secret store](../secret-store/index.md) automatically makes sure that you can use this extension on any injected `ISecretProvider` but when no secret provider is registered that supports synchronous secret retrieval, an `SecretNotFoundException` will be thrown nonetheless.
 
 # Caching Secrets
 Some secret providers recommend to cache secrets for a while to avoid hitting the service limitations.

--- a/docs/preview/03-Features/secrets/general.md
+++ b/docs/preview/03-Features/secrets/general.md
@@ -49,7 +49,7 @@ services.AddSingleton(serviceProvider =>
 });
 ```
 
-⚠ Make sure that you only call the `GetSecret` and `GetRawSecret` extension on `ISecretProvider` implementations that also implement the `ISyncSecretProvider` interface. The [Arcus secret store](../secret-store/index.md) automatically makes sure that you can use this extension on any injected `ISecretProvider` but when no secret provider is registered that supports synchronous secret retrieval, an `SecretNotFoundException` will be thrown nonetheless.
+⚠ Make sure that you only call the `GetSecret` and `GetRawSecret` extension on `ISecretProvider` implementations that also implement the `ISyncSecretProvider` interface. The [Arcus secret store](../secret-store/index.md) automatically makes sure that you can use this extension on any injected `ISecretProvider` but when no secret provider is registered that supports synchronous secret retrieval, an `NotSupportedException` will be thrown nonetheless.
 
 # Caching Secrets
 Some secret providers recommend to cache secrets for a while to avoid hitting the service limitations.
@@ -68,6 +68,8 @@ var cachedSecretProvider = new KeyVaultSecretProvider(vaultAuthentication, vault
                                     .WithCaching();
 Secret secret = await cachedSecretProvider.GetSecretAsync("EventGrid-AuthKey");
 ```
+
+⚠ Make sure that your only call the cache-specific `GetSecret("<secret-name>", ignoreCache: bool)` and others on `ISecretProvider` implementations that also implement the `ICachedSecretProvider` interface. The [Arcus secret store](../secret-store/index.md) automatically makes sure that you can inject the `ICachedSecretProvider` but when no secret provider is registered that supported caching, an `NotSupportedException` will be thrown nonethless.
 
 ## Configuring the cache
 By default, retrieved secrets are cached for **5 minutes**, but you can configure this yourself.

--- a/docs/preview/03-Features/secrets/general.md
+++ b/docs/preview/03-Features/secrets/general.md
@@ -49,7 +49,7 @@ services.AddSingleton(serviceProvider =>
 });
 ```
 
-⚠ Make sure that you only call the `GetSecret` and `GetRawSecret` extension on `ISecretProvider` implementations that also implement the `ISyncSecretProvider` interface. The [Arcus secret store](../secret-store/index.md) automatically makes sure that you can use this extension on any injected `ISecretProvider` but when no secret provider is registered that supports synchronous secret retrieval, an `NotSupportedException` will be thrown nonetheless.
+⚠ Make sure that you only call the `GetSecret` and `GetRawSecret` extension on `ISecretProvider` implementations that also implement the `ISyncSecretProvider` interface. The [Arcus secret store](../secret-store/index.md) automatically makes sure that you can use this extension on any injected `ISecretProvider` but when no secret provider is registered that supports synchronous secret retrieval, a `NotSupportedException` will be thrown nonetheless.
 
 # Caching Secrets
 Some secret providers recommend to cache secrets for a while to avoid hitting the service limitations.

--- a/docs/preview/03-Features/secrets/general.md
+++ b/docs/preview/03-Features/secrets/general.md
@@ -69,7 +69,7 @@ var cachedSecretProvider = new KeyVaultSecretProvider(vaultAuthentication, vault
 Secret secret = await cachedSecretProvider.GetSecretAsync("EventGrid-AuthKey");
 ```
 
-⚠ Make sure that your only call the cache-specific `GetSecret("<secret-name>", ignoreCache: bool)` and others on `ISecretProvider` implementations that also implement the `ICachedSecretProvider` interface. The [Arcus secret store](../secret-store/index.md) automatically makes sure that you can inject the `ICachedSecretProvider` but when no secret provider is registered that supported caching, an `NotSupportedException` will be thrown nonethless.
+⚠ Make sure that your only call the cache-specific `GetSecret("<secret-name>", ignoreCache: bool)` and others on `ISecretProvider` implementations that also implement the `ICachedSecretProvider` interface. The [Arcus secret store](../secret-store/index.md) automatically makes sure that you can inject the `ICachedSecretProvider` but when no secret provider is registered that supported caching, a `NotSupportedException` will be thrown nonethless.
 
 ## Configuring the cache
 By default, retrieved secrets are cached for **5 minutes**, but you can configure this yourself.

--- a/src/Arcus.Security.Core/CompositeSecretProvider.cs
+++ b/src/Arcus.Security.Core/CompositeSecretProvider.cs
@@ -580,7 +580,7 @@ namespace Arcus.Security.Core
             Func<SecretStoreSource, Task<T>> callRegisteredProvider,
             string eventName) where T : class
         {
-            LogSecurityEvent(secretName, source, eventName);
+            LogSecurityEvent(source, secretName, eventName);
 
             Task<T> resultAsync = callRegisteredProvider(source);
             if (resultAsync is null)
@@ -598,13 +598,13 @@ namespace Arcus.Security.Core
             Func<SecretStoreSource, T> callRegisteredProvider,
             string eventName)
         {
-            LogSecurityEvent(secretName, source, eventName);
+            LogSecurityEvent(source, secretName, eventName);
 
             T result = callRegisteredProvider(source);
             return result;
         }
 
-        private void LogSecurityEvent(string secretName, SecretStoreSource source, string eventName)
+        private void LogSecurityEvent(SecretStoreSource source, string secretName, string eventName)
         {
             if (_auditingOptions.EmitSecurityEvents)
             {

--- a/src/Arcus.Security.Core/Extensions/ISecretProviderExtensions.cs
+++ b/src/Arcus.Security.Core/Extensions/ISecretProviderExtensions.cs
@@ -14,6 +14,50 @@ namespace Arcus.Security.Core
     public static class ISecretProviderExtensions
     {
         /// <summary>
+        /// Retrieves the secret value, based on the given name
+        /// </summary>
+        /// <param name="secretProvider">The injected secret provider instance.</param>
+        /// <param name="secretName">The name of the secret key</param>
+        /// <returns>Returns the secret key.</returns>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="secretName"/> is blank.</exception>
+        /// <exception cref="SecretNotFoundException">Thrown when the secret was not found, using the given name.</exception>
+        public static string GetRawSecret(this ISecretProvider secretProvider, string secretName)
+        {
+            Guard.NotNullOrWhitespace(secretName, nameof(secretName), "Requires a non-blank secret name to look up the secret");
+
+            if (secretProvider is ISyncSecretProvider composite)
+            {
+                string secretValue = composite.GetRawSecret(secretName);
+                return secretValue;
+            }
+
+            throw new SecretNotFoundException(secretName, new InvalidOperationException(
+                $"Cannot retrieve secret '{secretName}' because the '{nameof(GetRawSecret)}' method is called on a '{nameof(ISecretProvider)}' that does not implement the '{nameof(ISyncSecretProvider)}'"));
+        }
+
+        /// <summary>
+        /// Retrieves the secret value, based on the given name
+        /// </summary>
+        /// <param name="secretProvider">The injected secret provider instance.</param>
+        /// <param name="secretName">The name of the secret key</param>
+        /// <returns>Returns the secret key.</returns>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="secretName"/> is blank.</exception>
+        /// <exception cref="SecretNotFoundException">Thrown when the secret was not found, using the given name.</exception>
+        public static Secret GetSecret(this ISecretProvider secretProvider, string secretName)
+        {
+            Guard.NotNullOrWhitespace(secretName, nameof(secretName), "Requires a non-blank secret name to look up the secret");
+
+            if (secretProvider is ISyncSecretProvider composite)
+            {
+                Secret secret = composite.GetSecret(secretName);
+                return secret;
+            }
+
+            throw new SecretNotFoundException(secretName, new InvalidOperationException(
+                $"Cannot retrieve secret '{secretName}' because the '{nameof(GetRawSecret)}' method is called on a '{nameof(ISecretProvider)}' that does not implement the '{nameof(ISyncSecretProvider)}'"));
+        }
+
+        /// <summary>
         /// Retrieves all the allowed versions of a secret value, based on the given <paramref name="secretName"/>.
         /// </summary>
         /// <remarks>

--- a/src/Arcus.Security.Core/Extensions/ISecretProviderExtensions.cs
+++ b/src/Arcus.Security.Core/Extensions/ISecretProviderExtensions.cs
@@ -32,8 +32,8 @@ namespace Arcus.Security.Core
                 return secretValue;
             }
 
-            throw new SecretNotFoundException(secretName, new InvalidOperationException(
-                $"Cannot retrieve secret '{secretName}' because the '{nameof(GetRawSecret)}' method is called on a '{nameof(ISecretProvider)}' that does not implement the '{nameof(ISyncSecretProvider)}'"));
+            throw new NotSupportedException(
+                $"Cannot retrieve secret '{secretName}' because the '{nameof(GetRawSecret)}' method is called on the '{secretProvider.GetType().Name}' implementation that does not implement the '{nameof(ISyncSecretProvider)}'");
         }
 
         /// <summary>
@@ -55,8 +55,8 @@ namespace Arcus.Security.Core
                 return secret;
             }
 
-            throw new SecretNotFoundException(secretName, new InvalidOperationException(
-                $"Cannot retrieve secret '{secretName}' because the '{nameof(GetRawSecret)}' method is called on a '{nameof(ISecretProvider)}' that does not implement the '{nameof(ISyncSecretProvider)}'"));
+            throw new NotSupportedException(
+                $"Cannot retrieve secret '{secretName}' because the '{nameof(GetRawSecret)}' method is called on a '{secretProvider.GetType().Name}' that does not implement the '{nameof(ISyncSecretProvider)}'");
         }
 
         /// <summary>

--- a/src/Arcus.Security.Core/Extensions/ISecretProviderExtensions.cs
+++ b/src/Arcus.Security.Core/Extensions/ISecretProviderExtensions.cs
@@ -23,6 +23,7 @@ namespace Arcus.Security.Core
         /// <exception cref="SecretNotFoundException">Thrown when the secret was not found, using the given name.</exception>
         public static string GetRawSecret(this ISecretProvider secretProvider, string secretName)
         {
+            Guard.NotNull(secretProvider, nameof(secretProvider), "Requires a secret provider to synchronously look up the secret");
             Guard.NotNullOrWhitespace(secretName, nameof(secretName), "Requires a non-blank secret name to look up the secret");
 
             if (secretProvider is ISyncSecretProvider composite)
@@ -45,6 +46,7 @@ namespace Arcus.Security.Core
         /// <exception cref="SecretNotFoundException">Thrown when the secret was not found, using the given name.</exception>
         public static Secret GetSecret(this ISecretProvider secretProvider, string secretName)
         {
+            Guard.NotNull(secretProvider, nameof(secretProvider), "Requires a secret provider to synchronously look up the secret");
             Guard.NotNullOrWhitespace(secretName, nameof(secretName), "Requires a non-blank secret name to look up the secret");
 
             if (secretProvider is ISyncSecretProvider composite)

--- a/src/Arcus.Security.Core/ISecretProvider.cs
+++ b/src/Arcus.Security.Core/ISecretProvider.cs
@@ -8,7 +8,6 @@ namespace Arcus.Security.Core
     /// </summary>
     public interface ISecretProvider
     {
-
         /// <summary>
         /// Retrieves the secret value, based on the given name
         /// </summary>

--- a/src/Arcus.Security.Core/ISyncSecretProvider.cs
+++ b/src/Arcus.Security.Core/ISyncSecretProvider.cs
@@ -1,0 +1,28 @@
+﻿using System;
+
+namespace Arcus.Security.Core
+{
+    /// <summary>
+    /// Represents an additional synchronous implementation on top of the <see cref="ISecretProvider"/>.
+    /// </summary>
+    public interface ISyncSecretProvider : ISecretProvider
+    {
+        /// <summary>
+        /// Retrieves the secret value, based on the given name
+        /// </summary>
+        /// <param name="secretName">The name of the secret key</param>
+        /// <returns>Returns the secret key.</returns>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="secretName"/> is blank.</exception>
+        /// <exception cref="SecretNotFoundException">Thrown when the secret was not found, using the given name.</exception>
+        string GetRawSecret(string secretName);
+
+        /// <summary>
+        /// Retrieves the secret value, based on the given name
+        /// </summary>
+        /// <param name="secretName">The name of the secret key</param>
+        /// <returns>Returns a <see cref="Secret"/> that contains the secret key</returns>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="secretName"/> is blank.</exception>
+        /// <exception cref="SecretNotFoundException">Thrown when the secret was not found, using the given name.</exception>
+        Secret GetSecret(string secretName);
+    }
+}

--- a/src/Arcus.Security.Core/SecretStoreBuilder.cs
+++ b/src/Arcus.Security.Core/SecretStoreBuilder.cs
@@ -218,6 +218,7 @@ namespace Microsoft.Extensions.Hosting
             Services.TryAddSingleton<ICachedSecretProvider, CompositeSecretProvider>();
             Services.TryAddSingleton<ISecretProvider>(serviceProvider => serviceProvider.GetRequiredService<ICachedSecretProvider>());
             Services.TryAddSingleton<ISecretStore>(serviceProvider => (CompositeSecretProvider) serviceProvider.GetRequiredService<ICachedSecretProvider>());
+            Services.TryAddSingleton<ISyncSecretProvider>(serviceProvider => (CompositeSecretProvider) serviceProvider.GetRequiredService<ICachedSecretProvider>());
         }
 
         private void AddSecretStoreSources()

--- a/src/Arcus.Security.Core/SecretStoreSource.cs
+++ b/src/Arcus.Security.Core/SecretStoreSource.cs
@@ -70,23 +70,7 @@ namespace Arcus.Security.Core
         {
             Guard.NotNull(secretProvider, nameof(secretProvider), "Requires a secret provider instance to register it in the secret store");
 
-            _secretProvider = secretProvider;
-
-            if (secretProvider is ICachedSecretProvider cachedSecretProvider)
-            {
-                CachedSecretProvider = cachedSecretProvider;
-            }
-
-            if (secretProvider is IVersionedSecretProvider secretVersionProvider)
-            {
-                VersionedSecretProvider = secretVersionProvider;
-            }
-
-            if (secretProvider is ISyncSecretProvider syncSecretProvider)
-            {
-                SyncSecretProvider = syncSecretProvider;
-            }
-
+            AssignSecretProvider(secretProvider);
             Options = options ?? new SecretProviderOptions();
         }
 
@@ -169,22 +153,27 @@ namespace Arcus.Security.Core
                         + "Please check if the secret providers are correctly registered in the secret store");
                 }
 
-                _secretProvider = secretProvider;
+                AssignSecretProvider(secretProvider);
+            }
+        }
 
-                if (secretProvider is ICachedSecretProvider cachedSecretProvider)
-                {
-                    CachedSecretProvider = cachedSecretProvider;
-                }
+        private void AssignSecretProvider(ISecretProvider secretProvider)
+        {
+            _secretProvider = secretProvider;
 
-                if (secretProvider is IVersionedSecretProvider secretVersionProvider)
-                {
-                    VersionedSecretProvider = secretVersionProvider;
-                }
+            if (secretProvider is ICachedSecretProvider cachedSecretProvider)
+            {
+                CachedSecretProvider = cachedSecretProvider;
+            }
 
-                if (secretProvider is ISyncSecretProvider syncSecretProvider)
-                {
-                    SyncSecretProvider = syncSecretProvider;
-                }
+            if (secretProvider is IVersionedSecretProvider secretVersionProvider)
+            {
+                VersionedSecretProvider = secretVersionProvider;
+            }
+
+            if (secretProvider is ISyncSecretProvider syncSecretProvider)
+            {
+                SyncSecretProvider = syncSecretProvider;
             }
         }
 

--- a/src/Arcus.Security.Core/SecretStoreSource.cs
+++ b/src/Arcus.Security.Core/SecretStoreSource.cs
@@ -82,6 +82,11 @@ namespace Arcus.Security.Core
                 VersionedSecretProvider = secretVersionProvider;
             }
 
+            if (secretProvider is ISyncSecretProvider syncSecretProvider)
+            {
+                SyncSecretProvider = syncSecretProvider;
+            }
+
             Options = options ?? new SecretProviderOptions();
         }
 
@@ -116,6 +121,15 @@ namespace Arcus.Security.Core
         ///     than the <see cref="EnsureSecretProviderCreated"/> method has to be called first to initialized the lazy created <see cref="IVersionedSecretProvider"/>.
         /// </remarks>
         public IVersionedSecretProvider VersionedSecretProvider { get; private set; }
+
+        /// <summary>
+        /// Gets the synchronous variant of this secret provider registration, if the <see cref="SecretProvider"/> is a <see cref="ISyncSecretProvider"/> implementation.
+        /// </summary>
+        /// <remarks>
+        ///     When this secret provider source registration was initialized with the <see cref="SecretStoreSource(Func{IServiceProvider,ISecretProvider},Func{string,string})"/>
+        ///     than the <see cref="EnsureSecretProviderCreated"/> method has to be called first to initialized the lazy created <see cref="ISyncSecretProvider"/>.
+        /// </remarks>
+        public ISyncSecretProvider SyncSecretProvider { get; private set; }
 
         /// <summary>
         /// Gets the cached provider for this secret provider registration, if the <see cref="SecretProvider"/> is a <see cref="ICachedSecretProvider"/> implementation.
@@ -165,6 +179,11 @@ namespace Arcus.Security.Core
                 if (secretProvider is IVersionedSecretProvider secretVersionProvider)
                 {
                     VersionedSecretProvider = secretVersionProvider;
+                }
+
+                if (secretProvider is ISyncSecretProvider syncSecretProvider)
+                {
+                    SyncSecretProvider = syncSecretProvider;
                 }
             }
         }

--- a/src/Arcus.Security.Providers.AzureKeyVault/KeyVaultSecretProvider.cs
+++ b/src/Arcus.Security.Providers.AzureKeyVault/KeyVaultSecretProvider.cs
@@ -163,7 +163,7 @@ namespace Arcus.Security.Providers.AzureKeyVault
         /// <returns>Returns the secret key.</returns>
         /// <exception cref="ArgumentException">Thrown when the <paramref name="secretName"/> is blank.</exception>
         /// <exception cref="SecretNotFoundException">Thrown when the secret was not found, using the given name.</exception>
-        public string GetRawSecret(string secretName)
+        public virtual string GetRawSecret(string secretName)
         {
             Guard.NotNullOrWhitespace(secretName, nameof(secretName), "Requires a non-blank secret name to request a secret in Azure Key Vault");
 
@@ -178,7 +178,7 @@ namespace Arcus.Security.Providers.AzureKeyVault
         /// <returns>Returns a <see cref="Secret"/> that contains the secret key</returns>
         /// <exception cref="ArgumentException">Thrown when the <paramref name="secretName"/> is blank.</exception>
         /// <exception cref="SecretNotFoundException">Thrown when the secret was not found, using the given name.</exception>
-        public Secret GetSecret(string secretName)
+        public virtual Secret GetSecret(string secretName)
         {
             Guard.NotNullOrWhitespace(secretName, nameof(secretName), "Requires a non-blank secret name to request a secret in Azure Key Vault");
 

--- a/src/Arcus.Security.Tests.Integration/DockerSecrets/SecretStoreBuilderExtensionTests.cs
+++ b/src/Arcus.Security.Tests.Integration/DockerSecrets/SecretStoreBuilderExtensionTests.cs
@@ -36,19 +36,27 @@ namespace Arcus.Security.Tests.Integration.DockerSecrets
             IHost host = hostBuilder.Build();
             var secretProvider = host.Services.GetRequiredService<ISecretProvider>();
 
-            string actualValue = await secretProvider.GetRawSecretAsync(secretKey);
-            Assert.Equal(expectedValue, actualValue);
+            Assert.Equal(expectedValue, secretProvider.GetRawSecret(secretKey));
+            Assert.Equal(expectedValue, secretProvider.GetSecret(secretKey).Value);
+            Assert.Equal(expectedValue, await secretProvider.GetRawSecretAsync(secretKey));
+            Assert.Equal(expectedValue, (await secretProvider.GetSecretAsync(secretKey)).Value);
         }
 
         [Fact]
         public async Task DockerSecretsProvider_ReturnsNull_WhenSecretNotFound()
         {
+            // Arrange
             var provider = new DockerSecretsSecretProvider(_secretLocation);
+            
+            // Act
             await SetSecretAsync("MyExistingSecret", "foo");
 
-            var secret = await provider.GetRawSecretAsync("MyNonExistingSecret");
-
-            Assert.Null(secret);
+            // Assert
+            var secretName = "MyNonExistingSecret";
+            Assert.Null(provider.GetRawSecret(secretName));
+            Assert.Null(provider.GetSecret(secretName).Value);
+            Assert.Null(await provider.GetRawSecretAsync(secretName));
+            Assert.Null((await provider.GetSecretAsync(secretName)).Value);
         }
 
         [Fact]
@@ -68,8 +76,11 @@ namespace Arcus.Security.Tests.Integration.DockerSecrets
             IHost host = hostBuilder.Build();
             var secretProvider = host.Services.GetRequiredService<ISecretProvider>();
 
-            string actualValue = await secretProvider.GetRawSecretAsync("ConnectionStrings:PersonDb");
-            Assert.Equal(expectedValue, actualValue);
+            var secretName = "ConnectionStrings:PersonDb";
+            Assert.Equal(expectedValue, secretProvider.GetRawSecret(secretName));
+            Assert.Equal(expectedValue, secretProvider.GetSecret(secretName).Value);
+            Assert.Equal(expectedValue, await secretProvider.GetRawSecretAsync(secretName));
+            Assert.Equal(expectedValue, (await secretProvider.GetSecretAsync(secretName)).Value);
         }
 
         [Fact]

--- a/src/Arcus.Security.Tests.Integration/DockerSecrets/SecretStoreBuilderExtensionTests.cs
+++ b/src/Arcus.Security.Tests.Integration/DockerSecrets/SecretStoreBuilderExtensionTests.cs
@@ -54,9 +54,9 @@ namespace Arcus.Security.Tests.Integration.DockerSecrets
             // Assert
             var secretName = "MyNonExistingSecret";
             Assert.Null(provider.GetRawSecret(secretName));
-            Assert.Null(provider.GetSecret(secretName).Value);
+            Assert.Null(provider.GetSecret(secretName));
             Assert.Null(await provider.GetRawSecretAsync(secretName));
-            Assert.Null((await provider.GetSecretAsync(secretName)).Value);
+            Assert.Null((await provider.GetSecretAsync(secretName)));
         }
 
         [Fact]

--- a/src/Arcus.Security.Tests.Integration/HashiCorp/SecretStoreBuilderExtensionsTests.cs
+++ b/src/Arcus.Security.Tests.Integration/HashiCorp/SecretStoreBuilderExtensionsTests.cs
@@ -140,7 +140,7 @@ namespace Arcus.Security.Tests.Integration.HashiCorp
 
         private void AssertTrackedHashiCorpVaultDependency(bool trackDependency)
         {
-            var expectedTrackedDependencyCount = Convert.ToInt16(trackDependency);
+            var expectedTrackedDependencyCount = trackDependency ? 2 : 0;
             int actualTrackedDependencyCount = InMemoryLogSink.LogEvents.Count(ev => ev.MessageTemplate.Text.Contains("Dependency"));
             
             Assert.Equal(expectedTrackedDependencyCount, actualTrackedDependencyCount);

--- a/src/Arcus.Security.Tests.Integration/HashiCorp/SecretStoreBuilderExtensionsTests.cs
+++ b/src/Arcus.Security.Tests.Integration/HashiCorp/SecretStoreBuilderExtensionsTests.cs
@@ -127,8 +127,11 @@ namespace Arcus.Security.Tests.Integration.HashiCorp
                 using (IHost host = builder.Build())
                 {
                     var provider = host.Services.GetRequiredService<ISecretProvider>();
-                    var exception = await Assert.ThrowsAsync<VaultApiException>(() => provider.GetRawSecretAsync(secretName));
-                    Assert.Equal(HttpStatusCode.Forbidden, exception.HttpStatusCode);
+                    
+                    var exceptionFromSecret = await Assert.ThrowsAsync<VaultApiException>(() => provider.GetSecretAsync(secretName));
+                    var exceptionFromRawSecret = await Assert.ThrowsAsync<VaultApiException>(() => provider.GetRawSecretAsync(secretName));
+                    Assert.Equal(HttpStatusCode.Forbidden, exceptionFromSecret.HttpStatusCode);
+                    Assert.Equal(HttpStatusCode.Forbidden, exceptionFromRawSecret.HttpStatusCode);
                 }
 
                 AssertTrackedHashiCorpVaultDependency(trackDependency);

--- a/src/Arcus.Security.Tests.Integration/HashiCorp/SecretStoreBuilderExtensionsTests.cs
+++ b/src/Arcus.Security.Tests.Integration/HashiCorp/SecretStoreBuilderExtensionsTests.cs
@@ -36,9 +36,9 @@ namespace Arcus.Security.Tests.Integration.HashiCorp
         }
 
         [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
-        public async Task AuthenticateWithInvalidUserPassPasswordKeyValue_GetSecret_Fails(bool trackDependency)
+        [InlineData(false, 0)]
+        [InlineData(true, 2)]
+        public async Task AuthenticateWithInvalidUserPassPasswordKeyValue_GetSecret_Fails(bool trackDependency, int expectedTrackedDependencies)
         {
             // Arrange
             string secretPath = "mysecret";
@@ -78,18 +78,20 @@ namespace Arcus.Security.Tests.Integration.HashiCorp
                 using (IHost host = builder.Build())
                 {
                     var provider = host.Services.GetRequiredService<ISecretProvider>();
-                    var exception = await Assert.ThrowsAsync<VaultApiException>(() => provider.GetRawSecretAsync(secretName));
-                    Assert.Equal(HttpStatusCode.BadRequest, exception.HttpStatusCode);
+                    var exceptionFromSecret = await Assert.ThrowsAsync<VaultApiException>(() => provider.GetSecretAsync(secretName));
+                    var exceptionFromRawSecret = await Assert.ThrowsAsync<VaultApiException>(() => provider.GetRawSecretAsync(secretName));
+                    Assert.Equal(HttpStatusCode.BadRequest, exceptionFromSecret.HttpStatusCode);
+                    Assert.Equal(HttpStatusCode.BadRequest, exceptionFromRawSecret.HttpStatusCode);
                 }
 
-                AssertTrackedHashiCorpVaultDependency(trackDependency);
+                AssertTrackedHashiCorpVaultDependency(expectedTrackedDependencies);
             }
         }
 
         [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
-        public async Task AuthenticateWithUnauthorizedUserPassUserKeyValue_GetSecret_Fails(bool trackDependency)
+        [InlineData(false, 0)]
+        [InlineData(true, 2)]
+        public async Task AuthenticateWithUnauthorizedUserPassUserKeyValue_GetSecret_Fails(bool trackDependency, int expectedTrackedDependencies)
         {
             // Arrange
             string secretPath = "mysecret";
@@ -134,15 +136,13 @@ namespace Arcus.Security.Tests.Integration.HashiCorp
                     Assert.Equal(HttpStatusCode.Forbidden, exceptionFromRawSecret.HttpStatusCode);
                 }
 
-                AssertTrackedHashiCorpVaultDependency(trackDependency);
+                AssertTrackedHashiCorpVaultDependency(expectedTrackedDependencies);
             }
         }
 
-        private void AssertTrackedHashiCorpVaultDependency(bool trackDependency)
+        private void AssertTrackedHashiCorpVaultDependency(int expectedTrackedDependencyCount)
         {
-            var expectedTrackedDependencyCount = trackDependency ? 2 : 0;
             int actualTrackedDependencyCount = InMemoryLogSink.LogEvents.Count(ev => ev.MessageTemplate.Text.Contains("Dependency"));
-            
             Assert.Equal(expectedTrackedDependencyCount, actualTrackedDependencyCount);
         }
     }

--- a/src/Arcus.Security.Tests.Integration/KeyVault/KeyVaultCachedSecretProviderTests.cs
+++ b/src/Arcus.Security.Tests.Integration/KeyVault/KeyVaultCachedSecretProviderTests.cs
@@ -17,8 +17,6 @@ namespace Arcus.Security.Tests.Integration.KeyVault
     [Trait(name: "Category", value: "Integration")]
     public class KeyVaultCachedSecretProviderTests : IntegrationTest
     {
-        private const string KeyVaultConnectionStringEnvironmentVariable = "AzureServicesAuthConnectionString";
-
         /// <summary>
         /// Initializes a new instance of the <see cref="KeyVaultCachedSecretProviderTests"/> class.
         /// </summary>
@@ -57,10 +55,10 @@ namespace Arcus.Security.Tests.Integration.KeyVault
                     Assert.NotNull(secret);
                     Assert.NotNull(secret.Value);
                     Assert.NotNull(secret.Version);
-                    Secret fetchedSecret = await cachedSecretProvider.GetSecretAsync(secretName);
-                    Assert.Equal(secretValue, fetchedSecret.Value);
-                    Assert.Equal(secret.Version, fetchedSecret.Version);
-                    Assert.Equal(secret.Expires, fetchedSecret.Expires);
+                    AssertEqualSecret(secret, cachedSecretProvider.GetSecret(secretName));
+                    AssertEqualSecret(secret, cachedSecretProvider.GetRawSecret(secretName));
+                    AssertEqualSecret(secret, await cachedSecretProvider.GetSecretAsync(secretName));
+                    AssertEqualSecret(secret, await cachedSecretProvider.GetRawSecretAsync(secretName));
                 }
                 finally
                 {
@@ -68,6 +66,18 @@ namespace Arcus.Security.Tests.Integration.KeyVault
                     await client.StartDeleteSecretAsync(secretName);
                 }
             }
+        }
+
+        private static void AssertEqualSecret(Secret expected, string secretValue)
+        {
+            Assert.Equal(expected.Value, secretValue);
+        }
+
+        private static void AssertEqualSecret(Secret expected, Secret actual)
+        {
+            Assert.Equal(expected.Value, actual.Value);
+            Assert.Equal(expected.Version, actual.Version);
+            Assert.Equal(expected.Expires, actual.Expires);
         }
     }
 }

--- a/src/Arcus.Security.Tests.Integration/KeyVault/KeyVaultSecretProviderTests.cs
+++ b/src/Arcus.Security.Tests.Integration/KeyVault/KeyVaultSecretProviderTests.cs
@@ -43,8 +43,6 @@ namespace Arcus.Security.Tests.Integration.KeyVault
                 vaultConfiguration: new KeyVaultConfiguration(VaultUri));
 
             // Act / Assert
-            AssertNotNullSecret(keyVaultSecretProvider.GetSecret(TestSecretName));
-            AssertNotNullSecret(keyVaultSecretProvider.GetRawSecret(TestSecretName));
             AssertNotNullSecret(await keyVaultSecretProvider.GetSecretAsync(TestSecretName));
             AssertNotNullSecret(await keyVaultSecretProvider.GetRawSecretAsync(TestSecretName));
         }
@@ -110,8 +108,6 @@ namespace Arcus.Security.Tests.Integration.KeyVault
                 vaultConfiguration: new KeyVaultConfiguration(VaultUri));
 
             // Act / Assert
-            AssertNotNullSecret(keyVaultSecretProvider.GetSecret(TestSecretName));
-            AssertNotNullSecret(keyVaultSecretProvider.GetRawSecret(TestSecretName));
             AssertNotNullSecret(await keyVaultSecretProvider.GetSecretAsync(TestSecretName));
             AssertNotNullSecret(await keyVaultSecretProvider.GetRawSecretAsync(TestSecretName));
         }
@@ -188,8 +184,6 @@ namespace Arcus.Security.Tests.Integration.KeyVault
             using (TemporaryEnvironmentVariable.Create(KeyVaultConnectionStringEnvironmentVariable, connectionString))
             {
                 // Act / Assert
-                AssertNotNullSecret(keyVaultSecretProvider.GetSecret(TestSecretName));
-                AssertNotNullSecret(keyVaultSecretProvider.GetRawSecret(TestSecretName));
                 AssertNotNullSecret(await keyVaultSecretProvider.GetSecretAsync(TestSecretName));
                 AssertNotNullSecret(await keyVaultSecretProvider.GetRawSecretAsync(TestSecretName));
             }

--- a/src/Arcus.Security.Tests.Integration/KeyVault/KeyVaultSecretProviderTests.cs
+++ b/src/Arcus.Security.Tests.Integration/KeyVault/KeyVaultSecretProviderTests.cs
@@ -42,13 +42,11 @@ namespace Arcus.Security.Tests.Integration.KeyVault
                 authentication: new ServicePrincipalAuthentication(ClientId, ClientSecret), 
                 vaultConfiguration: new KeyVaultConfiguration(VaultUri));
 
-            // Act
-            Secret secret = await keyVaultSecretProvider.GetSecretAsync(TestSecretName);
-
-            // Assert
-            Assert.NotNull(secret);
-            Assert.NotNull(secret.Value);
-            Assert.NotNull(secret.Version);
+            // Act / Assert
+            AssertNotNullSecret(keyVaultSecretProvider.GetSecret(TestSecretName));
+            AssertNotNullSecret(keyVaultSecretProvider.GetRawSecret(TestSecretName));
+            AssertNotNullSecret(await keyVaultSecretProvider.GetSecretAsync(TestSecretName));
+            AssertNotNullSecret(await keyVaultSecretProvider.GetRawSecretAsync(TestSecretName));
         }
 
         [Fact]
@@ -59,13 +57,11 @@ namespace Arcus.Security.Tests.Integration.KeyVault
                 tokenCredential: new ClientSecretCredential(TenantId, ClientId, ClientSecret), 
                 vaultConfiguration: new KeyVaultConfiguration(VaultUri));
 
-            // Act
-            Secret secret = await keyVaultSecretProvider.GetSecretAsync(TestSecretName);
-
-            // Assert
-            Assert.NotNull(secret);
-            Assert.NotNull(secret.Value);
-            Assert.NotNull(secret.Version);
+            // Act / Assert
+            AssertNotNullSecret(keyVaultSecretProvider.GetSecret(TestSecretName));
+            AssertNotNullSecret(keyVaultSecretProvider.GetRawSecret(TestSecretName));
+            AssertNotNullSecret(await keyVaultSecretProvider.GetSecretAsync(TestSecretName));
+            AssertNotNullSecret(await keyVaultSecretProvider.GetRawSecretAsync(TestSecretName));
         }
 
         [Fact]
@@ -113,13 +109,11 @@ namespace Arcus.Security.Tests.Integration.KeyVault
                 authentication: new ManagedServiceIdentityAuthentication(connectionString: connectionString),
                 vaultConfiguration: new KeyVaultConfiguration(VaultUri));
 
-            // Act
-            Secret secret = await keyVaultSecretProvider.GetSecretAsync(TestSecretName);
-
-            // Assert
-            Assert.NotNull(secret);
-            Assert.NotNull(secret.Value);
-            Assert.NotNull(secret.Version);
+            // Act / Assert
+            AssertNotNullSecret(keyVaultSecretProvider.GetSecret(TestSecretName));
+            AssertNotNullSecret(keyVaultSecretProvider.GetRawSecret(TestSecretName));
+            AssertNotNullSecret(await keyVaultSecretProvider.GetSecretAsync(TestSecretName));
+            AssertNotNullSecret(await keyVaultSecretProvider.GetRawSecretAsync(TestSecretName));
         }
 
         [Fact]
@@ -134,13 +128,11 @@ namespace Arcus.Security.Tests.Integration.KeyVault
                         tokenCredential: new ChainedTokenCredential(new ManagedIdentityCredential(ClientId), new EnvironmentCredential()),
                         vaultConfiguration: new KeyVaultConfiguration(VaultUri));
 
-                // Act
-                Secret secret = await keyVaultSecretProvider.GetSecretAsync(TestSecretName);
-
-                // Assert
-                Assert.NotNull(secret);
-                Assert.NotNull(secret.Value);
-                Assert.NotNull(secret.Version); 
+                // Act / Assert
+                AssertNotNullSecret(keyVaultSecretProvider.GetSecret(TestSecretName));
+                AssertNotNullSecret(keyVaultSecretProvider.GetRawSecret(TestSecretName));
+                AssertNotNullSecret(await keyVaultSecretProvider.GetSecretAsync(TestSecretName));
+                AssertNotNullSecret(await keyVaultSecretProvider.GetRawSecretAsync(TestSecretName));
             }
         }
 
@@ -195,13 +187,11 @@ namespace Arcus.Security.Tests.Integration.KeyVault
 
             using (TemporaryEnvironmentVariable.Create(KeyVaultConnectionStringEnvironmentVariable, connectionString))
             {
-                // Act
-                Secret secret = await keyVaultSecretProvider.GetSecretAsync(TestSecretName);
-
-                // Assert
-                Assert.NotNull(secret);
-                Assert.NotNull(secret.Value);
-                Assert.NotNull(secret.Version);
+                // Act / Assert
+                AssertNotNullSecret(keyVaultSecretProvider.GetSecret(TestSecretName));
+                AssertNotNullSecret(keyVaultSecretProvider.GetRawSecret(TestSecretName));
+                AssertNotNullSecret(await keyVaultSecretProvider.GetSecretAsync(TestSecretName));
+                AssertNotNullSecret(await keyVaultSecretProvider.GetRawSecretAsync(TestSecretName));
             }
         }
 
@@ -248,9 +238,7 @@ namespace Arcus.Security.Tests.Integration.KeyVault
                     Secret secret = await keyVaultSecretProvider.StoreSecretAsync(secretName, secretValue);
 
                     // Assert
-                    Assert.NotNull(secret);
-                    Assert.NotNull(secret.Value);
-                    Assert.NotNull(secret.Version);
+                    AssertNotNullSecret(secretValue);
                     Secret fetchedSecret = await keyVaultSecretProvider.GetSecretAsync(secretName);
                     Assert.Equal(secretValue, fetchedSecret.Value);
                     Assert.Equal(secret.Version, fetchedSecret.Version);
@@ -326,6 +314,18 @@ namespace Arcus.Security.Tests.Integration.KeyVault
             // Assert
             Assert.Equal(2, secrets.Count());
             Assert.Equal(TestSecretVersion, secrets.ElementAt(0).Version);
+        }
+
+        private void AssertNotNullSecret(Secret secret)
+        {
+            Assert.NotNull(secret);
+            AssertNotNullSecret(secret.Value);
+            Assert.NotNull(secret.Version);
+        }
+
+        private void AssertNotNullSecret(string secretValue)
+        {
+            Assert.NotNull(secretValue);
         }
     }
 }

--- a/src/Arcus.Security.Tests.Integration/KeyVault/SecretStoreBuilderExtensionsTests.cs
+++ b/src/Arcus.Security.Tests.Integration/KeyVault/SecretStoreBuilderExtensionsTests.cs
@@ -49,17 +49,27 @@ namespace Arcus.Security.Tests.Integration.KeyVault
             {
                 var provider = host.Services.GetRequiredService<ISecretProvider>();
 
-                Secret secret = await provider.GetSecretAsync(keyName);
-                Assert.NotNull(secret);
-                Assert.NotNull(secret.Value);
-                Assert.NotNull(secret.Version);
+                AssertNotNullSecret(await provider.GetSecretAsync(keyName));
+                AssertNotNullSecret(await provider.GetRawSecretAsync(keyName));
             }
         }
 
+        private void AssertNotNullSecret(Secret secret)
+        {
+            Assert.NotNull(secret);
+            AssertNotNullSecret(secret.Value);
+            Assert.NotNull(secret.Version);
+        }
+
+        private void AssertNotNullSecret(string secretValue)
+        {
+            Assert.NotNull(secretValue);
+        }
+
         [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
-        public async Task AddAzureKeyVaultWithDependencyTracking_WithServicePrincipal_GetSecretSucceeds(bool trackDependency)
+        [InlineData(false, 0)]
+        [InlineData(true, 2)]
+        public async Task AddAzureKeyVaultWithDependencyTracking_WithServicePrincipal_GetSecretSucceeds(bool trackDependency, int expectedTrackedDependencies)
         {
             // Arrange
             string applicationId = Configuration.GetValue<string>("Arcus:ServicePrincipal:ApplicationId");
@@ -82,13 +92,11 @@ namespace Arcus.Security.Tests.Integration.KeyVault
             {
                 var provider = host.Services.GetRequiredService<ISecretProvider>();
 
-                Secret secret = await provider.GetSecretAsync(keyName);
-                Assert.NotNull(secret);
-                Assert.NotNull(secret.Value);
-                Assert.NotNull(secret.Version);
+                AssertNotNullSecret(await provider.GetSecretAsync(keyName));
+                AssertNotNullSecret(await provider.GetRawSecretAsync(keyName));
             }
             
-            AssertTrackedAzureKeyVaultDependency(trackDependency);
+            AssertTrackedAzureKeyVaultDependency(expectedTrackedDependencies);
         }
 
         [Fact]
@@ -111,13 +119,16 @@ namespace Arcus.Security.Tests.Integration.KeyVault
             // Assert
             using IHost host = builder.Build();
             var provider = host.Services.GetRequiredService<ISecretProvider>();
+            Assert.Throws<SecretNotFoundException>(() => provider.GetSecret(keyName));
+            Assert.Throws<SecretNotFoundException>(() => provider.GetRawSecret(keyName));
             await Assert.ThrowsAsync<SecretNotFoundException>(() => provider.GetSecretAsync(keyName));
+            await Assert.ThrowsAsync<SecretNotFoundException>(() => provider.GetRawSecretAsync(keyName));
         }
 
         [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
-        public async Task AddAzureKeyVaultWithDependencyTracking_WithServicePrincipal_GetSecretFails(bool trackDependency)
+        [InlineData(false, 0)]
+        [InlineData(true, 2)]
+        public async Task AddAzureKeyVaultWithDependencyTracking_WithServicePrincipal_GetSecretFails(bool trackDependency, int expectedTrackedDependencies)
         {
             // Arrange
             string applicationId = Configuration.GetValue<string>("Arcus:ServicePrincipal:ApplicationId");
@@ -140,10 +151,11 @@ namespace Arcus.Security.Tests.Integration.KeyVault
             {
                 var provider = host.Services.GetRequiredService<ISecretProvider>();
                 await Assert.ThrowsAsync<SecretNotFoundException>(() => provider.GetSecretAsync(keyName));
+                await Assert.ThrowsAsync<SecretNotFoundException>(() => provider.GetRawSecretAsync(keyName));
             }
             
             Assert.NotEmpty(InMemoryLogSink.LogEvents);
-            AssertTrackedAzureKeyVaultDependency(trackDependency);
+            AssertTrackedAzureKeyVaultDependency(expectedTrackedDependencies);
         }
 
         [Fact]
@@ -168,10 +180,9 @@ namespace Arcus.Security.Tests.Integration.KeyVault
             using IHost host = builder.Build();
             var provider = host.Services.GetRequiredService<ISecretProvider>();
 
-            Secret secret = await provider.GetSecretAsync("Test-" + keyName);
-            Assert.NotNull(secret);
-            Assert.NotNull(secret.Value);
-            Assert.NotNull(secret.Version);
+            string appendedKeyName = "Test-" + keyName;
+            AssertNotNullSecret(await provider.GetSecretAsync(appendedKeyName));
+            AssertNotNullSecret(await provider.GetRawSecretAsync(appendedKeyName));
         }
 
         [Fact]
@@ -195,8 +206,10 @@ namespace Arcus.Security.Tests.Integration.KeyVault
             // Assert
             using IHost host = builder.Build();
             var provider = host.Services.GetRequiredService<ISecretProvider>();
-            await Assert.ThrowsAsync<SecretNotFoundException>(
-                () => provider.GetSecretAsync(keyName));
+            Assert.Throws<SecretNotFoundException>(() => provider.GetSecret(keyName));
+            Assert.Throws<SecretNotFoundException>(() => provider.GetRawSecret(keyName));
+            await Assert.ThrowsAsync<SecretNotFoundException>(() => provider.GetSecretAsync(keyName));
+            await Assert.ThrowsAsync<SecretNotFoundException>(() => provider.GetRawSecretAsync(keyName));
         }
 
         [Fact]
@@ -220,10 +233,8 @@ namespace Arcus.Security.Tests.Integration.KeyVault
             using IHost host = builder.Build();
             var provider = host.Services.GetRequiredService<ISecretProvider>();
 
-            Secret secret = await provider.GetSecretAsync(keyName);
-            Assert.NotNull(secret);
-            Assert.NotNull(secret.Value);
-            Assert.NotNull(secret.Version);
+            AssertNotNullSecret(await provider.GetSecretAsync(keyName));
+            AssertNotNullSecret(await provider.GetRawSecretAsync(keyName));
         }
 
         [Fact]
@@ -246,7 +257,10 @@ namespace Arcus.Security.Tests.Integration.KeyVault
             // Assert
             using IHost host = builder.Build();
             var provider = host.Services.GetRequiredService<ISecretProvider>();
+            Assert.Throws<SecretNotFoundException>(() => provider.GetSecret(keyName));
+            Assert.Throws<SecretNotFoundException>(() => provider.GetRawSecret(keyName));
             await Assert.ThrowsAsync<SecretNotFoundException>(() => provider.GetSecretAsync(keyName));
+            await Assert.ThrowsAsync<SecretNotFoundException>(() => provider.GetRawSecretAsync(keyName));
         }
 
         [Fact]
@@ -271,10 +285,9 @@ namespace Arcus.Security.Tests.Integration.KeyVault
             using IHost host = builder.Build();
             var provider = host.Services.GetRequiredService<ISecretProvider>();
 
-            Secret secret = await provider.GetSecretAsync("Test-" + keyName);
-            Assert.NotNull(secret);
-            Assert.NotNull(secret.Value);
-            Assert.NotNull(secret.Version);
+            string appendedKeyName = "Test-" + keyName;
+            AssertNotNullSecret(await provider.GetSecretAsync(appendedKeyName));
+            AssertNotNullSecret(await provider.GetRawSecretAsync(appendedKeyName));
         }
 
         [Fact]
@@ -298,8 +311,10 @@ namespace Arcus.Security.Tests.Integration.KeyVault
             // Assert
             using IHost host = builder.Build();
             var provider = host.Services.GetRequiredService<ISecretProvider>();
-            await Assert.ThrowsAsync<SecretNotFoundException>(
-                () => provider.GetSecretAsync(keyName));
+            Assert.Throws<SecretNotFoundException>(() => provider.GetSecret(keyName));
+            Assert.Throws<SecretNotFoundException>(() => provider.GetRawSecret(keyName));
+            await Assert.ThrowsAsync<SecretNotFoundException>(() => provider.GetSecretAsync(keyName));
+            await Assert.ThrowsAsync<SecretNotFoundException>(() => provider.GetRawSecretAsync(keyName));
         }
 
         [Fact]
@@ -319,16 +334,14 @@ namespace Arcus.Security.Tests.Integration.KeyVault
             using IHost host = builder.Build();
             var provider = host.Services.GetRequiredService<ISecretProvider>();
 
-            Secret secret = await provider.GetSecretAsync(keyName);
-            Assert.NotNull(secret);
-            Assert.NotNull(secret.Value);
-            Assert.NotNull(secret.Version);
+            AssertNotNullSecret(await provider.GetSecretAsync(keyName));
+            AssertNotNullSecret(await provider.GetRawSecretAsync(keyName));
         }
 
         [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
-        public async Task AddAzureKeyVaultWithOptions_WithManagedServiceIdentity_GetSecretSucceeds(bool trackDependency)
+        [InlineData(false, 0)]
+        [InlineData(true, 2)]
+        public async Task AddAzureKeyVaultWithOptions_WithManagedServiceIdentity_GetSecretSucceeds(bool trackDependency, int expectedTrackedDependencies)
         {
             // Arrange
             var keyVaultUri = Configuration.GetValue<string>("Arcus:KeyVault:Uri");
@@ -347,13 +360,11 @@ namespace Arcus.Security.Tests.Integration.KeyVault
             {
                 var provider = host.Services.GetRequiredService<ISecretProvider>();
 
-                Secret secret = await provider.GetSecretAsync(keyName);
-                Assert.NotNull(secret);
-                Assert.NotNull(secret.Value);
-                Assert.NotNull(secret.Version);
+                AssertNotNullSecret(await provider.GetSecretAsync(keyName));
+                AssertNotNullSecret(await provider.GetRawSecretAsync(keyName));
             }
             
-            AssertTrackedAzureKeyVaultDependency(trackDependency);
+            AssertTrackedAzureKeyVaultDependency(expectedTrackedDependencies);
         }
 
         [Fact]
@@ -377,6 +388,7 @@ namespace Arcus.Security.Tests.Integration.KeyVault
             var provider = host.Services.GetRequiredService<ISecretProvider>();
 
             await Assert.ThrowsAsync<SecretNotFoundException>(() => provider.GetSecretAsync(keyName));
+            await Assert.ThrowsAsync<SecretNotFoundException>(() => provider.GetRawSecretAsync(keyName));
         }
 
         [Fact]
@@ -400,10 +412,9 @@ namespace Arcus.Security.Tests.Integration.KeyVault
             using IHost host = builder.Build();
             var provider = host.Services.GetRequiredService<ISecretProvider>();
 
-            Secret secret = await provider.GetSecretAsync("Test-" + keyName);
-            Assert.NotNull(secret);
-            Assert.NotNull(secret.Value);
-            Assert.NotNull(secret.Version);
+            string appendedKeyName = "Test-" + keyName;
+            AssertNotNullSecret(await provider.GetSecretAsync(appendedKeyName));
+            AssertNotNullSecret(await provider.GetRawSecretAsync(appendedKeyName));
         }
 
         [Fact]
@@ -427,8 +438,10 @@ namespace Arcus.Security.Tests.Integration.KeyVault
             using IHost host = builder.Build();
             var provider = host.Services.GetRequiredService<ISecretProvider>();
 
-            await Assert.ThrowsAsync<SecretNotFoundException>(
-                () => provider.GetSecretAsync(keyName));
+            Assert.Throws<SecretNotFoundException>(() => provider.GetSecret(keyName));
+            Assert.Throws<SecretNotFoundException>(() => provider.GetRawSecret(keyName));
+            await Assert.ThrowsAsync<SecretNotFoundException>(() => provider.GetSecretAsync(keyName));
+            await Assert.ThrowsAsync<SecretNotFoundException>(() => provider.GetRawSecretAsync(keyName));
         }
 
         [Fact]
@@ -452,10 +465,8 @@ namespace Arcus.Security.Tests.Integration.KeyVault
             using IHost host = builder.Build();
             var provider = host.Services.GetRequiredService<ISecretProvider>();
 
-            Secret secret = await provider.GetSecretAsync(keyName);
-            Assert.NotNull(secret);
-            Assert.NotNull(secret.Value);
-            Assert.NotNull(secret.Version);
+            AssertNotNullSecret(await provider.GetSecretAsync(keyName));
+            AssertNotNullSecret(await provider.GetRawSecretAsync(keyName));
             Assert.True(cacheConfiguration.IsCalled);
         }
 
@@ -480,8 +491,10 @@ namespace Arcus.Security.Tests.Integration.KeyVault
             using IHost host = builder.Build();
             var provider = host.Services.GetRequiredService<ISecretProvider>();
 
-            await Assert.ThrowsAsync<SecretNotFoundException>(
-                () => provider.GetSecretAsync(keyName));
+            Assert.Throws<SecretNotFoundException>(() => provider.GetSecret(keyName));
+            Assert.Throws<SecretNotFoundException>(() => provider.GetRawSecret(keyName));
+            await Assert.ThrowsAsync<SecretNotFoundException>(() => provider.GetSecretAsync(keyName));
+            await Assert.ThrowsAsync<SecretNotFoundException>(() => provider.GetRawSecretAsync(keyName));
         }
 
         [Fact]
@@ -506,10 +519,9 @@ namespace Arcus.Security.Tests.Integration.KeyVault
             using IHost host = builder.Build();
             var provider = host.Services.GetRequiredService<ISecretProvider>();
 
-            Secret secret = await provider.GetSecretAsync("Test-" + keyName);
-            Assert.NotNull(secret);
-            Assert.NotNull(secret.Value);
-            Assert.NotNull(secret.Version);
+            string appendedKeyName = "Test-" + keyName;
+            AssertNotNullSecret(await provider.GetSecretAsync(appendedKeyName));
+            AssertNotNullSecret(await provider.GetRawSecretAsync(appendedKeyName));
             Assert.True(cacheConfiguration.IsCalled);
         }
 
@@ -535,7 +547,10 @@ namespace Arcus.Security.Tests.Integration.KeyVault
             using IHost host = builder.Build();
             var provider = host.Services.GetRequiredService<ISecretProvider>();
 
+            Assert.Throws<SecretNotFoundException>(() => provider.GetSecret(keyName));
+            Assert.Throws<SecretNotFoundException>(() => provider.GetRawSecret(keyName));
             await Assert.ThrowsAsync<SecretNotFoundException>(() => provider.GetSecretAsync(keyName));
+            await Assert.ThrowsAsync<SecretNotFoundException>(() => provider.GetRawSecretAsync(keyName));
         }
 
         [Fact]
@@ -557,8 +572,11 @@ namespace Arcus.Security.Tests.Integration.KeyVault
            using  IHost host = builder.Build();
             var provider = host.Services.GetRequiredService<ISecretProvider>();
 
-            var exception = await Assert.ThrowsAsync<AdalServiceException>(() => provider.GetSecretAsync(keyName));
-            Assert.Equal("unauthorized_client", exception.ErrorCode);
+            var exceptionFromSecretAsync = await Assert.ThrowsAsync<AdalServiceException>(() => provider.GetSecretAsync(keyName));
+            var exceptionFromRawSecretAsync = await Assert.ThrowsAsync<AdalServiceException>(() => provider.GetRawSecretAsync(keyName));
+            var errorCode = "unauthorized_client";
+            Assert.Equal(errorCode, exceptionFromSecretAsync.ErrorCode);
+            Assert.Equal(errorCode, exceptionFromRawSecretAsync.ErrorCode);
         }
 
         [Fact]
@@ -582,8 +600,10 @@ namespace Arcus.Security.Tests.Integration.KeyVault
             using IHost host = builder.Build();
             var provider = host.Services.GetRequiredService<ISecretProvider>();
 
-            var exception = await Assert.ThrowsAsync<KeyVaultErrorException>(() => provider.GetSecretAsync(keyName));
-            Assert.Equal(HttpStatusCode.Forbidden, exception.Response.StatusCode);
+            var exceptionFromSecretAsync = await Assert.ThrowsAsync<KeyVaultErrorException>(() => provider.GetSecretAsync(keyName));
+            var exceptionFromRawSecretAsync = await Assert.ThrowsAsync<KeyVaultErrorException>(() => provider.GetRawSecretAsync(keyName));
+            Assert.Equal(HttpStatusCode.Forbidden, exceptionFromSecretAsync.Response.StatusCode);
+            Assert.Equal(HttpStatusCode.Forbidden, exceptionFromRawSecretAsync.Response.StatusCode);
         }
         
         [Fact]
@@ -608,10 +628,10 @@ namespace Arcus.Security.Tests.Integration.KeyVault
             using IHost host = builder.Build();
             var provider = host.Services.GetRequiredService<ISecretProvider>();
 
-            Secret secret = await provider.GetSecretAsync(keyName);
-            Assert.NotNull(secret);
-            Assert.NotNull(secret.Value);
-            Assert.NotNull(secret.Version);
+            AssertNotNullSecret(provider.GetSecret(keyName));
+            AssertNotNullSecret(provider.GetRawSecret(keyName));
+            AssertNotNullSecret(await provider.GetSecretAsync(keyName));
+            AssertNotNullSecret(await provider.GetRawSecretAsync(keyName));
         }
 
         [Fact]
@@ -644,16 +664,17 @@ namespace Arcus.Security.Tests.Integration.KeyVault
             using IHost host = builder.Build();
             var provider = host.Services.GetRequiredService<ISecretProvider>();
 
-            Secret secret = await provider.GetSecretAsync(prefix + keyName);
-            Assert.NotNull(secret);
-            Assert.NotNull(secret.Value);
-            Assert.NotNull(secret.Version);
+            string appendedKeyName = "Test-" + keyName;
+            AssertNotNullSecret(provider.GetSecret(appendedKeyName));
+            AssertNotNullSecret(provider.GetRawSecret(appendedKeyName));
+            AssertNotNullSecret(await provider.GetSecretAsync(appendedKeyName));
+            AssertNotNullSecret(await provider.GetRawSecretAsync(appendedKeyName));
         }
 
         [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
-        public async Task AddAzureKeyVaultWithTenantWithDependencyTracking_WithServicePrincipal_GetSecretSucceeds(bool trackDependency)
+        [InlineData(false, 0)]
+        [InlineData(true, 2)]
+        public async Task AddAzureKeyVaultWithTenantWithDependencyTracking_WithServicePrincipal_GetSecretSucceeds(bool trackDependency, int expectedTrackedDependencies)
         {
             // Arrange
             string tenantId = Configuration.GetTenantId();
@@ -677,13 +698,11 @@ namespace Arcus.Security.Tests.Integration.KeyVault
             {
                 var provider = host.Services.GetRequiredService<ISecretProvider>();
 
-                Secret secret = await provider.GetSecretAsync(keyName);
-                Assert.NotNull(secret);
-                Assert.NotNull(secret.Value);
-                Assert.NotNull(secret.Version); 
+                AssertNotNullSecret(await provider.GetSecretAsync(keyName));
+                AssertNotNullSecret(await provider.GetRawSecretAsync(keyName));
             }
 
-            AssertTrackedAzureKeyVaultDependency(trackDependency);
+            AssertTrackedAzureKeyVaultDependency(expectedTrackedDependencies);
         }
 
         [Fact]
@@ -708,13 +727,16 @@ namespace Arcus.Security.Tests.Integration.KeyVault
             using IHost host = builder.Build();
             var provider = host.Services.GetRequiredService<ISecretProvider>();
 
+            Assert.Throws<SecretNotFoundException>(() => provider.GetSecret(keyName));
+            Assert.Throws<SecretNotFoundException>(() => provider.GetRawSecret(keyName));
+            await Assert.ThrowsAsync<SecretNotFoundException>(() => provider.GetSecretAsync(keyName));
             await Assert.ThrowsAsync<SecretNotFoundException>(() => provider.GetSecretAsync(keyName));
         }
 
         [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
-        public async Task AddAzureKeyVaultWithTenantWithDependencyTracking_WithServicePrincipal_GetSecretFails(bool trackDependency)
+        [InlineData(false, 0)]
+        [InlineData(true, 2)]
+        public async Task AddAzureKeyVaultWithTenantWithDependencyTracking_WithServicePrincipal_GetSecretFails(bool trackDependency, int expectedTrackedDependencies)
         {
             // Arrange
             string tenantId = Configuration.GetTenantId();
@@ -738,9 +760,10 @@ namespace Arcus.Security.Tests.Integration.KeyVault
             {
                 var provider = host.Services.GetRequiredService<ISecretProvider>();
                 await Assert.ThrowsAsync<SecretNotFoundException>(() => provider.GetSecretAsync(keyName));
+                await Assert.ThrowsAsync<SecretNotFoundException>(() => provider.GetRawSecretAsync(keyName));
             }
             
-            AssertTrackedAzureKeyVaultDependency(trackDependency);
+            AssertTrackedAzureKeyVaultDependency(expectedTrackedDependencies);
         }
 
         [Fact]
@@ -769,10 +792,11 @@ namespace Arcus.Security.Tests.Integration.KeyVault
             using IHost host = builder.Build();
             var provider = host.Services.GetRequiredService<ISecretProvider>();
 
-            Secret secret = await provider.GetSecretAsync("Test-" + keyName);
-            Assert.NotNull(secret);
-            Assert.NotNull(secret.Value);
-            Assert.NotNull(secret.Version);
+            string appendedKeyName = "Test-" + keyName;
+            AssertNotNullSecret(provider.GetSecret(appendedKeyName));
+            AssertNotNullSecret(provider.GetRawSecret(appendedKeyName));
+            AssertNotNullSecret(await provider.GetSecretAsync(appendedKeyName));
+            AssertNotNullSecret(await provider.GetRawSecretAsync(appendedKeyName));
         }
 
         [Fact]
@@ -801,8 +825,10 @@ namespace Arcus.Security.Tests.Integration.KeyVault
             using IHost host = builder.Build();
             var provider = host.Services.GetRequiredService<ISecretProvider>();
 
-            await Assert.ThrowsAsync<SecretNotFoundException>(
-                () => provider.GetSecretAsync(keyName));
+            Assert.Throws<SecretNotFoundException>(() => provider.GetSecret(keyName));
+            Assert.Throws<SecretNotFoundException>(() => provider.GetRawSecret(keyName));
+            await Assert.ThrowsAsync<SecretNotFoundException>(() => provider.GetSecretAsync(keyName));
+            await Assert.ThrowsAsync<SecretNotFoundException>(() => provider.GetSecretAsync(keyName));
         }
 
         [Fact]
@@ -827,10 +853,10 @@ namespace Arcus.Security.Tests.Integration.KeyVault
             using IHost host = builder.Build();
             var provider = host.Services.GetRequiredService<ISecretProvider>();
 
-            Secret secret = await provider.GetSecretAsync(keyName);
-            Assert.NotNull(secret);
-            Assert.NotNull(secret.Value);
-            Assert.NotNull(secret.Version);
+            AssertNotNullSecret(provider.GetSecret(keyName));
+            AssertNotNullSecret(provider.GetRawSecret(keyName));
+            AssertNotNullSecret(await provider.GetSecretAsync(keyName));
+            AssertNotNullSecret(await provider.GetRawSecretAsync(keyName));
         }
 
         [Fact]
@@ -855,7 +881,10 @@ namespace Arcus.Security.Tests.Integration.KeyVault
             using IHost host = builder.Build();
             var provider = host.Services.GetRequiredService<ISecretProvider>();
 
+            Assert.Throws<SecretNotFoundException>(() => provider.GetSecret(keyName));
+            Assert.Throws<SecretNotFoundException>(() => provider.GetRawSecret(keyName));
             await Assert.ThrowsAsync<SecretNotFoundException>(() => provider.GetSecretAsync(keyName));
+            await Assert.ThrowsAsync<SecretNotFoundException>(() => provider.GetRawSecretAsync(keyName));
         }
 
         [Fact]
@@ -884,10 +913,11 @@ namespace Arcus.Security.Tests.Integration.KeyVault
             using IHost host = builder.Build();
             var provider = host.Services.GetRequiredService<ISecretProvider>();
 
-            Secret secret = await provider.GetSecretAsync("Test-" + keyName);
-            Assert.NotNull(secret);
-            Assert.NotNull(secret.Value);
-            Assert.NotNull(secret.Version);
+            string appendedKeyName = "Test-" + keyName;
+            AssertNotNullSecret(provider.GetSecret(appendedKeyName));
+            AssertNotNullSecret(provider.GetRawSecret(appendedKeyName));
+            AssertNotNullSecret(await provider.GetSecretAsync(appendedKeyName));
+            AssertNotNullSecret(await provider.GetRawSecretAsync(appendedKeyName));
         }
 
         [Fact]
@@ -916,8 +946,10 @@ namespace Arcus.Security.Tests.Integration.KeyVault
             using IHost host = builder.Build();
             var provider = host.Services.GetRequiredService<ISecretProvider>();
 
-            await Assert.ThrowsAsync<SecretNotFoundException>(
-                () => provider.GetSecretAsync(keyName));
+            Assert.Throws<SecretNotFoundException>(() => provider.GetSecret(keyName));
+            Assert.Throws<SecretNotFoundException>(() => provider.GetRawSecret(keyName));
+            await Assert.ThrowsAsync<SecretNotFoundException>(() => provider.GetSecretAsync(keyName));
+            await Assert.ThrowsAsync<SecretNotFoundException>(() => provider.GetRawSecretAsync(keyName));
         }
 
         [Fact]
@@ -943,10 +975,10 @@ namespace Arcus.Security.Tests.Integration.KeyVault
                 using IHost host = builder.Build();
                 var provider = host.Services.GetRequiredService<ISecretProvider>();
 
-                Secret secret = await provider.GetSecretAsync(keyName);
-                Assert.NotNull(secret);
-                Assert.NotNull(secret.Value);
-                Assert.NotNull(secret.Version); 
+                AssertNotNullSecret(provider.GetSecret(keyName));
+                AssertNotNullSecret(provider.GetRawSecret(keyName));
+                AssertNotNullSecret(await provider.GetSecretAsync(keyName));
+                AssertNotNullSecret(await provider.GetRawSecretAsync(keyName));
             }
         }
 
@@ -982,17 +1014,18 @@ namespace Arcus.Security.Tests.Integration.KeyVault
                 using IHost host = builder.Build();
                 var provider = host.Services.GetRequiredService<ISecretProvider>();
 
-                Secret secret = await provider.GetSecretAsync(prefix + keyName);
-                Assert.NotNull(secret);
-                Assert.NotNull(secret.Value);
-                Assert.NotNull(secret.Version); 
+                string appendedKeyName = "Test-" + keyName;
+                AssertNotNullSecret(provider.GetSecret(appendedKeyName));
+                AssertNotNullSecret(provider.GetRawSecret(appendedKeyName));
+                AssertNotNullSecret(await provider.GetSecretAsync(appendedKeyName));
+                AssertNotNullSecret(await provider.GetRawSecretAsync(appendedKeyName));
             }
         }
 
         [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
-        public async Task AddAzureKeyVaultWithDependencyTracking_WithManagedIdentity_GetSecretSucceeds(bool trackDependency)
+        [InlineData(false, 0)]
+        [InlineData(true, 2)]
+        public async Task AddAzureKeyVaultWithDependencyTracking_WithManagedIdentity_GetSecretSucceeds(bool trackDependency, int expectedTrackedDependencies)
         {
             // Arrange
             var keyVaultUri = Configuration.GetValue<string>("Arcus:KeyVault:Uri");
@@ -1018,13 +1051,11 @@ namespace Arcus.Security.Tests.Integration.KeyVault
             {
                 var provider = host.Services.GetRequiredService<ISecretProvider>();
 
-                Secret secret = await provider.GetSecretAsync(keyName);
-                Assert.NotNull(secret);
-                Assert.NotNull(secret.Value);
-                Assert.NotNull(secret.Version);
+                AssertNotNullSecret(await provider.GetSecretAsync(keyName));
+                AssertNotNullSecret(await provider.GetRawSecretAsync(keyName));
             }
 
-            AssertTrackedAzureKeyVaultDependency(trackDependency);
+            AssertTrackedAzureKeyVaultDependency(expectedTrackedDependencies);
         }
 
         [Fact]
@@ -1057,10 +1088,11 @@ namespace Arcus.Security.Tests.Integration.KeyVault
                 using IHost host = builder.Build();
                 var provider = host.Services.GetRequiredService<ISecretProvider>();
 
-                Secret secret = await provider.GetSecretAsync("Test-" + keyName);
-                Assert.NotNull(secret);
-                Assert.NotNull(secret.Value);
-                Assert.NotNull(secret.Version); 
+                string appendedKeyName = "Test-" + keyName;
+                AssertNotNullSecret(provider.GetSecret(appendedKeyName));
+                AssertNotNullSecret(provider.GetRawSecret(appendedKeyName));
+                AssertNotNullSecret(await provider.GetSecretAsync(appendedKeyName));
+                AssertNotNullSecret(await provider.GetRawSecretAsync(appendedKeyName));
             }
         }
 
@@ -1094,15 +1126,17 @@ namespace Arcus.Security.Tests.Integration.KeyVault
                 using IHost host = builder.Build();
                 var provider = host.Services.GetRequiredService<ISecretProvider>();
 
-                await Assert.ThrowsAsync<SecretNotFoundException>(
-                    () => provider.GetSecretAsync(keyName)); 
+                Assert.Throws<SecretNotFoundException>(() => provider.GetSecret(keyName));
+                Assert.Throws<SecretNotFoundException>(() => provider.GetRawSecret(keyName));
+                await Assert.ThrowsAsync<SecretNotFoundException>(() => provider.GetSecretAsync(keyName));
+                await Assert.ThrowsAsync<SecretNotFoundException>(() => provider.GetRawSecretAsync(keyName));
             }
         }
 
         [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
-        public async Task AddAzureKeyVaultWithDependencyTracking_WithManagedIdentityWrongMutation_GetsSecretFails(bool trackDependency)
+        [InlineData(false, 0)]
+        [InlineData(true, 2)]
+        public async Task AddAzureKeyVaultWithDependencyTracking_WithManagedIdentityWrongMutation_GetsSecretFails(bool trackDependency, int expectedTrackedDependencies)
         {
             // Arrange
             var keyVaultUri = Configuration.GetValue<string>("Arcus:KeyVault:Uri");
@@ -1132,12 +1166,12 @@ namespace Arcus.Security.Tests.Integration.KeyVault
                 using (IHost host = builder.Build())
                 {
                     var provider = host.Services.GetRequiredService<ISecretProvider>();
-                    await Assert.ThrowsAsync<SecretNotFoundException>(
-                        () => provider.GetSecretAsync(keyName)); 
+                    await Assert.ThrowsAsync<SecretNotFoundException>(() => provider.GetSecretAsync(keyName));
+                    await Assert.ThrowsAsync<SecretNotFoundException>(() => provider.GetRawSecretAsync(keyName));
                 }
             }
 
-            AssertTrackedAzureKeyVaultDependency(trackDependency);
+            AssertTrackedAzureKeyVaultDependency(expectedTrackedDependencies);
         }
 
         [Fact]
@@ -1167,10 +1201,10 @@ namespace Arcus.Security.Tests.Integration.KeyVault
                 using IHost host = builder.Build();
                 var provider = host.Services.GetRequiredService<ISecretProvider>();
 
-                Secret secret = await provider.GetSecretAsync(keyName);
-                Assert.NotNull(secret);
-                Assert.NotNull(secret.Value);
-                Assert.NotNull(secret.Version);
+                AssertNotNullSecret(provider.GetSecret(keyName));
+                AssertNotNullSecret(provider.GetRawSecret(keyName));
+                AssertNotNullSecret(await provider.GetSecretAsync(keyName));
+                AssertNotNullSecret(await provider.GetRawSecretAsync(keyName));
                 Assert.True(cacheConfiguration.IsCalled); 
             }
         }
@@ -1202,8 +1236,10 @@ namespace Arcus.Security.Tests.Integration.KeyVault
                 using IHost host = builder.Build();
                 var provider = host.Services.GetRequiredService<ISecretProvider>();
 
-                await Assert.ThrowsAsync<SecretNotFoundException>(
-                    () => provider.GetSecretAsync(keyName)); 
+                Assert.Throws<SecretNotFoundException>(() => provider.GetSecret(keyName));
+                Assert.Throws<SecretNotFoundException>(() => provider.GetRawSecret(keyName));
+                await Assert.ThrowsAsync<SecretNotFoundException>(() => provider.GetSecretAsync(keyName));
+                await Assert.ThrowsAsync<SecretNotFoundException>(() => provider.GetRawSecretAsync(keyName));
             }
         }
 
@@ -1238,10 +1274,11 @@ namespace Arcus.Security.Tests.Integration.KeyVault
                 using IHost host = builder.Build();
                 var provider = host.Services.GetRequiredService<ISecretProvider>();
 
-                Secret secret = await provider.GetSecretAsync("Test-" + keyName);
-                Assert.NotNull(secret);
-                Assert.NotNull(secret.Value);
-                Assert.NotNull(secret.Version);
+                string appendedKeyName = "Test-" + keyName;
+                AssertNotNullSecret(provider.GetSecret(appendedKeyName));
+                AssertNotNullSecret(provider.GetRawSecret(appendedKeyName));
+                AssertNotNullSecret(await provider.GetSecretAsync(appendedKeyName));
+                AssertNotNullSecret(await provider.GetRawSecretAsync(appendedKeyName));
                 Assert.True(cacheConfiguration.IsCalled); 
             }
         }
@@ -1277,7 +1314,10 @@ namespace Arcus.Security.Tests.Integration.KeyVault
                 using IHost host = builder.Build();
                 var provider = host.Services.GetRequiredService<ISecretProvider>();
 
-                await Assert.ThrowsAsync<SecretNotFoundException>(() => provider.GetSecretAsync(keyName)); 
+                Assert.Throws<SecretNotFoundException>(() => provider.GetSecret(keyName));
+                Assert.Throws<SecretNotFoundException>(() => provider.GetRawSecret(keyName));
+                await Assert.ThrowsAsync<SecretNotFoundException>(() => provider.GetSecretAsync(keyName));
+                await Assert.ThrowsAsync<SecretNotFoundException>(() => provider.GetRawSecretAsync(keyName));
             }
         }
 
@@ -1301,7 +1341,10 @@ namespace Arcus.Security.Tests.Integration.KeyVault
             using IHost host = builder.Build();
             var provider = host.Services.GetRequiredService<ISecretProvider>();
 
+            Assert.Throws<AuthenticationFailedException>(() => provider.GetSecret(keyName));
+            Assert.Throws<AuthenticationFailedException>(() => provider.GetRawSecret(keyName));
             await Assert.ThrowsAsync<AuthenticationFailedException>(() => provider.GetSecretAsync(keyName));
+            await Assert.ThrowsAsync<AuthenticationFailedException>(() => provider.GetRawSecretAsync(keyName));
         }
 
         [Fact]
@@ -1327,13 +1370,18 @@ namespace Arcus.Security.Tests.Integration.KeyVault
             using IHost host = builder.Build();
             var provider = host.Services.GetRequiredService<ISecretProvider>();
 
-            var exception = await Assert.ThrowsAsync<RequestFailedException>(() => provider.GetSecretAsync(keyName));
-            Assert.Equal((int) HttpStatusCode.Forbidden, exception.Status);
+            var exceptionFromSecretSync = Assert.Throws<RequestFailedException>(() => provider.GetSecret(keyName));
+            var exceptionFromRawSecretSync = Assert.Throws<RequestFailedException>(() => provider.GetRawSecret(keyName));
+            var exceptionFromSecretAsync = await Assert.ThrowsAsync<RequestFailedException>(() => provider.GetSecretAsync(keyName));
+            var exceptionFromRawSecretAsync = await Assert.ThrowsAsync<RequestFailedException>(() => provider.GetRawSecretAsync(keyName));
+            Assert.Equal((int) HttpStatusCode.Forbidden, exceptionFromSecretSync.Status);
+            Assert.Equal((int) HttpStatusCode.Forbidden, exceptionFromRawSecretSync.Status);
+            Assert.Equal((int) HttpStatusCode.Forbidden, exceptionFromSecretAsync.Status);
+            Assert.Equal((int) HttpStatusCode.Forbidden, exceptionFromRawSecretAsync.Status);
         }
 
-        private void AssertTrackedAzureKeyVaultDependency(bool trackDependency)
+        private void AssertTrackedAzureKeyVaultDependency(int expectedTrackedDependencyCount)
         {
-            var expectedTrackedDependencyCount = Convert.ToInt16(trackDependency);
             int actualTrackedDependencyCount = InMemoryLogSink.LogEvents.Count(ev => ev.MessageTemplate.Text.Contains("Dependency"));
 
             Assert.Equal(expectedTrackedDependencyCount, actualTrackedDependencyCount);

--- a/src/Arcus.Security.Tests.Integration/UserSecrets/SecretStoreBuilderExtensionsTests.cs
+++ b/src/Arcus.Security.Tests.Integration/UserSecrets/SecretStoreBuilderExtensionsTests.cs
@@ -52,8 +52,10 @@ namespace Arcus.Security.Tests.Integration.UserSecrets
             IHost host = hostBuilder.Build();
             var secretProvider = host.Services.GetRequiredService<ISecretProvider>();
 
-            string actualValue = await secretProvider.GetRawSecretAsync(secretKey);
-            Assert.Equal(expectedValue, actualValue);
+            Assert.Equal(expectedValue, secretProvider.GetRawSecret(secretKey));
+            Assert.Equal(expectedValue, secretProvider.GetSecret(secretKey).Value);
+            Assert.Equal(expectedValue, await secretProvider.GetRawSecretAsync(secretKey));
+            Assert.Equal(expectedValue, (await secretProvider.GetSecretAsync(secretKey)).Value);
         }
 
         [Fact]
@@ -73,8 +75,10 @@ namespace Arcus.Security.Tests.Integration.UserSecrets
             IHost host = hostBuilder.Build();
             var secretProvider = host.Services.GetRequiredService<ISecretProvider>();
 
-            string actualValue = await secretProvider.GetRawSecretAsync(secretKey);
-            Assert.Equal(expectedValue, actualValue);
+            Assert.Equal(expectedValue, secretProvider.GetRawSecret(secretKey));
+            Assert.Equal(expectedValue, secretProvider.GetSecret(secretKey).Value);
+            Assert.Equal(expectedValue, await secretProvider.GetRawSecretAsync(secretKey));
+            Assert.Equal(expectedValue, (await secretProvider.GetSecretAsync(secretKey)).Value);
         }
 
         [Fact]
@@ -95,8 +99,10 @@ namespace Arcus.Security.Tests.Integration.UserSecrets
             IHost host = hostBuilder.Build();
             var secretProvider = host.Services.GetRequiredService<ISecretProvider>();
 
-            await Assert.ThrowsAsync<SecretNotFoundException>(
-                () => secretProvider.GetRawSecretAsync(secretKey));
+            Assert.Throws<SecretNotFoundException>(() => secretProvider.GetRawSecret(secretKey));
+            Assert.Throws<SecretNotFoundException>(() => secretProvider.GetSecret(secretKey));
+            await Assert.ThrowsAsync<SecretNotFoundException>(() => secretProvider.GetRawSecretAsync(secretKey));
+            await Assert.ThrowsAsync<SecretNotFoundException>(() => secretProvider.GetSecretAsync(secretKey));
         }
 
         [Fact]
@@ -120,8 +126,10 @@ namespace Arcus.Security.Tests.Integration.UserSecrets
             IHost host = hostBuilder.Build();
             var secretProvider = host.Services.GetRequiredService<ISecretProvider>();
 
-            await Assert.ThrowsAsync<SecretNotFoundException>(
-                () => secretProvider.GetRawSecretAsync(secretKey));
+            Assert.Throws<SecretNotFoundException>(() => secretProvider.GetRawSecret(secretKey));
+            Assert.Throws<SecretNotFoundException>(() => secretProvider.GetSecret(secretKey));
+            await Assert.ThrowsAsync<SecretNotFoundException>(() => secretProvider.GetRawSecretAsync(secretKey));
+            await Assert.ThrowsAsync<SecretNotFoundException>(() => secretProvider.GetSecretAsync(secretKey));
         }
 
         [Fact]
@@ -144,8 +152,10 @@ namespace Arcus.Security.Tests.Integration.UserSecrets
             IHost host = hostBuilder.Build();
             var secretProvider = host.Services.GetRequiredService<ISecretProvider>();
 
-            string actualValue = await secretProvider.GetRawSecretAsync("My.Dummy.Setting");
-            Assert.Equal(expectedValue, actualValue);
+            Assert.Equal(expectedValue, secretProvider.GetRawSecret("My.Dummy.Setting"));
+            Assert.Equal(expectedValue, secretProvider.GetSecret("My.Dummy.Setting").Value);
+            Assert.Equal(expectedValue, await secretProvider.GetRawSecretAsync("My.Dummy.Setting"));
+            Assert.Equal(expectedValue, (await secretProvider.GetSecretAsync("My.Dummy.Setting")).Value);
         }
 
         [Fact]
@@ -168,8 +178,10 @@ namespace Arcus.Security.Tests.Integration.UserSecrets
             IHost host = hostBuilder.Build();
             var secretProvider = host.Services.GetRequiredService<ISecretProvider>();
 
-            string actualValue = await secretProvider.GetRawSecretAsync("My.Dummy.Setting");
-            Assert.Equal(expectedValue, actualValue);
+            Assert.Equal(expectedValue, secretProvider.GetRawSecret("My.Dummy.Setting"));
+            Assert.Equal(expectedValue, secretProvider.GetSecret("My.Dummy.Setting").Value);
+            Assert.Equal(expectedValue, await secretProvider.GetRawSecretAsync("My.Dummy.Setting"));
+            Assert.Equal(expectedValue, (await secretProvider.GetSecretAsync("My.Dummy.Setting")).Value);
         }
 
         [Fact]
@@ -192,8 +204,10 @@ namespace Arcus.Security.Tests.Integration.UserSecrets
             IHost host = hostBuilder.Build();
             var secretProvider = host.Services.GetRequiredService<ISecretProvider>();
 
-            await Assert.ThrowsAsync<SecretNotFoundException>(
-                () => secretProvider.GetRawSecretAsync(secretKey));
+            Assert.Throws<SecretNotFoundException>(() => secretProvider.GetRawSecret(secretKey));
+            Assert.Throws<SecretNotFoundException>(() => secretProvider.GetSecret(secretKey));
+            await Assert.ThrowsAsync<SecretNotFoundException>(() => secretProvider.GetRawSecretAsync(secretKey));
+            await Assert.ThrowsAsync<SecretNotFoundException>(() => secretProvider.GetSecretAsync(secretKey));
         }
 
         [Fact]
@@ -216,8 +230,10 @@ namespace Arcus.Security.Tests.Integration.UserSecrets
             IHost host = hostBuilder.Build();
             var secretProvider = host.Services.GetRequiredService<ISecretProvider>();
 
-            await Assert.ThrowsAsync<SecretNotFoundException>(
-                () => secretProvider.GetRawSecretAsync(secretKey));
+            Assert.Throws<SecretNotFoundException>(() => secretProvider.GetRawSecret(secretKey));
+            Assert.Throws<SecretNotFoundException>(() => secretProvider.GetSecret(secretKey));
+            await Assert.ThrowsAsync<SecretNotFoundException>(() => secretProvider.GetRawSecretAsync(secretKey));
+            await Assert.ThrowsAsync<SecretNotFoundException>(() => secretProvider.GetSecretAsync(secretKey));
         }
 
         [Fact]
@@ -238,8 +254,10 @@ namespace Arcus.Security.Tests.Integration.UserSecrets
             IHost host = hostBuilder.Build();
             var secretProvider = host.Services.GetRequiredService<ISecretProvider>();
 
-            string actualValue = await secretProvider.GetRawSecretAsync(secretKey);
-            Assert.Equal(expectedValue, actualValue);
+            Assert.Equal(expectedValue, secretProvider.GetRawSecret(secretKey));
+            Assert.Equal(expectedValue, secretProvider.GetSecret(secretKey).Value);
+            Assert.Equal(expectedValue, await secretProvider.GetRawSecretAsync(secretKey));
+            Assert.Equal(expectedValue, (await secretProvider.GetSecretAsync(secretKey)).Value);
         }
 
         [Fact]
@@ -278,8 +296,10 @@ namespace Arcus.Security.Tests.Integration.UserSecrets
             IHost host = hostBuilder.Build();
             var secretProvider = host.Services.GetRequiredService<ISecretProvider>();
 
-            await Assert.ThrowsAsync<SecretNotFoundException>(
-                () => secretProvider.GetRawSecretAsync(secretKey));
+            Assert.Throws<SecretNotFoundException>(() => secretProvider.GetRawSecret(secretKey));
+            Assert.Throws<SecretNotFoundException>(() => secretProvider.GetSecret(secretKey));
+            await Assert.ThrowsAsync<SecretNotFoundException>(() => secretProvider.GetRawSecretAsync(secretKey));
+            await Assert.ThrowsAsync<SecretNotFoundException>(() => secretProvider.GetSecretAsync(secretKey));
         }
 
         [Fact]
@@ -303,8 +323,10 @@ namespace Arcus.Security.Tests.Integration.UserSecrets
             IHost host = hostBuilder.Build();
             var secretProvider = host.Services.GetRequiredService<ISecretProvider>();
 
-            string actualValue = await secretProvider.GetRawSecretAsync("My.Dummy.Setting");
-            Assert.Equal(expectedValue, actualValue);
+            Assert.Equal(expectedValue, secretProvider.GetRawSecret("My.Dummy.Setting"));
+            Assert.Equal(expectedValue, secretProvider.GetSecret("My.Dummy.Setting").Value);
+            Assert.Equal(expectedValue, await secretProvider.GetRawSecretAsync("My.Dummy.Setting"));
+            Assert.Equal(expectedValue, (await secretProvider.GetSecretAsync("My.Dummy.Setting")).Value);
         }
 
         [Fact]
@@ -328,8 +350,10 @@ namespace Arcus.Security.Tests.Integration.UserSecrets
             IHost host = hostBuilder.Build();
             var secretProvider = host.Services.GetRequiredService<ISecretProvider>();
 
-            string actualValue = await secretProvider.GetRawSecretAsync("My.Dummy.Setting");
-            Assert.Equal(expectedValue, actualValue);
+            Assert.Equal(expectedValue, secretProvider.GetRawSecret("My.Dummy.Setting"));
+            Assert.Equal(expectedValue, secretProvider.GetSecret("My.Dummy.Setting").Value);
+            Assert.Equal(expectedValue, await secretProvider.GetRawSecretAsync("My.Dummy.Setting"));
+            Assert.Equal(expectedValue, (await secretProvider.GetSecretAsync("My.Dummy.Setting")).Value);
         }
 
         [Fact]
@@ -353,8 +377,10 @@ namespace Arcus.Security.Tests.Integration.UserSecrets
             IHost host = hostBuilder.Build();
             var secretProvider = host.Services.GetRequiredService<ISecretProvider>();
 
-            await Assert.ThrowsAsync<SecretNotFoundException>(
-                () => secretProvider.GetRawSecretAsync(secretKey));
+            Assert.Throws<SecretNotFoundException>(() => secretProvider.GetRawSecret(secretKey));
+            Assert.Throws<SecretNotFoundException>(() => secretProvider.GetSecret(secretKey));
+            await Assert.ThrowsAsync<SecretNotFoundException>(() => secretProvider.GetRawSecretAsync(secretKey));
+            await Assert.ThrowsAsync<SecretNotFoundException>(() => secretProvider.GetSecretAsync(secretKey));
         }
 
         [Fact]
@@ -374,8 +400,10 @@ namespace Arcus.Security.Tests.Integration.UserSecrets
             IHost host = hostBuilder.Build();
             var secretProvider = host.Services.GetRequiredService<ISecretProvider>();
 
-            string actualValue = await secretProvider.GetRawSecretAsync(secretKey);
-            Assert.Equal(expectedValue, actualValue);
+            Assert.Equal(expectedValue, secretProvider.GetRawSecret(secretKey));
+            Assert.Equal(expectedValue, secretProvider.GetSecret(secretKey).Value);
+            Assert.Equal(expectedValue, await secretProvider.GetRawSecretAsync(secretKey));
+            Assert.Equal(expectedValue, (await secretProvider.GetSecretAsync(secretKey)).Value);
         }
 
         [Fact]
@@ -398,8 +426,10 @@ namespace Arcus.Security.Tests.Integration.UserSecrets
             IHost host = hostBuilder.Build();
             var secretProvider = host.Services.GetRequiredService<ISecretProvider>();
 
-            string actualValue = await secretProvider.GetRawSecretAsync(secretKey);
-            Assert.Equal(expectedValue, actualValue);
+            Assert.Equal(expectedValue, secretProvider.GetRawSecret(secretKey));
+            Assert.Equal(expectedValue, secretProvider.GetSecret(secretKey).Value);
+            Assert.Equal(expectedValue, await secretProvider.GetRawSecretAsync(secretKey));
+            Assert.Equal(expectedValue, (await secretProvider.GetSecretAsync(secretKey)).Value);
         }
 
         [Fact]
@@ -436,8 +466,10 @@ namespace Arcus.Security.Tests.Integration.UserSecrets
             IHost host = hostBuilder.Build();
             var secretProvider = host.Services.GetRequiredService<ISecretProvider>();
 
-            await Assert.ThrowsAsync<SecretNotFoundException>(
-                () => secretProvider.GetRawSecretAsync(secretKey));
+            Assert.Throws<SecretNotFoundException>(() => secretProvider.GetRawSecret(secretKey));
+            Assert.Throws<SecretNotFoundException>(() => secretProvider.GetSecret(secretKey));
+            await Assert.ThrowsAsync<SecretNotFoundException>(() => secretProvider.GetRawSecretAsync(secretKey));
+            await Assert.ThrowsAsync<SecretNotFoundException>(() => secretProvider.GetSecretAsync(secretKey));
         }
 
         [Fact]
@@ -460,8 +492,10 @@ namespace Arcus.Security.Tests.Integration.UserSecrets
             IHost host = hostBuilder.Build();
             var secretProvider = host.Services.GetRequiredService<ISecretProvider>();
 
-            string actualValue = await secretProvider.GetRawSecretAsync("My.Dummy.Setting");
-            Assert.Equal(expectedValue, actualValue);
+            Assert.Equal(expectedValue, secretProvider.GetRawSecret("My.Dummy.Setting"));
+            Assert.Equal(expectedValue, secretProvider.GetSecret("My.Dummy.Setting").Value);
+            Assert.Equal(expectedValue, await secretProvider.GetRawSecretAsync("My.Dummy.Setting"));
+            Assert.Equal(expectedValue, (await secretProvider.GetSecretAsync("My.Dummy.Setting")).Value);
         }
 
         [Fact]
@@ -484,8 +518,10 @@ namespace Arcus.Security.Tests.Integration.UserSecrets
             IHost host = hostBuilder.Build();
             var secretProvider = host.Services.GetRequiredService<ISecretProvider>();
 
-            string actualValue = await secretProvider.GetRawSecretAsync("My.Dummy.Setting");
-            Assert.Equal(expectedValue, actualValue);
+            Assert.Equal(expectedValue, secretProvider.GetRawSecret("My.Dummy.Setting"));
+            Assert.Equal(expectedValue, secretProvider.GetSecret("My.Dummy.Setting").Value);
+            Assert.Equal(expectedValue, await secretProvider.GetRawSecretAsync("My.Dummy.Setting"));
+            Assert.Equal(expectedValue, (await secretProvider.GetSecretAsync("My.Dummy.Setting")).Value);
         }
 
         [Fact]
@@ -508,8 +544,10 @@ namespace Arcus.Security.Tests.Integration.UserSecrets
             IHost host = hostBuilder.Build();
             var secretProvider = host.Services.GetRequiredService<ISecretProvider>();
 
-            await Assert.ThrowsAsync<SecretNotFoundException>(
-                () => secretProvider.GetRawSecretAsync(secretKey));
+            Assert.Throws<SecretNotFoundException>(() => secretProvider.GetRawSecret(secretKey));
+            Assert.Throws<SecretNotFoundException>(() => secretProvider.GetSecret(secretKey));
+            await Assert.ThrowsAsync<SecretNotFoundException>(() => secretProvider.GetRawSecretAsync(secretKey));
+            await Assert.ThrowsAsync<SecretNotFoundException>(() => secretProvider.GetSecretAsync(secretKey));
         }
 
         [Fact]
@@ -532,8 +570,10 @@ namespace Arcus.Security.Tests.Integration.UserSecrets
             IHost host = hostBuilder.Build();
             var secretProvider = host.Services.GetRequiredService<ISecretProvider>();
 
-            await Assert.ThrowsAsync<SecretNotFoundException>(
-                () => secretProvider.GetRawSecretAsync(secretKey));
+            Assert.Throws<SecretNotFoundException>(() => secretProvider.GetRawSecret(secretKey));
+            Assert.Throws<SecretNotFoundException>(() => secretProvider.GetSecret(secretKey));
+            await Assert.ThrowsAsync<SecretNotFoundException>(() => secretProvider.GetRawSecretAsync(secretKey));
+            await Assert.ThrowsAsync<SecretNotFoundException>(() => secretProvider.GetSecretAsync(secretKey));
         }
 
         private void SetSecret(string id, string key, string value)

--- a/src/Arcus.Security.Tests.Unit/CommandLine/SecretStoreBuilderExtensionsTests.cs
+++ b/src/Arcus.Security.Tests.Unit/CommandLine/SecretStoreBuilderExtensionsTests.cs
@@ -24,9 +24,11 @@ namespace Arcus.Security.Tests.Unit.CommandLine
             using (IHost host = builder.Build())
             {
                 var provider = host.Services.GetRequiredService<ISecretProvider>();
-                string actual = await provider.GetRawSecretAsync(secretName);
-                
-                Assert.Equal(expected, actual);
+
+                Assert.Equal(expected, provider.GetRawSecret(secretName));
+                Assert.Equal(expected, provider.GetSecret(secretName).Value);
+                Assert.Equal(expected, await provider.GetRawSecretAsync(secretName));
+                Assert.Equal(expected, (await provider.GetSecretAsync(secretName)).Value);
             }
         }
         

--- a/src/Arcus.Security.Tests.Unit/Core/EnvironmentVariableSecretProviderTests.cs
+++ b/src/Arcus.Security.Tests.Unit/Core/EnvironmentVariableSecretProviderTests.cs
@@ -29,8 +29,10 @@ namespace Arcus.Security.Tests.Unit.Core
                 IHost host = builder.Build();
                 var provider = host.Services.GetRequiredService<ISecretProvider>();
 
-                string actual = await provider.GetRawSecretAsync(secretKey);
-                Assert.Equal(expected, actual);
+                Assert.Equal(expected, provider.GetRawSecret(secretKey));
+                Assert.Equal(expected, provider.GetSecret(secretKey).Value);
+                Assert.Equal(expected, await provider.GetRawSecretAsync(secretKey));
+                Assert.Equal(expected, (await provider.GetSecretAsync(secretKey)).Value);
             }
         }
 
@@ -55,8 +57,10 @@ namespace Arcus.Security.Tests.Unit.Core
                 IHost host = builder.Build();
                 var provider = host.Services.GetRequiredService<ISecretProvider>();
 
-                string actual = await provider.GetRawSecretAsync(secretKey);
-                Assert.Equal(expected, actual);
+                Assert.Equal(expected, provider.GetRawSecret(secretKey));
+                Assert.Equal(expected, provider.GetSecret(secretKey).Value);
+                Assert.Equal(expected, await provider.GetRawSecretAsync(secretKey));
+                Assert.Equal(expected, (await provider.GetSecretAsync(secretKey)).Value);
             }
         }
 
@@ -80,8 +84,10 @@ namespace Arcus.Security.Tests.Unit.Core
                 var provider = host.Services.GetRequiredService<ISecretProvider>();
 
                 string nonPrefixedSecret = secretKey.Substring(prefix.Length);
-                string actual = await provider.GetRawSecretAsync(nonPrefixedSecret);
-                Assert.Equal(expected, actual);
+                Assert.Equal(expected, provider.GetRawSecret(nonPrefixedSecret));
+                Assert.Equal(expected, provider.GetSecret(nonPrefixedSecret).Value);
+                Assert.Equal(expected, await provider.GetRawSecretAsync(nonPrefixedSecret));
+                Assert.Equal(expected, (await provider.GetSecretAsync(nonPrefixedSecret)).Value);
             }
         }
 
@@ -105,8 +111,10 @@ namespace Arcus.Security.Tests.Unit.Core
                 var provider = host.Services.GetRequiredService<ISecretProvider>();
 
                 string nonPrefixedSecret = secretKey.Substring(prefix.Length);
-                string actual = await provider.GetRawSecretAsync(nonPrefixedSecret);
-                Assert.Equal(expected, actual);
+                Assert.Equal(expected, provider.GetRawSecret(nonPrefixedSecret));
+                Assert.Equal(expected, provider.GetSecret(nonPrefixedSecret).Value);
+                Assert.Equal(expected, await provider.GetRawSecretAsync(nonPrefixedSecret));
+                Assert.Equal(expected, (await provider.GetSecretAsync(nonPrefixedSecret)).Value);
             }
         }
 
@@ -176,8 +184,11 @@ namespace Arcus.Security.Tests.Unit.Core
                 IHost host = builder.Build();
                 var provider = host.Services.GetRequiredService<ISecretProvider>();
 
-                string actual = await provider.GetRawSecretAsync("Arcus.Environment.Secret");
-                Assert.Equal(expected, actual);
+                string secretName = "Arcus.Environment.Secret";
+                Assert.Equal(expected, provider.GetRawSecret(secretName));
+                Assert.Equal(expected, provider.GetSecret(secretName).Value);
+                Assert.Equal(expected, await provider.GetRawSecretAsync(secretName));
+                Assert.Equal(expected, (await provider.GetSecretAsync(secretName)).Value);
             }
         }
 
@@ -200,8 +211,11 @@ namespace Arcus.Security.Tests.Unit.Core
                 IHost host = builder.Build();
                 var provider = host.Services.GetRequiredService<ISecretProvider>();
 
-                string actual = await provider.GetRawSecretAsync("Arcus.Environment.Secret");
-                Assert.Equal(expected, actual);
+                string secretName = "Arcus.Environment.Secret";
+                Assert.Equal(expected, provider.GetRawSecret(secretName));
+                Assert.Equal(expected, provider.GetSecret(secretName).Value);
+                Assert.Equal(expected, await provider.GetRawSecretAsync(secretName));
+                Assert.Equal(expected, (await provider.GetSecretAsync(secretName)).Value);
             }
         }
 
@@ -211,7 +225,8 @@ namespace Arcus.Security.Tests.Unit.Core
             // Arrange
             var builder = new HostBuilder();
 
-            using (TemporaryEnvironmentVariable.Create("ARCUS_ENVIRONMENT_SECRET", Guid.NewGuid().ToString()))
+            var secretName = "ARCUS_ENVIRONMENT_SECRET";
+            using (TemporaryEnvironmentVariable.Create(secretName, Guid.NewGuid().ToString()))
             {
                 // Act
                 builder.ConfigureSecretStore((config, stores) =>
@@ -223,7 +238,10 @@ namespace Arcus.Security.Tests.Unit.Core
                 IHost host = builder.Build();
                 var provider = host.Services.GetRequiredService<ISecretProvider>();
 
-                await Assert.ThrowsAsync<SecretNotFoundException>(() => provider.GetSecretAsync("ARCUS_ENVIRONMENT_SECRET"));
+                Assert.Throws<SecretNotFoundException>(() => provider.GetSecret(secretName));
+                Assert.Throws<SecretNotFoundException>(() => provider.GetRawSecret(secretName));
+                await Assert.ThrowsAsync<SecretNotFoundException>(() => provider.GetSecretAsync(secretName));
+                await Assert.ThrowsAsync<SecretNotFoundException>(() => provider.GetRawSecretAsync(secretName));
             }
         }
 
@@ -233,7 +251,8 @@ namespace Arcus.Security.Tests.Unit.Core
             // Arrange
             var builder = new HostBuilder();
 
-            using (TemporaryEnvironmentVariable.Create("ARCUS_ENVIRONMENT_SECRET", Guid.NewGuid().ToString()))
+            var secretName = "ARCUS_ENVIRONMENT_SECRET";
+            using (TemporaryEnvironmentVariable.Create(secretName, Guid.NewGuid().ToString()))
             {
                 // Act
                 builder.ConfigureSecretStore((config, stores) =>
@@ -245,7 +264,10 @@ namespace Arcus.Security.Tests.Unit.Core
                 IHost host = builder.Build();
                 var provider = host.Services.GetRequiredService<ISecretProvider>();
 
-                await Assert.ThrowsAsync<SecretNotFoundException>(() => provider.GetSecretAsync("ARCUS_ENVIRONMENT_SECRET"));
+                Assert.Throws<SecretNotFoundException>(() => provider.GetSecret(secretName));
+                Assert.Throws<SecretNotFoundException>(() => provider.GetRawSecret(secretName));
+                await Assert.ThrowsAsync<SecretNotFoundException>(() => provider.GetSecretAsync(secretName));
+                await Assert.ThrowsAsync<SecretNotFoundException>(() => provider.GetRawSecretAsync(secretName));
             }
         }
 
@@ -295,10 +317,8 @@ namespace Arcus.Security.Tests.Unit.Core
         }
 
         [Theory]
-        [InlineData(null)]
-        [InlineData("")]
-        [InlineData("  ")]
-        public async Task GetSecret_WithoutSecretName_Throws(string secretName)
+        [ClassData(typeof(Blanks))]
+        public async Task GetSecretAsnc_WithoutSecretName_Throws(string secretName)
         {
             // Arrange
             var provider = new EnvironmentVariableSecretProvider();
@@ -308,16 +328,36 @@ namespace Arcus.Security.Tests.Unit.Core
         }
 
         [Theory]
-        [InlineData(null)]
-        [InlineData("")]
-        [InlineData("  ")]
-        public async Task GetRawSecret_WithoutSecretName_Throws(string secretName)
+        [ClassData(typeof(Blanks))]
+        public async Task GetRawSecretAsync_WithoutSecretName_Throws(string secretName)
         {
             // Arrange
             var provider = new EnvironmentVariableSecretProvider();
 
             // Act / Assert
             await Assert.ThrowsAnyAsync<ArgumentException>(() => provider.GetRawSecretAsync(secretName));
+        }
+
+        [Theory]
+        [ClassData(typeof(Blanks))]
+        public void GetSecret_WithoutSecretName_Throws(string secretName)
+        {
+            // Arrange
+            var provider = new EnvironmentVariableSecretProvider();
+
+            // Act / Assert
+            Assert.ThrowsAny<ArgumentException>(() => provider.GetSecret(secretName));
+        }
+
+        [Theory]
+        [ClassData(typeof(Blanks))]
+        public void GetRawSecret_WithoutSecretName_Throws(string secretName)
+        {
+            // Arrange
+            var provider = new EnvironmentVariableSecretProvider();
+
+            // Act / Assert
+            Assert.ThrowsAny<ArgumentException>(() => provider.GetRawSecret(secretName));
         }
         
         [Fact]

--- a/src/Arcus.Security.Tests.Unit/Core/Stubs/AsyncStaticSecretProvider.cs
+++ b/src/Arcus.Security.Tests.Unit/Core/Stubs/AsyncStaticSecretProvider.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Arcus.Security.Core;
+
+namespace Arcus.Security.Tests.Unit.Core.Stubs
+{
+    internal class AsyncStaticSecretProvider : ISecretProvider
+    {
+        private readonly string _secretValue;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AsyncStaticSecretProvider" /> class.
+        /// </summary>
+        public AsyncStaticSecretProvider(string secretValue)
+        {
+            _secretValue = secretValue;
+        }
+
+        public Task<string> GetRawSecretAsync(string secretName)
+        {
+            return Task.FromResult(_secretValue);
+        }
+
+        public Task<Secret> GetSecretAsync(string secretName)
+        {
+            return Task.FromResult(new Secret(_secretValue));
+        }
+    }
+}

--- a/src/Arcus.Security.Tests.Unit/Core/Stubs/SyncStaticSecretProvider.cs
+++ b/src/Arcus.Security.Tests.Unit/Core/Stubs/SyncStaticSecretProvider.cs
@@ -1,0 +1,38 @@
+﻿using System.Threading.Tasks;
+using Arcus.Security.Core;
+
+namespace Arcus.Security.Tests.Unit.Core.Stubs
+{
+    internal class SyncStaticSecretProvider : ISyncSecretProvider
+    {
+        private readonly string _secretValue;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SyncStaticSecretProvider" /> class.
+        /// </summary>
+        public SyncStaticSecretProvider(string secretValue)
+        {
+            _secretValue = secretValue;
+        }
+
+        public Task<string> GetRawSecretAsync(string secretName)
+        {
+            return Task.FromResult(_secretValue);
+        }
+
+        public Task<Secret> GetSecretAsync(string secretName)
+        {
+            return Task.FromResult(new Secret(_secretValue));
+        }
+
+        public string GetRawSecret(string secretName)
+        {
+            return _secretValue;
+        }
+
+        public Secret GetSecret(string secretName)
+        {
+            return new Secret(_secretValue);
+        }
+    }
+}

--- a/src/Arcus.Security.Tests.Unit/Core/Stubs/TestSecretProviderStub.cs
+++ b/src/Arcus.Security.Tests.Unit/Core/Stubs/TestSecretProviderStub.cs
@@ -4,7 +4,7 @@ using Arcus.Security.Core;
 
 namespace Arcus.Security.Tests.Unit.Core.Stubs
 {
-    public class TestSecretProviderStub : ISecretProvider
+    public class TestSecretProviderStub : ISyncSecretProvider
     {
         public string SecretValue { get; set; }
 
@@ -23,10 +23,9 @@ namespace Arcus.Security.Tests.Unit.Core.Stubs
         /// <exception cref="System.ArgumentException">The name must not be empty</exception>
         /// <exception cref="System.ArgumentNullException">The name must not be null</exception>
         /// <exception cref="SecretNotFoundException">The secret was not found, using the given name</exception>
-        public async Task<string> GetRawSecretAsync(string secretName)
+        public Task<string> GetRawSecretAsync(string secretName)
         {
-            Secret secret = await GetSecretAsync(secretName);
-            return secret?.Value;
+            return Task.FromResult(GetRawSecret(secretName));
         }
 
         /// <summary>
@@ -39,8 +38,32 @@ namespace Arcus.Security.Tests.Unit.Core.Stubs
         /// <exception cref="SecretNotFoundException">The secret was not found, using the given name</exception>
         public Task<Secret> GetSecretAsync(string secretName)
         {
+            return Task.FromResult(GetSecret(secretName));
+        }
+
+        /// <summary>
+        /// Retrieves the secret value, based on the given name
+        /// </summary>
+        /// <param name="secretName">The name of the secret key</param>
+        /// <returns>Returns the secret key.</returns>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="secretName"/> is blank.</exception>
+        /// <exception cref="SecretNotFoundException">Thrown when the secret was not found, using the given name.</exception>
+        public string GetRawSecret(string secretName)
+        {
+            return GetSecret(secretName).Value;
+        }
+
+        /// <summary>
+        /// Retrieves the secret value, based on the given name
+        /// </summary>
+        /// <param name="secretName">The name of the secret key</param>
+        /// <returns>Returns a <see cref="Secret"/> that contains the secret key</returns>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="secretName"/> is blank.</exception>
+        /// <exception cref="SecretNotFoundException">Thrown when the secret was not found, using the given name.</exception>
+        public Secret GetSecret(string secretName)
+        {
             ++CallsMadeSinceCreation;
-            return Task.FromResult(new Secret(SecretValue, version: Guid.NewGuid().ToString()));
+            return new Secret(SecretValue, version: Guid.NewGuid().ToString());
         }
     }
 }

--- a/src/Arcus.Security.Tests.Unit/Core/SyncSecretTests.cs
+++ b/src/Arcus.Security.Tests.Unit/Core/SyncSecretTests.cs
@@ -1,6 +1,11 @@
 ﻿using System;
 using Arcus.Security.Core;
+using Arcus.Security.Providers.HashiCorp.Extensions;
 using Arcus.Security.Tests.Unit.Core.Stubs;
+using Microsoft.Extensions.DependencyInjection;
+using VaultSharp;
+using VaultSharp.V1.AuthMethods.Custom;
+using VaultSharp.V1.AuthMethods.UserPass;
 using Xunit;
 
 namespace Arcus.Security.Tests.Unit.Core
@@ -43,7 +48,7 @@ namespace Arcus.Security.Tests.Unit.Core
             var provider = new AsyncStaticSecretProvider(Guid.NewGuid().ToString());
 
             // Act / Assert
-            Assert.Throws<SecretNotFoundException>(() => provider.GetSecret("Some.Secret"));
+            Assert.Throws<NotSupportedException>(() => provider.GetSecret("Some.Secret"));
         }
 
         [Fact]
@@ -53,7 +58,7 @@ namespace Arcus.Security.Tests.Unit.Core
             var provider = new AsyncStaticSecretProvider(Guid.NewGuid().ToString());
 
             // Act / Assert
-            Assert.Throws<SecretNotFoundException>(() => provider.GetRawSecret("Some.Secret"));
+            Assert.Throws<NotSupportedException>(() => provider.GetRawSecret("Some.Secret"));
         }
     }
 }

--- a/src/Arcus.Security.Tests.Unit/Core/SyncSecretTests.cs
+++ b/src/Arcus.Security.Tests.Unit/Core/SyncSecretTests.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using Arcus.Security.Core;
+using Arcus.Security.Tests.Unit.Core.Stubs;
+using Xunit;
+
+namespace Arcus.Security.Tests.Unit.Core
+{
+    public class SyncSecretTests
+    {
+        [Fact]
+        public void GetSecret_OnSyncSecretProvider_Fails()
+        {
+            // Arrange
+            var secretValue = Guid.NewGuid().ToString();
+            var provider = new SyncStaticSecretProvider(secretValue);
+
+            // Act
+            Secret secret = provider.GetSecret("Some.Secret");
+
+            // Assert
+            Assert.NotNull(secret);
+            Assert.Equal(secretValue, secret.Value);
+        }
+
+        [Fact]
+        public void GetRawSecret_OnSyncSecretProvider_Fails()
+        {
+            // Arrange
+            var expected = Guid.NewGuid().ToString();
+            var provider = new SyncStaticSecretProvider(expected);
+
+            // Act
+            string actual = provider.GetRawSecret("Some.Secret");
+
+            // Assert
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void GetSecret_OnAsyncSecretProvider_Fails()
+        {
+            // Arrange
+            var provider = new AsyncStaticSecretProvider(Guid.NewGuid().ToString());
+
+            // Act / Assert
+            Assert.Throws<SecretNotFoundException>(() => provider.GetSecret("Some.Secret"));
+        }
+
+        [Fact]
+        public void GetRawSecret_OnAsyncSecretProvider_Fails()
+        {
+            // Arrange
+            var provider = new AsyncStaticSecretProvider(Guid.NewGuid().ToString());
+
+            // Act / Assert
+            Assert.Throws<SecretNotFoundException>(() => provider.GetRawSecret("Some.Secret"));
+        }
+    }
+}


### PR DESCRIPTION
Add support for retrieving secrets synchronously via the secret store, plus allow all built-in secret providers to benefit from this new functionality.

Closes #257