### PR TITLE
chore(core): deprecate 'get raw secret' exposure

### DIFF
--- a/docs/preview/03-Features/secret-store/versioned-secret-provider.md
+++ b/docs/preview/03-Features/secret-store/versioned-secret-provider.md
@@ -57,9 +57,6 @@ public class OrderController : ControllerBase
     {
         // Get all secrets available.
         IEnumeration<Secret> secrets = await _secretProvider.GetSecretsAsync("MySecret");
-
-        // Get all secret values available.
-        IEnumeration<string> secretValues = await _secretProvider.GetRawSecretsAsync("MySecret");
     }
 }
 ```

--- a/docs/preview/03-Features/secrets/general.md
+++ b/docs/preview/03-Features/secrets/general.md
@@ -16,14 +16,6 @@ string secretVersion = secret.Version;
 DateTimeOffset? expirationDate = secret.Expires;
 ```
 
-## Raw secrets
-In some scenarios you'd like to just get the secret value directly without any metadata.
-This is possible by calling the `...Raw...` variants on the `ISecretProvider` implementations.
-
-```csharp
-string secretValue = await secretProvider.GetRawSecretAsync("EventGrid-AuthKey");
-```
-
 ## Synchronous secrets
 In some scenarios you'd like to retrieve secrets synchronously. A common situation is when you want to register a dependent service into the dependency container that requires a secret, but since such a container only registers instances or synchronous functions, there is no easy way to retrieve a secret asynchronously.
 
