### PR TITLE
chore(deps): use package wildcards in core

### DIFF
--- a/src/Arcus.Security.Core/Arcus.Security.Core.csproj
+++ b/src/Arcus.Security.Core/Arcus.Security.Core.csproj
@@ -26,8 +26,8 @@
 
   <ItemGroup>
     <PackageReference Include="Arcus.Observability.Telemetry.Core" Version="[3.0.0,4.0.0)" />
-    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="[8.*,10.0.0)" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="[8.*,10.0.0)" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Fixes the vulnerability of the caching in-memory package by already providing package wildcards for it.