### PR TITLE
chore: remove guard.net from core and keyvault secret provider

### DIFF
--- a/src/Arcus.Security.Core/Arcus.Security.Core.csproj
+++ b/src/Arcus.Security.Core/Arcus.Security.Core.csproj
@@ -26,7 +26,6 @@
 
   <ItemGroup>
     <PackageReference Include="Arcus.Observability.Telemetry.Core" Version="[3.0.0,4.0.0)" />
-    <PackageReference Include="Guard.Net" Version="3.0.0" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="6.0.0" />
   </ItemGroup>

--- a/src/Arcus.Security.Core/CriticalExceptionFilter.cs
+++ b/src/Arcus.Security.Core/CriticalExceptionFilter.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using GuardNet;
 
 namespace Arcus.Security.Core
 {
@@ -20,9 +19,16 @@ namespace Arcus.Security.Core
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="exceptionType"/> or the <paramref name="exceptionFilter"/> is <c>null</c>.</exception>
         public CriticalExceptionFilter(Type exceptionType, Func<Exception, bool> exceptionFilter)
         {
-            Guard.NotNull(exceptionType, nameof(exceptionType), "Requires an exception type to create an critical exception filter");
-            Guard.NotNull(exceptionFilter, nameof(exceptionFilter), "Requires an exception filter to determine whether an exception is considered critical");
-            
+            if (exceptionType is null)
+            {
+                throw new ArgumentNullException(nameof(exceptionType));
+            }
+
+            if (exceptionFilter is null)
+            {
+                throw new ArgumentNullException(nameof(exceptionFilter));
+            }
+
             _exceptionFilter = exceptionFilter;
             ExceptionType = exceptionType;
         }
@@ -42,7 +48,11 @@ namespace Arcus.Security.Core
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="exception"/> is <c>null</c>.</exception>
         public bool IsCritical(Exception exception)
         {
-            Guard.NotNull(exception, nameof(exception), "Requires an exception instance to determine if it's considered a critical one");
+            if (exception is null)
+            {
+                throw new ArgumentNullException(nameof(exception));
+            }
+
             return _exceptionFilter(exception);
         }
     }

--- a/src/Arcus.Security.Core/Secret.cs
+++ b/src/Arcus.Security.Core/Secret.cs
@@ -15,12 +15,9 @@ namespace Arcus.Security.Core
         /// <param name="version">The version of the secret.</param>
         /// <param name="expirationDate">The expiration date of the secret.</param>
         /// <exception cref="ArgumentNullException">The <paramref name="value"/> cannot be <c>null</c>.</exception>
-        /// <exception cref="ArgumentNullException">The <paramref name="version"/> cannot be <c>null</c>.</exception>
         public Secret(string value, string version = null, DateTimeOffset? expirationDate = null)
         {
-            Guard.NotNull(value, nameof(value));
-
-            Value = value;
+            Value = value ?? throw new ArgumentNullException(nameof(value));
             Version = version;
             Expires = expirationDate;
         }

--- a/src/Arcus.Security.Core/SecretNotFoundException.cs
+++ b/src/Arcus.Security.Core/SecretNotFoundException.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using GuardNet;
 
 namespace Arcus.Security.Core
 {
@@ -34,7 +33,11 @@ namespace Arcus.Security.Core
         /// <exception cref="ArgumentNullException">The name must not be <c>null</c>.</exception>
         public SecretNotFoundException(string name, Exception innerException) : base($"The secret {name} was not found.", innerException)
         {
-            Guard.NotNullOrEmpty(name, nameof(name));
+            if (string.IsNullOrWhiteSpace(name))
+            {
+                throw new ArgumentException("Requires a non-blank secret name", nameof(name));
+            }
+
             Name = name;
         }
 

--- a/src/Arcus.Security.Core/SecretProviderOptions.cs
+++ b/src/Arcus.Security.Core/SecretProviderOptions.cs
@@ -1,7 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using GuardNet;
-using Microsoft.Extensions.Hosting;
 
 namespace Arcus.Security.Core
 {
@@ -28,10 +26,11 @@ namespace Arcus.Security.Core
             get => _name;
             set
             {
-                Guard.For<ArgumentException>(
-                    () => value != null && String.IsNullOrWhiteSpace(value),
-                    "Requires a non-blank value for the name of the secret provider to be registered in the secret store");
-                
+                if (value != null && string.IsNullOrWhiteSpace(value))
+                {
+                    throw new ArgumentException("Requires a non-blank value for the name of the secret provider to be registered in the secret store", nameof(value));
+                }
+
                 _name = value;
             }
         }
@@ -46,8 +45,15 @@ namespace Arcus.Security.Core
         /// <exception cref="ArgumentOutOfRangeException">Thrown when the <paramref name="allowedVersions"/> is less than zero.</exception>
         public void AddVersionedSecret(string secretName, int allowedVersions)
         {
-            Guard.NotNullOrWhitespace(secretName, nameof(secretName), "Requires a non-blank secret name to make the secret a versioned secret in the secret store");
-            Guard.NotLessThan(allowedVersions, 1, nameof(allowedVersions), "Requires at least 1 secret version to make the secret a versioned secret in the secret store");
+            if (string.IsNullOrWhiteSpace(secretName))
+            {
+                throw new ArgumentException("Requires a non-blank secret name to make the secret a versioned secret in the secret store", nameof(secretName));
+            }
+
+            if (allowedVersions < 1)
+            {
+                throw new ArgumentOutOfRangeException(nameof(allowedVersions), allowedVersions, "Requires at least 1 secret version to make the secret a versioned secret in the secret store");
+            }
 
             _versionedSecretNames[secretName] = allowedVersions;
         }
@@ -63,7 +69,11 @@ namespace Arcus.Security.Core
         /// <exception cref="ArgumentException">Thrown when the <paramref name="secretName"/> is blank.</exception>
         internal bool TryGetAllowedSecretVersions(string secretName, out int allowedVersions)
         {
-            Guard.NotNullOrWhitespace(secretName, nameof(secretName), "Requires a non-blank secret name to retrieve a versioned secret in the secret store");
+            if (string.IsNullOrWhiteSpace(secretName))
+            {
+                throw new ArgumentException("Requires a non-blank secret name to make the secret a versioned secret in the secret store", nameof(secretName));
+            }
+
             return _versionedSecretNames.TryGetValue(secretName, out allowedVersions);
         }
     }