@@ -38,18 +30,16 @@ services.AddSingleton(serviceProvider =>
     // #1 injecting the `ISyncSecretProvider`:
     var syncSecretProvider = serviceProvider.GetRequiredService<ISyncSecretProvider>();
     Secret secret = synSecretProvider.GetSecret("EventGrid-AuthKey");
-    string secretValue = syncSecretProvider.GetRawSecret("EventGrid-AuthKey");
 
     // #2 calling `GetSecret` or `GetRawSecret` extension on `ISecretProvider`:
     var secretProvider = serviceProvider.GetRequiredService<ISecretProvider>();
     Secret secret = secretProvider.GetSecret("EventGrid-AuthKey");
-    string secretProvider = secretProvider.GetRawSecret("EventGrid-AuthKey");
 
     return new MyDependentService(secretValue);
 });
 ```
 
-⚠ Make sure that you only call the `GetSecret` and `GetRawSecret` extension on `ISecretProvider` implementations that also implement the `ISyncSecretProvider` interface. The [Arcus secret store](../secret-store/index.md) automatically makes sure that you can use this extension on any injected `ISecretProvider` but when no secret provider is registered that supports synchronous secret retrieval, a `NotSupportedException` will be thrown nonetheless.
+⚠ Make sure that you only call the `GetSecret` extension on `ISecretProvider` implementations that also implement the `ISyncSecretProvider` interface. The [Arcus secret store](../secret-store/index.md) automatically makes sure that you can use this extension on any injected `ISecretProvider` but when no secret provider is registered that supports synchronous secret retrieval, a `NotSupportedException` will be thrown nonetheless.
 
 # Caching Secrets
 Some secret providers recommend to cache secrets for a while to avoid hitting the service limitations.

--- a/src/Arcus.Security.Core/Caching/ICachedSecretProvider.cs
+++ b/src/Arcus.Security.Core/Caching/ICachedSecretProvider.cs
@@ -23,6 +23,7 @@ namespace Arcus.Security.Core.Caching
         /// <exception cref="ArgumentException">The name must not be empty</exception>
         /// <exception cref="ArgumentNullException">The name must not be null</exception>
         /// <exception cref="SecretNotFoundException">The secret was not found, using the given name</exception>
+        [Obsolete("Will be removed in v3 in favor of solely using " + nameof(GetSecretAsync) + " instead")]
         Task<string> GetRawSecretAsync(string secretName, bool ignoreCache);
 
         /// <summary>

--- a/src/Arcus.Security.Core/CompositeSecretProvider.cs
+++ b/src/Arcus.Security.Core/CompositeSecretProvider.cs
@@ -265,6 +265,7 @@ namespace Arcus.Security.Core
         /// <returns>Returns the secret key.</returns>
         /// <exception cref="ArgumentException">Thrown when the <paramref name="secretName"/> is blank.</exception>
         /// <exception cref="SecretNotFoundException">Thrown when the secret was not found, using the given name.</exception>
+        [Obsolete("Will be removed in v3 in favor of solely using " + nameof(GetSecretAsync) + " instead")]
         public string GetRawSecret(string secretName)
         {
             if (string.IsNullOrWhiteSpace(secretName))
@@ -357,6 +358,7 @@ namespace Arcus.Security.Core
         /// <param name="secretName">The name of the secret.</param>
         /// <exception cref="ArgumentException">Thrown when the <paramref name="secretName"/> is blank.</exception>
         /// <exception cref="SecretNotFoundException">Thrown when no secret was not found, using the given <paramref name="secretName"/>.</exception>
+        [Obsolete("Will be removed in v3 in favor of solely using " + nameof(GetSecretsAsync) + " instead")]
         internal async Task<IEnumerable<string>> GetRawSecretsAsync(string secretName)
         {
             if (string.IsNullOrWhiteSpace(secretName))
@@ -398,6 +400,7 @@ namespace Arcus.Security.Core
         /// <exception cref="ArgumentException">Thrown when the <paramref name="secretName"/> is blank.</exception>
         /// <exception cref="ArgumentOutOfRangeException">Thrown when the <paramref name="amountOfVersions"/> is less than zero.</exception>
         /// <exception cref="SecretNotFoundException">Thrown when no secret was not found, using the given <paramref name="secretName"/>.</exception>
+        [Obsolete("Will be removed in v3 in favor of solely using " + nameof(GetSecretsAsync) + " instead")]
         public async Task<IEnumerable<string>> GetRawSecretsAsync(string secretName, int amountOfVersions)
         {
             if (string.IsNullOrWhiteSpace(secretName))
@@ -480,6 +483,7 @@ namespace Arcus.Security.Core
         /// <exception cref="System.ArgumentException">The <paramref name="secretName"/> must not be empty</exception>
         /// <exception cref="System.ArgumentNullException">The <paramref name="secretName"/> must not be null</exception>
         /// <exception cref="SecretNotFoundException">The secret was not found, using the given name</exception>
+        [Obsolete("Will be removed in v3 in favor of solely using " + nameof(GetSecretAsync) + " instead")]
         public async Task<string> GetRawSecretAsync(string secretName)
         {
             if (string.IsNullOrWhiteSpace(secretName))
@@ -524,6 +528,7 @@ namespace Arcus.Security.Core
         /// <exception cref="ArgumentNullException">The name must not be null</exception>
         /// <exception cref="SecretNotFoundException">The secret was not found, using the given name</exception>
         /// <exception cref="NotSupportedException">Thrown when none of the registered secret providers are registered as <see cref="ICachedSecretProvider"/> instances.</exception>
+        [Obsolete("Will be removed in v3 in favor of solely using " + nameof(GetSecretAsync) + " instead")]
         public async Task<string> GetRawSecretAsync(string secretName, bool ignoreCache)
         {
             if (string.IsNullOrWhiteSpace(secretName))

--- a/src/Arcus.Security.Core/Extensions/ISecretProviderExtensions.cs
+++ b/src/Arcus.Security.Core/Extensions/ISecretProviderExtensions.cs
@@ -21,6 +21,7 @@ namespace Arcus.Security.Core
         /// <returns>Returns the secret key.</returns>
         /// <exception cref="ArgumentException">Thrown when the <paramref name="secretName"/> is blank.</exception>
         /// <exception cref="SecretNotFoundException">Thrown when the secret was not found, using the given name.</exception>
+        [Obsolete("Will be removed in v3 in favor of solely using " + nameof(ISecretProvider.GetSecretAsync) + " instead")]
         public static string GetRawSecret(this ISecretProvider secretProvider, string secretName)
         {
             Guard.NotNull(secretProvider, nameof(secretProvider), "Requires a secret provider to synchronously look up the secret");
@@ -71,6 +72,7 @@ namespace Arcus.Security.Core
         /// <exception cref="ArgumentException">The <paramref name="secretName"/> must not be empty</exception>
         /// <exception cref="ArgumentNullException">The <paramref name="secretName"/> must not be null</exception>
         /// <exception cref="SecretNotFoundException">The secret was not found, using the given name</exception>
+        [Obsolete("Will be removed in v3 in favor of solely using " + nameof(GetSecretsAsync) + " instead")]
         public static async Task<IEnumerable<string>> GetRawSecretsAsync(this ISecretProvider secretProvider, string secretName)
         {
             Guard.NotNullOrWhitespace(secretName, nameof(secretName), "Requires a non-blank secret name to look up the secret");

--- a/src/Arcus.Security.Core/ISecretProvider.cs
+++ b/src/Arcus.Security.Core/ISecretProvider.cs
@@ -16,6 +16,7 @@ namespace Arcus.Security.Core
         /// <exception cref="ArgumentException">The <paramref name="secretName"/> must not be empty</exception>
         /// <exception cref="ArgumentNullException">The <paramref name="secretName"/> must not be null</exception>
         /// <exception cref="SecretNotFoundException">The secret was not found, using the given name</exception>
+        [Obsolete("Will be removed in v3 in favor of solely using " + nameof(GetSecretAsync) + " instead")]
         Task<string> GetRawSecretAsync(string secretName);
 
         /// <summary>

--- a/src/Arcus.Security.Core/ISyncSecretProvider.cs
+++ b/src/Arcus.Security.Core/ISyncSecretProvider.cs
@@ -14,6 +14,7 @@ namespace Arcus.Security.Core
         /// <returns>Returns the secret key.</returns>
         /// <exception cref="ArgumentException">Thrown when the <paramref name="secretName"/> is blank.</exception>
         /// <exception cref="SecretNotFoundException">Thrown when the secret was not found, using the given name.</exception>
+        [Obsolete("Will be removed in v3 in favor of solely using " + nameof(GetSecret) + " instead")]
         string GetRawSecret(string secretName);
 
         /// <summary>

--- a/src/Arcus.Security.Core/Providers/MutatedSecretNameCachedSecretProvider.cs
+++ b/src/Arcus.Security.Core/Providers/MutatedSecretNameCachedSecretProvider.cs
@@ -47,6 +47,7 @@ namespace Arcus.Security.Core.Providers
         /// <exception cref="ArgumentException">The name must not be empty</exception>
         /// <exception cref="ArgumentNullException">The name must not be null</exception>
         /// <exception cref="SecretNotFoundException">The secret was not found, using the given name</exception>
+        [Obsolete("Will be removed in v3 in favor of solely using " + nameof(GetSecretAsync) + " instead")]
         public async Task<string> GetRawSecretAsync(string secretName, bool ignoreCache)
         {
             Guard.NotNullOrWhitespace(secretName, nameof(secretName), "Requires a non-blank secret name when mutating secret names");
@@ -89,7 +90,7 @@ namespace Arcus.Security.Core.Providers
         {
             Guard.NotNullOrWhitespace(secretName, nameof(secretName), "Requires a non-blank secret name when mutating secret names");
 
-            await SafeguardMutateSecretAsync(secretName, async mutatedSecretName => 
+            await SafeguardMutateSecretAsync(secretName, async mutatedSecretName =>
             {
                 await _implementation.InvalidateSecretAsync(mutatedSecretName);
             });

--- a/src/Arcus.Security.Core/Providers/MutatedSecretNameSecretProvider.cs
+++ b/src/Arcus.Security.Core/Providers/MutatedSecretNameSecretProvider.cs
@@ -26,12 +26,12 @@ namespace Arcus.Security.Core.Providers
         public MutatedSecretNameSecretProvider(ISecretProvider implementation, Func<string, string> mutateSecretName, ILogger logger)
         {
             Guard.NotNull(implementation, nameof(implementation), "Requires an secret provider instance to pass the mutated secret name to");
-            Guard.NotNull(mutateSecretName, nameof(mutateSecretName), 
+            Guard.NotNull(mutateSecretName, nameof(mutateSecretName),
                 "Requires an transformation function to mutate the incoming secret name to something that the actual secret provider can understand");
 
             _mutateSecretName = mutateSecretName;
             _implementation = implementation;
-            
+
             Logger = logger ?? NullLogger<MutatedSecretNameSecretProvider>.Instance;
         }
 
@@ -48,6 +48,7 @@ namespace Arcus.Security.Core.Providers
         /// <exception cref="ArgumentException">The <paramref name="secretName"/> must not be empty</exception>
         /// <exception cref="ArgumentNullException">The <paramref name="secretName"/> must not be null</exception>
         /// <exception cref="SecretNotFoundException">The secret was not found, using the given name</exception>
+        [Obsolete("Will be removed in v3 in favor of solely using " + nameof(GetSecretAsync) + " instead")]
         public async Task<string> GetRawSecretAsync(string secretName)
         {
             Guard.NotNullOrWhitespace(secretName, nameof(secretName), "Requires a non-blank secret name when mutating secret names");
@@ -87,6 +88,7 @@ namespace Arcus.Security.Core.Providers
         /// <returns>Returns the secret key.</returns>
         /// <exception cref="ArgumentException">Thrown when the <paramref name="secretName"/> is blank.</exception>
         /// <exception cref="SecretNotFoundException">Thrown when the secret was not found, using the given name.</exception>
+        [Obsolete("Will be removed in v3 in favor of solely using " + nameof(GetSecretAsync) + " instead")]
         public string GetRawSecret(string secretName)
         {
             Guard.NotNullOrWhitespace(secretName, nameof(secretName), "Requires a non-blank secret name when mutating secret names");
@@ -177,7 +179,7 @@ namespace Arcus.Security.Core.Providers
             }
         }
 
-         /// <summary>
+        /// <summary>
         /// Safeguards an asynchronous function that will run after the given <paramref name="secretName"/> is mutated.
         /// </summary>
         /// <typeparam name="T">The return type of the asynchronous function.</typeparam>

--- a/src/Arcus.Security.Providers.AzureKeyVault/Configuration/ArcusConfigurationProvider.cs
+++ b/src/Arcus.Security.Providers.AzureKeyVault/Configuration/ArcusConfigurationProvider.cs
@@ -2,7 +2,6 @@
 using System.Threading.Tasks;
 using Arcus.Security.Core;
 using Microsoft.Extensions.Configuration;
-using GuardNet;
 
 namespace Arcus.Security.Providers.AzureKeyVault.Configuration
 {
@@ -21,7 +20,7 @@ namespace Arcus.Security.Providers.AzureKeyVault.Configuration
         {
             _secretProvider = secretProvider ?? throw new ArgumentNullException(nameof(secretProvider));
         }
-        
+
         /// <summary>
         /// Attempts to find a value with the given key, returns true if one is found, false otherwise.
         /// </summary>
@@ -30,13 +29,13 @@ namespace Arcus.Security.Providers.AzureKeyVault.Configuration
         /// <returns>True if key has a value, false otherwise.</returns>
         public override bool TryGet(string key, out string value)
         {
-            Task<string> getSecretValueAsync = _secretProvider.GetRawSecretAsync(key);
-            if (getSecretValueAsync != null) 
+            Task<Secret> getSecretValueAsync = _secretProvider.GetSecretAsync(key);
+            if (getSecretValueAsync != null)
             {
-                string secretValue = getSecretValueAsync.ConfigureAwait(false).GetAwaiter().GetResult();
-                
-                value = secretValue;
-                return secretValue != null;
+                Secret secret = getSecretValueAsync.ConfigureAwait(false).GetAwaiter().GetResult();
+
+                value = secret.Value;
+                return secret.Value != null;
             }
 
             value = null;


### PR DESCRIPTION
As discussed in #438 , the 'raw secret' functionality is something from the past and only adds unnecessary/duplicated maintainability overhead while not providing enough added-value.

This PR deprecates all mentions of the 'get raw secret' functionality in the core component.