### PR TITLE
chore: upgrade az identity in keyvault secret provider

### DIFF
--- a/src/Arcus.Security.Providers.AzureKeyVault/Arcus.Security.Providers.AzureKeyVault.csproj
+++ b/src/Arcus.Security.Providers.AzureKeyVault/Arcus.Security.Providers.AzureKeyVault.csproj
@@ -24,7 +24,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Identity" Version="1.10.2" />
+    <PackageReference Include="Azure.Identity" Version="1.11.0" />
     <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.5.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.0" />
     <PackageReference Include="Polly" Version="7.2.1" />


### PR DESCRIPTION
Upgrade to first next version of `Azure.Idenity` that is not vulnerable in the Azure Key vault secret provider package.