### PR TITLE
fix: get versioned secrets should run though all non-versioned secret providers (❗)

### DIFF
--- a/src/Arcus.Security.Core/CompositeSecretProvider.cs
+++ b/src/Arcus.Security.Core/CompositeSecretProvider.cs
@@ -290,6 +290,11 @@ namespace Arcus.Security.Core
                     }
 
                     Secret secret = await source.SecretProvider.GetSecretAsync(secretName);
+                    if (secret is null)
+                    {
+                        return null;
+                    }
+
                     return new[] { secret };
                 });
 
@@ -321,6 +326,11 @@ namespace Arcus.Security.Core
                     }
 
                     string secretValue = await source.SecretProvider.GetRawSecretAsync(secretName);
+                    if (secretValue is null)
+                    {
+                        return null;
+                    }
+
                     return new[] { secretValue };
                 });
 
@@ -340,8 +350,25 @@ namespace Arcus.Security.Core
             Guard.NotNullOrWhitespace(secretName, nameof(secretName), "Requires a non-blank secret name to look up the secret");
             Guard.NotLessThan(amountOfVersions, 1, nameof(amountOfVersions), "Requires at least 1 secret version to retrieve the secret in the secret store");
 
-            IEnumerable<Secret> secrets = await GetSecretsAsync(secretName);
-            return secrets.Select(secret => secret?.Value).ToArray();
+            IEnumerable<string> secretValues = 
+                await WithSecretStoreAsync(secretName, async source =>
+                {
+                    if (source.VersionedSecretProvider != null)
+                    {
+                        IEnumerable<string> secretValues = await source.VersionedSecretProvider.GetRawSecretsAsync(secretName, amountOfVersions);
+                        return secretValues.ToArray();
+                    }
+
+                    string secretValue = await source.SecretProvider.GetRawSecretAsync(secretName);
+                    if (secretValue is null)
+                    {
+                        return null;
+                    }
+
+                    return new[] { secretValue };
+                });
+
+            return secretValues.ToArray();
         }
 
         /// <summary>
@@ -367,6 +394,11 @@ namespace Arcus.Security.Core
                     }
 
                     Secret secret = await source.SecretProvider.GetSecretAsync(secretName);
+                    if (secret is null)
+                    {
+                        return null;
+                    }
+
                     return new[] { secret };
                 });
 

--- a/src/Arcus.Security.Tests.Unit/Core/VersionedSecretTests.cs
+++ b/src/Arcus.Security.Tests.Unit/Core/VersionedSecretTests.cs
@@ -165,5 +165,55 @@ namespace Arcus.Security.Tests.Unit.Core
             Assert.Equal(amountOfVersions, secretValues2.Count());
             Assert.Equal(2, inMemory.CallsSinceCreation);
         }
+
+        [Fact]
+        public async Task GetRawSecretsAsync_WithNonVersionedSecretProviders_RunsThroughAllProviders()
+        {
+            // Arrange
+            var services = new ServiceCollection();
+            var secretName = "MySecret";
+            var secretValue = Guid.NewGuid().ToString();
+
+            var secretProvider1 = new InMemorySecretProvider();
+            var secretProvider2 = new InMemorySecretProvider((secretName, secretValue));
+            
+            // Act
+            services.AddSecretStore(stores =>
+            {
+                stores.AddProvider(secretProvider1)
+                      .AddProvider(secretProvider2);
+            });
+
+            // Assert
+            IServiceProvider serviceProvider = services.BuildServiceProvider();
+            var secretProvider = serviceProvider.GetRequiredService<ISecretProvider>();
+            IEnumerable<string> rawSecrets = await secretProvider.GetRawSecretsAsync(secretName);
+            Assert.Equal(new[] { secretValue }, rawSecrets);
+        }
+
+        [Fact]
+        public async Task GetSecretsAsync_WithNonVersionedSecretProviders_RunsThroughAllProviders()
+        {
+            // Arrange
+            var services = new ServiceCollection();
+            var secretName = "MySecret";
+            var secretValue = Guid.NewGuid().ToString();
+
+            var secretProvider1 = new InMemorySecretProvider();
+            var secretProvider2 = new InMemorySecretProvider((secretName, secretValue));
+            
+            // Act
+            services.AddSecretStore(stores =>
+            {
+                stores.AddProvider(secretProvider1)
+                      .AddProvider(secretProvider2);
+            });
+
+            // Assert
+            IServiceProvider serviceProvider = services.BuildServiceProvider();
+            var secretProvider = serviceProvider.GetRequiredService<ISecretProvider>();
+            IEnumerable<Secret> secrets = await secretProvider.GetSecretsAsync(secretName);
+            Assert.Equal(secretValue, Assert.Single(secrets.Select(secret => secret.Value)));
+        }
     }
 }


### PR DESCRIPTION
When no versioned secret provider is registered, the secret store should still run through all the registered secret providers to find a secret value.

Closes #380