--- a/src/Arcus.Security.Core/SecretStoreBuilder.cs
+++ b/src/Arcus.Security.Core/SecretStoreBuilder.cs
@@ -4,7 +4,6 @@ using System.Collections.ObjectModel;
 using Arcus.Security.Core;
 using Arcus.Security.Core.Caching;
 using Arcus.Security.Core.Providers;
-using GuardNet;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Logging;
@@ -26,8 +25,7 @@ namespace Microsoft.Extensions.Hosting
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="services"/> is <c>null</c>.</exception>
         public SecretStoreBuilder(IServiceCollection services)
         {
-            Guard.NotNull(services, nameof(services), "Requires a sequence of registered services to register the secret providers for the secret store");
-            Services = services;
+            Services = services ?? throw new ArgumentNullException(nameof(services));
         }
 
         /// <summary>
@@ -69,9 +67,7 @@ namespace Microsoft.Extensions.Hosting
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="secretProvider"/> is <c>null</c>.</exception>
         public SecretStoreBuilder AddProvider(ISecretProvider secretProvider)
         {
-            Guard.NotNull(secretProvider, nameof(secretProvider), "Requires a secret provider to add to the secret store");
-
-            return AddProvider(secretProvider, configureOptions: null);
+            return AddProvider(secretProvider ?? throw new ArgumentNullException(nameof(secretProvider)), configureOptions: null);
         }
 
         /// <summary>
