### PR TITLE
chore(net10.0): add support for .net 10.0 throughout

### DIFF
--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -25,7 +25,7 @@ jobs:
       uses: actions/checkout@v2
     - uses: actions/setup-dotnet@v3
       with:
-        dotnet-version: '8.0.x'
+        dotnet-version: '10.0.x'
         dotnet-quality: 'preview'
 
     - name: Coverlet coverage unit test

--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -29,7 +29,7 @@ jobs:
         dotnet-quality: 'preview'
 
     - name: Coverlet coverage unit test
-      run: dotnet test --framework net8.0 -p:coverletOutput=coverage.json -p:CollectCoverage=true -p:CoverletOutputFormat=\"opencover,json\" -p:ExcludeByAttribute=\"Obsolete,GeneratedCodeAttribute,CompilerGeneratedAttribute\" -p:Exclude=\"[Arcus.Security.Tests.*]*,[Arcus.Security.Providers.*]*\" src/Arcus.Security.Tests.Unit/Arcus.Security.Tests.Unit.csproj
+      run: dotnet test --framework net10.0 -p:coverletOutput=coverage.json -p:CollectCoverage=true -p:CoverletOutputFormat=\"opencover,json\" -p:ExcludeByAttribute=\"Obsolete,GeneratedCodeAttribute,CompilerGeneratedAttribute\" -p:Exclude=\"[Arcus.Security.Tests.*]*,[Arcus.Security.Providers.*]*\" src/Arcus.Security.Tests.Unit/Arcus.Security.Tests.Unit.csproj
 
     - name: Codecov
       uses: codecov/codecov-action@v3.1.1

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -41,7 +41,7 @@ jobs:
       uses: actions/checkout@v2
     - uses: actions/setup-dotnet@v3
       with:
-        dotnet-version: '8.0.x'
+        dotnet-version: '10.0.x'
         dotnet-quality: 'preview'
 
     # Initializes the CodeQL tools for scanning.

--- a/build/variables/build.yml
+++ b/build/variables/build.yml
@@ -1,7 +1,7 @@
 variables:
-  DotNet.Sdk.Version: '8.0.x'
+  DotNet.Sdk.Version: '10.0.x'
   # Backwards compatible .NET SDK version
-  DotNet.Sdk.VersionBC: '6.0.100'
-  DotNet.Sdk.IncludePreviewVersions: false
+  DotNet.Sdk.VersionBC: '8.0.x'
+  DotNet.Sdk.IncludePreviewVersions: true
   Project: 'Arcus.Security'
   Vm.Image: 'ubuntu-latest'

--- a/src/Arcus.Security.Core/Arcus.Security.Core.csproj
+++ b/src/Arcus.Security.Core/Arcus.Security.Core.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net6.0;netstandard2.1</TargetFrameworks>
+    <TargetFrameworks>net10.0;net8.0</TargetFrameworks>
     <Authors>Arcus</Authors>
     <Company>Arcus</Company>
     <Description>Contains core functionality for Arcus.Security</Description>

--- a/src/Arcus.Security.Providers.AzureKeyVault/Arcus.Security.Providers.AzureKeyVault.csproj
+++ b/src/Arcus.Security.Providers.AzureKeyVault/Arcus.Security.Providers.AzureKeyVault.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net6.0;netstandard2.1</TargetFrameworks>
+    <TargetFrameworks>net10.0;net8.0</TargetFrameworks>
     <Authors>Arcus</Authors>
     <Description>Provides support for Azure Key Vault</Description>
     <Copyright>Copyright (c) Arcus</Copyright>

--- a/src/Arcus.Security.Providers.CommandLine/Arcus.Security.Providers.CommandLine.csproj
+++ b/src/Arcus.Security.Providers.CommandLine/Arcus.Security.Providers.CommandLine.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net6.0;netstandard2.1</TargetFrameworks>
+    <TargetFrameworks>net10.0;net8.0</TargetFrameworks>
     <Authors>Arcus</Authors>
     <Description>Provides support for command line arguments with Arcus Secret Store</Description>
     <Copyright>Copyright (c) Arcus</Copyright>

--- a/src/Arcus.Security.Providers.DockerSecrets/Arcus.Security.Providers.DockerSecrets.csproj
+++ b/src/Arcus.Security.Providers.DockerSecrets/Arcus.Security.Providers.DockerSecrets.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net6.0;netstandard2.1</TargetFrameworks>
+    <TargetFrameworks>net10.0;net8.0</TargetFrameworks>
     <Authors>Arcus</Authors>
     <Description>Provides support for Docker Secrets</Description>
     <Copyright>Copyright (c) Arcus</Copyright>

--- a/src/Arcus.Security.Providers.HashiCorp/Arcus.Security.Providers.HashiCorp.csproj
+++ b/src/Arcus.Security.Providers.HashiCorp/Arcus.Security.Providers.HashiCorp.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net6.0;netstandard2.1</TargetFrameworks>
+    <TargetFrameworks>net10.0;net8.0</TargetFrameworks>
     <Authors>Arcus</Authors>
     <Description>Provides support for HashiCorp</Description>
     <Copyright>Copyright (c) Arcus</Copyright>

--- a/src/Arcus.Security.Providers.UserSecrets/Arcus.Security.Providers.UserSecrets.csproj
+++ b/src/Arcus.Security.Providers.UserSecrets/Arcus.Security.Providers.UserSecrets.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net6.0;netstandard2.1</TargetFrameworks>
+    <TargetFrameworks>net10.0;net8.0</TargetFrameworks>
     <Authors>Arcus</Authors>
     <Description>Provides support for User Secrets with Arcus Secret Store</Description>
     <Copyright>Copyright (c) Arcus</Copyright>

--- a/src/Arcus.Security.Tests.Core/Arcus.Security.Tests.Core.csproj
+++ b/src/Arcus.Security.Tests.Core/Arcus.Security.Tests.Core.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
+    <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Arcus.Security.Tests.Integration/Arcus.Security.Tests.Integration.csproj
+++ b/src/Arcus.Security.Tests.Integration/Arcus.Security.Tests.Integration.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net6.0</TargetFrameworks>
+    <TargetFramework>net10.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <NoWarn>CS0618</NoWarn>
   </PropertyGroup>

--- a/src/Arcus.Security.Tests.Unit/Arcus.Security.Tests.Unit.csproj
+++ b/src/Arcus.Security.Tests.Unit/Arcus.Security.Tests.Unit.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net6.0</TargetFrameworks>
+    <TargetFramework>net10.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <NoWarn>CS0618</NoWarn>
   </PropertyGroup>


### PR DESCRIPTION
Adds .NET 10 support throughout the solution mostly for more easily migration to .NET 10 without already removing Arcus in one go.