### PR TITLE
chore: ability to push single package

### DIFF
--- a/build/nuget-release.yml
+++ b/build/nuget-release.yml
@@ -6,6 +6,9 @@ pr: none
 parameters:
   - name: 'Package.Version'
     type: 'string'
+  - name: 'Package.Name'
+    type: 'string'
+    default: '*'
 
 resources:
   repositories:
@@ -133,3 +136,5 @@ stages:
                 ### Removal
                 None.
           - template: nuget/publish-official-package.yml@templates
+            parameters:
+              packagesToPush: "**/${{ parameters['Package.Name'] }}.${{ parameters['Package.Version'] }}.nupkg"

--- a/build/nuget-release.yml
+++ b/build/nuget-release.yml
@@ -137,4 +137,4 @@ stages:
                 None.
           - template: nuget/publish-official-package.yml@templates
             parameters:
-              packagesToPush: "**/${{ parameters['Package.Name'] }}.${{ parameters['Package.Version'] }}.nupkg"
+              packagesToPush: "**/$(Package.Name).$(Package.Version).nupkg"


### PR DESCRIPTION
Add ability to push a single NuGet package with the YAML release pipeline by passing a package name as parameter.