@@ -87,7 +83,10 @@ namespace Microsoft.Extensions.Hosting
             ISecretProvider secretProvider,
             Action<SecretProviderOptions> configureOptions)
         {
-            Guard.NotNull(secretProvider, nameof(secretProvider), "Requires a secret provider to add to the secret store");
+            if (secretProvider is null)
+            {
+                throw new ArgumentNullException(nameof(secretProvider));
+            }
 
             var options = new SecretProviderOptions();
             configureOptions?.Invoke(options);
@@ -115,9 +114,7 @@ namespace Microsoft.Extensions.Hosting
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="createSecretProvider"/> is <c>null</c>.</exception>
         public SecretStoreBuilder AddProvider(Func<IServiceProvider, ISecretProvider> createSecretProvider)
         {
-            Guard.NotNull(createSecretProvider, nameof(createSecretProvider), "Requires a function to create a secret provider to add to the secret store");
-
-            return AddProvider(createSecretProvider, configureOptions: null);
+            return AddProvider(createSecretProvider ?? throw new ArgumentNullException(nameof(createSecretProvider)), configureOptions: null);
         }
 
         /// <summary>
@@ -133,7 +130,10 @@ namespace Microsoft.Extensions.Hosting
             Func<IServiceProvider, ISecretProvider> createSecretProvider,
             Action<SecretProviderOptions> configureOptions)
         {
-            Guard.NotNull(createSecretProvider, nameof(createSecretProvider), "Requires a function to create a secret provider to add to the secret store");
+            if (createSecretProvider is null)
+            {
+                throw new ArgumentNullException(nameof(createSecretProvider));
+            }
 
             var options = new SecretProviderOptions();
             configureOptions?.Invoke(options);
@@ -171,7 +171,10 @@ namespace Microsoft.Extensions.Hosting
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="exceptionFilter"/> is <c>null</c>.</exception>
         public SecretStoreBuilder AddCriticalException<TException>(Func<TException, bool> exceptionFilter) where TException : Exception
         {
-            Guard.NotNull(exceptionFilter, nameof(exceptionFilter), "Requires an exception filter to select only exceptions that match a specific criteria");
+            if (exceptionFilter is null)
+            {
+                throw new ArgumentNullException(nameof(exceptionFilter));
+            }
 
             CriticalExceptionFilters.Add(new CriticalExceptionFilter(typeof(TException), exception =>
             {
@@ -193,9 +196,7 @@ namespace Microsoft.Extensions.Hosting
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="configureOptions"/> is <c>null</c>.</exception>
         public SecretStoreBuilder WithAuditing(Action<SecretStoreAuditingOptions> configureOptions)
         {
-            Guard.NotNull(configureOptions, nameof(configureOptions), "Requires a function to configure the auditing options");
-
-            _configureAuditingOptions.Add(configureOptions);
+            _configureAuditingOptions.Add(configureOptions ?? throw new ArgumentNullException(nameof(configureOptions)));
             return this;
         }
 

--- a/src/Arcus.Security.Core/SecretStoreSource.cs
+++ b/src/Arcus.Security.Core/SecretStoreSource.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using Arcus.Security.Core.Caching;
-using GuardNet;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
@@ -27,9 +26,7 @@ namespace Arcus.Security.Core
             Func<IServiceProvider, ISecretProvider> createSecretProvider,
             SecretProviderOptions options)
         {
-            Guard.NotNull(createSecretProvider, nameof(createSecretProvider), "Requires a function to create an secret provider instance to register it in the secret store");
-            
-            _createSecretProvider = createSecretProvider;
+            _createSecretProvider = createSecretProvider ?? throw new ArgumentNullException(nameof(createSecretProvider));
             
             Options = options ?? new SecretProviderOptions();
         }
@@ -42,9 +39,7 @@ namespace Arcus.Security.Core
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="secretProvider"/> is <c>null</c>.</exception>
         public SecretStoreSource(ISecretProvider secretProvider, SecretProviderOptions options)
         {
-            Guard.NotNull(secretProvider, nameof(secretProvider), "Requires a secret provider instance to register it in the secret store");
-
-            AssignSecretProvider(secretProvider);
+            AssignSecretProvider(secretProvider ?? throw new ArgumentNullException(nameof(secretProvider)));
             Options = options ?? new SecretProviderOptions();
         }
 
@@ -98,8 +93,10 @@ namespace Arcus.Security.Core
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="serviceProvider"/> is <c>null</c>.</exception>
         public void EnsureSecretProviderCreated(IServiceProvider serviceProvider)
         {
-            Guard.NotNull(serviceProvider, nameof(serviceProvider), 
-                $"Requires an instance to provide the registered services to create the {nameof(ISecretProvider)} and possible {nameof(ICachedSecretProvider)}");
+            if (serviceProvider is null)
+            {
+                throw new ArgumentNullException(nameof(serviceProvider));
+            }
 
             if (_secretProvider is null)
             {

--- a/src/Arcus.Security.Providers.AzureKeyVault/Configuration/ArcusConfigurationProvider.cs
+++ b/src/Arcus.Security.Providers.AzureKeyVault/Configuration/ArcusConfigurationProvider.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+﻿using System;
+using System.Threading.Tasks;
 using Arcus.Security.Core;
 using Microsoft.Extensions.Configuration;
 using GuardNet;
@@ -18,9 +19,7 @@ namespace Arcus.Security.Providers.AzureKeyVault.Configuration
         /// <param name="secretProvider">The provider to retrieve secret values for configuration tokens.</param>
         internal ArcusConfigurationProvider(ISecretProvider secretProvider)
         {
-            Guard.NotNull(secretProvider, nameof(secretProvider), $"Requires a {nameof(ISecretProvider)} instance");
-
-            _secretProvider = secretProvider;
+            _secretProvider = secretProvider ?? throw new ArgumentNullException(nameof(secretProvider));
         }
         
         /// <summary>

--- a/src/Arcus.Security.Providers.AzureKeyVault/Configuration/KeyVaultConfiguration.cs
+++ b/src/Arcus.Security.Providers.AzureKeyVault/Configuration/KeyVaultConfiguration.cs
@@ -29,8 +29,14 @@ namespace Arcus.Security.Providers.AzureKeyVault.Configuration
         /// </summary>
         /// <param name="rawVaultUri">The Uri of the Azure Key Vault you want to connect to.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="rawVaultUri"/> is not using https.</exception>
-        public KeyVaultConfiguration(string rawVaultUri) : this(new Uri(rawVaultUri))
+        public KeyVaultConfiguration(string rawVaultUri)
         {
+            if (string.IsNullOrWhiteSpace(rawVaultUri))
+            {
+                throw new ArgumentException("Requires a non-blank Azure Key vault URI", nameof(rawVaultUri));
+            }
+
+            VaultUri = new Uri(rawVaultUri);
         }
     }
 }

--- a/src/Arcus.Security.Providers.AzureKeyVault/Configuration/KeyVaultConfiguration.cs
+++ b/src/Arcus.Security.Providers.AzureKeyVault/Configuration/KeyVaultConfiguration.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Text.RegularExpressions;
-using GuardNet;
 
 namespace Arcus.Security.Providers.AzureKeyVault.Configuration
 {
@@ -9,10 +7,6 @@ namespace Arcus.Security.Providers.AzureKeyVault.Configuration
     /// </summary>
     public class KeyVaultConfiguration : IKeyVaultConfiguration
     {
-        private const string VaultUriPattern = "^https:\\/\\/[0-9a-zA-Z\\-]{3,24}\\.vault.azure.net(\\/)?$";
-
-        private readonly Regex _vaultUriRegex = new Regex(VaultUriPattern, RegexOptions.Compiled);
-
         /// <summary>
         ///     The Uri of the Azure Key Vault you want to connect to.
         /// </summary>
@@ -27,15 +21,7 @@ namespace Arcus.Security.Providers.AzureKeyVault.Configuration
         /// <exception cref="UriFormatException">Thrown when the <paramref name="vaultUri"/> is not using https.</exception>
         public KeyVaultConfiguration(Uri vaultUri)
         {
-            Guard.NotNull(vaultUri, nameof(vaultUri));
-            Guard.For<UriFormatException>(
-                () => vaultUri.Scheme != Uri.UriSchemeHttps,
-                "Requires the vault URI to have a 'https' scheme");
-            Guard.For<UriFormatException>(
-                () => !_vaultUriRegex.IsMatch(vaultUri.ToString()),
-                "Requires the Azure Key Vault host to be in the right format, see https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#objects-identifiers-and-versioning");
-
-            VaultUri = vaultUri;
+            VaultUri = vaultUri ?? throw new ArgumentNullException(nameof(vaultUri));
         }
 
         /// <summary>

--- a/src/Arcus.Security.Providers.AzureKeyVault/Extensions/SecretStoreBuilderExtensions.cs
+++ b/src/Arcus.Security.Providers.AzureKeyVault/Extensions/SecretStoreBuilderExtensions.cs
@@ -144,6 +144,11 @@ namespace Microsoft.Extensions.Hosting
             Action<KeyVaultOptions> configureOptions,
             Action<SecretProviderOptions> configureProviderOptions)
         {
+            if (string.IsNullOrWhiteSpace(clientId))
+            {
+                throw new ArgumentException("Requires a non-blank client ID to authenticate the Azure Key vault secret provider with a certificate", nameof(clientId));
+            }
+
             return AddAzureKeyVault(
                 builder,
                 new ClientCertificateCredential(tenantId, clientId, certificate),
@@ -468,6 +473,16 @@ namespace Microsoft.Extensions.Hosting
             Action<KeyVaultOptions> configureOptions,
             Action<SecretProviderOptions> configureProviderOptions)
         {
+            if (string.IsNullOrWhiteSpace(clientId))
+            {
+                throw new ArgumentException("Requires a non-blank client ID to authenticate the Azure Key vault secret provider", nameof(clientId));
+            }
+
+            if (string.IsNullOrWhiteSpace(clientKey))
+            {
+                throw new ArgumentException("Requires a non-blank client secret to authenticate the Azure Key vault secret provider", nameof(clientKey));
+            }
+
             return AddAzureKeyVault(
                 builder,
                 new ClientSecretCredential(tenantId, clientId, clientKey), 

--- a/src/Arcus.Security.Providers.AzureKeyVault/Extensions/SecretStoreBuilderExtensions.cs
+++ b/src/Arcus.Security.Providers.AzureKeyVault/Extensions/SecretStoreBuilderExtensions.cs
@@ -7,7 +7,6 @@ using Arcus.Security.Providers.AzureKeyVault.Configuration;
 using Azure;
 using Azure.Core;
 using Azure.Identity;
-using GuardNet;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 
@@ -36,12 +35,6 @@ namespace Microsoft.Extensions.Hosting
             string clientId,
             X509Certificate2 certificate)
         {
-            Guard.NotNull(builder, nameof(builder), "Requires a secret store builder to add the Azure Key Vault secret provider");
-            Guard.NotNullOrWhitespace(rawVaultUri, nameof(rawVaultUri), "Requires a non-blank URI of the Azure Key Vault instance to add the secret provider to the secret store");
-            Guard.NotNullOrWhitespace(tenantId, nameof(tenantId), "Requires a non-blank tenant ID of the directory where the client or application is located");
-            Guard.NotNullOrWhitespace(clientId, nameof(clientId), "Requires a non-blank client ID of the application requesting the authentication token that has read permissions on the Azure Key Vault to add a secret provider to the secret store");
-            Guard.NotNull(certificate, nameof(certificate), "Requires a certificate that is being used as credential on the Azure Key Vault to add the secret provider to the secret store");
-
             return AddAzureKeyVaultWithCertificate(
                 builder,
                 rawVaultUri,
@@ -72,12 +65,6 @@ namespace Microsoft.Extensions.Hosting
             X509Certificate2 certificate,
             ICacheConfiguration cacheConfiguration)
         {
-            Guard.NotNull(builder, nameof(builder), "Requires a secret store builder to add the Azure Key Vault secret provider");
-            Guard.NotNullOrWhitespace(rawVaultUri, nameof(rawVaultUri), "Requires a non-blank URI of the Azure Key Vault instance to add the secret provider to the secret store");
-            Guard.NotNullOrWhitespace(tenantId, nameof(tenantId), "Requires a non-blank tenant ID of the directory where the client or application is located");
-            Guard.NotNullOrWhitespace(clientId, nameof(clientId), "Requires a non-blank client ID of the application requesting the authentication token that has read permissions on the Azure Key Vault to add a secret provider to the secret store");
-            Guard.NotNull(certificate, nameof(certificate), "Requires a certificate that is being used as credential on the Azure Key Vault to add the secret provider to the secret store");
-
             return AddAzureKeyVaultWithCertificate(
                 builder,
                 rawVaultUri,
@@ -117,12 +104,6 @@ namespace Microsoft.Extensions.Hosting
             string name,
             Func<string, string> mutateSecretName)
         {
-            Guard.NotNull(builder, nameof(builder), "Requires a secret store builder to add the Azure Key Vault secret provider");
-            Guard.NotNullOrWhitespace(rawVaultUri, nameof(rawVaultUri), "Requires a non-blank URI of the Azure Key Vault instance to add the secret provider to the secret store");
-            Guard.NotNullOrWhitespace(tenantId, nameof(tenantId), "Requires a non-blank tenant ID of the directory where the client or application is located");
-            Guard.NotNullOrWhitespace(clientId, nameof(clientId), "Requires a non-blank client ID of the application requesting the authentication token that has read permissions on the Azure Key Vault to add a secret provider to the secret store");
-            Guard.NotNull(certificate, nameof(certificate), "Requires a certificate that is being used as credential on the Azure Key Vault to add the secret provider to the secret store");
-
             return AddAzureKeyVaultWithCertificate(
                 builder,
                 rawVaultUri,
@@ -163,12 +144,6 @@ namespace Microsoft.Extensions.Hosting
             Action<KeyVaultOptions> configureOptions,
             Action<SecretProviderOptions> configureProviderOptions)
         {
-            Guard.NotNull(builder, nameof(builder), "Requires a secret store builder to add the Azure Key Vault secret provider");
-            Guard.NotNullOrWhitespace(rawVaultUri, nameof(rawVaultUri), "Requires a non-blank URI of the Azure Key Vault instance to add the secret provider to the secret store");
-            Guard.NotNullOrWhitespace(tenantId, nameof(tenantId), "Requires a non-blank tenant ID of the directory where the client or application is located");
-            Guard.NotNullOrWhitespace(clientId, nameof(clientId), "Requires a non-blank client ID of the application requesting the authentication token that has read permissions on the Azure Key Vault to add a secret provider to the secret store");
-            Guard.NotNull(certificate, nameof(certificate), "Requires a certificate that is being used as credential on the Azure Key Vault to add the secret provider to the secret store");
-
             return AddAzureKeyVault(
                 builder,
                 new ClientCertificateCredential(tenantId, clientId, certificate),
@@ -189,9 +164,6 @@ namespace Microsoft.Extensions.Hosting
             this SecretStoreBuilder builder,
             string rawVaultUri)
         {
-            Guard.NotNull(builder, nameof(builder), "Requires a secret store builder to add the Azure Key Vault secret provider");
-            Guard.NotNullOrWhitespace(rawVaultUri, nameof(rawVaultUri), "Requires a non-blank URI of the Azure Key Vault instance to add the secret provider to the secret store");
-
             return AddAzureKeyVaultWithManagedIdentity(
                 builder,
                 rawVaultUri,
@@ -214,9 +186,6 @@ namespace Microsoft.Extensions.Hosting
             string rawVaultUri,
             string clientId)
         {
-            Guard.NotNull(builder, nameof(builder), "Requires a secret store builder to add the Azure Key Vault secret provider");
-            Guard.NotNullOrWhitespace(rawVaultUri, nameof(rawVaultUri), "Requires a non-blank URI of the Azure Key Vault instance to add the secret provider to the secret store");
-
             return AddAzureKeyVaultWithManagedIdentity(
                 builder,
                 rawVaultUri,
@@ -240,9 +209,6 @@ namespace Microsoft.Extensions.Hosting
             string rawVaultUri,
             ICacheConfiguration cacheConfiguration)
         {
-            Guard.NotNull(builder, nameof(builder), "Requires a secret store builder to add the Azure Key Vault secret provider");
-            Guard.NotNullOrWhitespace(rawVaultUri, nameof(rawVaultUri), "Requires a non-blank URI of the Azure Key Vault instance to add the secret provider to the secret store");
-
             return AddAzureKeyVaultWithManagedIdentity(
                 builder,
                 rawVaultUri,
@@ -267,9 +233,6 @@ namespace Microsoft.Extensions.Hosting
             ICacheConfiguration cacheConfiguration,
             string clientId)
         {
-            Guard.NotNull(builder, nameof(builder), "Requires a secret store builder to add the Azure Key Vault secret provider");
-            Guard.NotNullOrWhitespace(rawVaultUri, nameof(rawVaultUri), "Requires a non-blank URI of the Azure Key Vault instance to add the secret provider to the secret store");
-
             return AddAzureKeyVaultWithManagedIdentity(
                 builder,
                 rawVaultUri,
@@ -299,9 +262,6 @@ namespace Microsoft.Extensions.Hosting
             string name,
             Func<string, string> mutateSecretName)
         {
-            Guard.NotNull(builder, nameof(builder), "Requires a secret store builder to add the Azure Key Vault secret provider");
-            Guard.NotNullOrWhitespace(rawVaultUri, nameof(rawVaultUri), "Requires a non-blank URI of the Azure Key Vault instance to add the secret provider to the secret store");
-
             return AddAzureKeyVaultWithManagedIdentity(
                 builder,
                 rawVaultUri,
@@ -335,9 +295,6 @@ namespace Microsoft.Extensions.Hosting
             string name,
             Func<string, string> mutateSecretName)
         {
-            Guard.NotNull(builder, nameof(builder), "Requires a secret store builder to add the Azure Key Vault secret provider");
-            Guard.NotNullOrWhitespace(rawVaultUri, nameof(rawVaultUri), "Requires a non-blank URI of the Azure Key Vault instance to add the secret provider to the secret store");
-
             return AddAzureKeyVaultWithManagedIdentity(
                 builder,
                 rawVaultUri,
@@ -372,9 +329,6 @@ namespace Microsoft.Extensions.Hosting
             Action<KeyVaultOptions> configureOptions,
             Action<SecretProviderOptions> configureProviderOptions)
         {
-            Guard.NotNull(builder, nameof(builder), "Requires a secret store builder to add the Azure Key Vault secret provider");
-            Guard.NotNullOrWhitespace(rawVaultUri, nameof(rawVaultUri), "Requires a non-blank URI of the Azure Key Vault instance to add the secret provider to the secret store");
-
             return AddAzureKeyVault(
                 builder,
                 new DefaultAzureCredential(new DefaultAzureCredentialOptions { ManagedIdentityClientId = clientId }), 
@@ -401,12 +355,6 @@ namespace Microsoft.Extensions.Hosting
             string clientId,
             string clientKey)
         {
-            Guard.NotNull(builder, nameof(builder), "Requires a secret store builder to add the Azure Key Vault secret provider");
-            Guard.NotNullOrWhitespace(rawVaultUri, nameof(rawVaultUri), "Requires a non-blank URI of the Azure Key Vault instance to add the secret provider to the secret store");
-            Guard.NotNullOrWhitespace(tenantId, nameof(tenantId), "Requires a non-blank tenant ID of the directory where the Service Principal is located");
-            Guard.NotNullOrWhitespace(clientId, nameof(clientId), "Requires a non-blank client ID of the Service Principal that has permissions to read the secrets in the Azure Key Vault to add the secret provider to the secret store");
-            Guard.NotNullOrWhitespace(clientKey, nameof(clientKey), "Requires a non-blank client access key of the Service Principal that has permissions to read the secrets in the Azure Key Vault to add to the secret provider to the secret store");
-
             return AddAzureKeyVaultWithServicePrincipal(
                 builder,
                 rawVaultUri,
@@ -437,12 +385,6 @@ namespace Microsoft.Extensions.Hosting
             string clientKey,
             ICacheConfiguration cacheConfiguration)
         {
-            Guard.NotNull(builder, nameof(builder), "Requires a secret store builder to add the Azure Key Vault secret provider");
-            Guard.NotNullOrWhitespace(rawVaultUri, nameof(rawVaultUri), "Requires a non-blank URI of the Azure Key Vault instance to add the secret provider to the secret store");
-            Guard.NotNullOrWhitespace(tenantId, nameof(tenantId), "Requires a non-blank tenant ID of the directory where the Service Principal is located");
-            Guard.NotNullOrWhitespace(clientId, nameof(clientId), "Requires a non-blank client ID of the Service Principal that has permissions to read the secrets in the Azure Key Vault to add the secret provider to the secret store");
-            Guard.NotNullOrWhitespace(clientKey, nameof(clientKey), "Requires a non-blank client access key of the Service Principal that has permissions to read the secrets in the Azure Key Vault to add to the secret provider to the secret store");
-
             return AddAzureKeyVaultWithServicePrincipal(
                 builder,
                 rawVaultUri,
@@ -484,12 +426,6 @@ namespace Microsoft.Extensions.Hosting
             string name,
             Func<string, string> mutateSecretName)
         {
-            Guard.NotNull(builder, nameof(builder), "Requires a secret store builder to add the Azure Key Vault secret provider");
-            Guard.NotNullOrWhitespace(rawVaultUri, nameof(rawVaultUri), "Requires a non-blank URI of the Azure Key Vault instance to add the secret provider to the secret store");
-            Guard.NotNullOrWhitespace(tenantId, nameof(tenantId), "Requires a non-blank tenant ID of the directory where the Service Principal is located");
-            Guard.NotNullOrWhitespace(clientId, nameof(clientId), "Requires a non-blank client ID of the Service Principal that has permissions to read the secrets in the Azure Key Vault to add the secret provider to the secret store");
-            Guard.NotNullOrWhitespace(clientKey, nameof(clientKey), "Requires a non-blank client access key of the Service Principal that has permissions to read the secrets in the Azure Key Vault to add to the secret provider to the secret store");
-
             return AddAzureKeyVaultWithServicePrincipal(
                 builder,
                 rawVaultUri,
@@ -532,12 +468,6 @@ namespace Microsoft.Extensions.Hosting
             Action<KeyVaultOptions> configureOptions,
             Action<SecretProviderOptions> configureProviderOptions)
         {
-            Guard.NotNull(builder, nameof(builder), "Requires a secret store builder to add the Azure Key Vault secret provider");
-            Guard.NotNullOrWhitespace(rawVaultUri, nameof(rawVaultUri), "Requires a non-blank URI of the Azure Key Vault instance to add the secret provider to the secret store");
-            Guard.NotNullOrWhitespace(tenantId, nameof(tenantId), "Requires a non-blank tenant ID of the directory where the Service Principal is located");
-            Guard.NotNullOrWhitespace(clientId, nameof(clientId), "Requires a non-blank client ID of the Service Principal that has permissions to read the secrets in the Azure Key Vault to add the secret provider to the secret store");
-            Guard.NotNullOrWhitespace(clientKey, nameof(clientKey), "Requires a non-blank client access key of the Service Principal that has permissions to read the secrets in the Azure Key Vault to add to the secret provider to the secret store");
-
             return AddAzureKeyVault(
                 builder,
                 new ClientSecretCredential(tenantId, clientId, clientKey), 
@@ -561,10 +491,6 @@ namespace Microsoft.Extensions.Hosting
             IKeyVaultConfiguration configuration,
             ICacheConfiguration cacheConfiguration)
         {
-            Guard.NotNull(builder, nameof(builder), "Requires a secret store builder to add the Azure Key Vault secret provider");
-            Guard.NotNull(tokenCredential, nameof(tokenCredential), "Requires an Azure Key Vault authentication instance to add the secret provider to the secret store");
-            Guard.NotNull(configuration, nameof(configuration), "Requires an Azure Key Vault configuration instance to add the secret provider to the secret store");
-
             return AddAzureKeyVault(
                 builder,
                 tokenCredential,
@@ -587,10 +513,6 @@ namespace Microsoft.Extensions.Hosting
             TokenCredential tokenCredential,
             IKeyVaultConfiguration configuration)
         {
-            Guard.NotNull(builder, nameof(builder), "Requires a secret store builder to add the Azure Key Vault secret provider");
-            Guard.NotNull(tokenCredential, nameof(tokenCredential), "Requires an Azure Key Vault authentication instance to add the secret provider to the secret store");
-            Guard.NotNull(configuration, nameof(configuration), "Requires an Azure Key Vault configuration instance to add the secret provider to the secret store");
-
             return AddAzureKeyVault(
                 builder,
                 tokenCredential,
@@ -618,10 +540,6 @@ namespace Microsoft.Extensions.Hosting
             string name,
             Func<string, string> mutateSecretName)
         {
-            Guard.NotNull(builder, nameof(builder), "Requires a secret store builder to add the Azure Key Vault secret provider");
-            Guard.NotNull(tokenCredential, nameof(tokenCredential), "Requires an Azure Key Vault authentication instance to add the secret provider to the secret store");
-            Guard.NotNull(configuration, nameof(configuration), "Requires an Azure Key Vault configuration instance to add the secret provider to the secret store");
-
             return AddAzureKeyVault(
                 builder,
                 tokenCredential,
@@ -653,9 +571,20 @@ namespace Microsoft.Extensions.Hosting
             Action<KeyVaultOptions> configureOptions,
             Action<SecretProviderOptions> configureProviderOptions)
         {
-            Guard.NotNull(builder, nameof(builder), "Requires a secret store builder to add the Azure Key Vault secret provider");
-            Guard.NotNull(tokenCredential, nameof(tokenCredential), "Requires an Azure Key Vault authentication instance to add the secret provider to the secret store");
-            Guard.NotNull(configuration, nameof(configuration), "Requires an Azure Key Vault configuration instance to add the secret provider to the secret store");
+            if (builder is null)
+            {
+                throw new ArgumentNullException(nameof(builder));
+            }
+
+            if (tokenCredential is null)
+            {
+                throw new ArgumentNullException(nameof(tokenCredential));
+            }
+
+            if (configuration is null)
+            {
+                throw new ArgumentNullException(nameof(configuration));
+            }
 
             // Thrown during failure with Key Vault authorization.
             builder.AddCriticalException<RequestFailedException>(exception =>

--- a/src/Arcus.Security.Tests.Unit/KeyVault/Configuration/KeyVaultConfigurationTests.cs
+++ b/src/Arcus.Security.Tests.Unit/KeyVault/Configuration/KeyVaultConfigurationTests.cs
@@ -7,13 +7,6 @@ namespace Arcus.Security.Tests.Unit.KeyVault.Configuration
     public class KeyVaultConfigurationTests
     {
         [Fact]
-        public void Constructor_UriWithoutVaultSuffix_Fails()
-        {
-            Assert.ThrowsAny<UriFormatException>(
-                () => new KeyVaultConfiguration("https://something-without-azure-vault-suffix"));
-        }
-
-        [Fact]
         public void Constructor_ValidRawUri_Succeeds()
         {
             // Arrange
@@ -43,34 +36,13 @@ namespace Arcus.Security.Tests.Unit.KeyVault.Configuration
         }
 
         [Fact]
-        public void Constructor_RawUriWithHttp_ThrowsUriFormatException()
-        {
-            // Arrange
-            string vaultUri = $"http://{Guid.NewGuid():N}.vault.azure.net/";
-
-            // Act & Assert
-            Assert.Throws<UriFormatException>(() => new KeyVaultConfiguration(vaultUri));
-        }
-
-        [Fact]
-        public void Constructor_UriWithHttp_ThrowsUriFormatException()
-        {
-            // Arrange
-            string vaultUri = $"http://{Guid.NewGuid():N}.vault.azure.net/";
-            var expectedVaultUri = new Uri(vaultUri);
-
-            // Act & Assert
-            Assert.Throws<UriFormatException>(() => new KeyVaultConfiguration(expectedVaultUri));
-        }
-
-        [Fact]
         public void Constructor_NoUriSpecified_ThrowsArgumentNullException()
         {
             // Arrange
             Uri vaultUri = null;
 
             // Act & Assert
-            Assert.Throws<ArgumentNullException>(() => new KeyVaultConfiguration(vaultUri));
+            Assert.ThrowsAny<ArgumentException>(() => new KeyVaultConfiguration(vaultUri));
         }
 
         [Fact]
@@ -80,7 +52,7 @@ namespace Arcus.Security.Tests.Unit.KeyVault.Configuration
             string rawVaultUri = null;
 
             // Act & Assert
-            Assert.Throws<ArgumentNullException>(() => new KeyVaultConfiguration(rawVaultUri));
+            Assert.ThrowsAny<ArgumentException>(() => new KeyVaultConfiguration(rawVaultUri));
         }
 
         [Fact]
@@ -90,7 +62,7 @@ namespace Arcus.Security.Tests.Unit.KeyVault.Configuration
             string rawVaultUri = string.Empty;
 
             // Act & Assert
-            Assert.Throws<UriFormatException>(() => new KeyVaultConfiguration(rawVaultUri));
+            Assert.ThrowsAny<ArgumentException>(() => new KeyVaultConfiguration(rawVaultUri));
         }
 
         [Fact]
@@ -100,7 +72,7 @@ namespace Arcus.Security.Tests.Unit.KeyVault.Configuration
             string rawVaultUri = " ";
 
             // Act & Assert
-            Assert.Throws<System.UriFormatException>(() => new KeyVaultConfiguration(rawVaultUri));
+            Assert.ThrowsAny<ArgumentException>(() => new KeyVaultConfiguration(rawVaultUri));
         }
     }
 }


### PR DESCRIPTION
Remove the `Guard.Net` package from the core and Azure Key vault secret provider projects.

Relates to #434 