### PR TITLE
chore(cmd.line): internally implement new secret provider for cmd line

### DIFF
--- a/src/Arcus.Security.Core/ISecretProvider.cs
+++ b/src/Arcus.Security.Core/ISecretProvider.cs
@@ -1,6 +1,9 @@
 ﻿using System;
+using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using GuardNet;
+
+[assembly: InternalsVisibleTo("Arcus.Security.Providers.CommandLine")]
 
 namespace Arcus.Security.Core
 {

--- a/src/Arcus.Security.Providers.CommandLine/CommandLineSecretProvider.cs
+++ b/src/Arcus.Security.Providers.CommandLine/CommandLineSecretProvider.cs
@@ -4,15 +4,17 @@ using Arcus.Security.Core;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Configuration.CommandLine;
 
+#pragma warning disable S1133
+
 namespace Arcus.Security.Providers.CommandLine
 {
     /// <summary>
     /// Represents an <see cref="ISecretProvider"/> implementation that provides the command line arguments as secrets to the secret store.
     /// </summary>
-    public class CommandLineSecretProvider : ISyncSecretProvider
+    public class CommandLineSecretProvider : ISyncSecretProvider, ISecretProvider
     {
         private readonly CommandLineConfigurationProvider _configurationProvider;
-        
+
         /// <summary>
         /// Initializes a new instance of the <see cref="CommandLineSecretProvider"/> class.
         /// </summary>
@@ -24,11 +26,30 @@ namespace Arcus.Security.Providers.CommandLine
         }
 
         /// <summary>
+        /// Gets the secret by its name from the registered provider.
+        /// </summary>
+        /// <param name="secretName">The name to identity the stored secret.</param>
+        /// <returns>
+        ///     <para>[Success] when the secret with the provided <paramref name="secretName"/> was found;</para>
+        ///     <para>[Failure] when the secret could not be retrieved via the provider.</para>
+        /// </returns>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="secretName"/> is blank.</exception>
+        SecretResult ISecretProvider.GetSecret(string secretName)
+        {
+            ArgumentException.ThrowIfNullOrWhiteSpace(secretName);
+
+            return _configurationProvider.TryGet(secretName, out string secretValue)
+                ? SecretResult.Success(secretName, secretValue)
+                : SecretResult.NotFound($"no secret '{secretName}' found in command line arguments");
+        }
+
+        /// <summary>
         /// Retrieves the secret value, based on the given name
         /// </summary>
         /// <param name="secretName">The name of the secret key</param>
         /// <returns>Returns a <see cref="Secret"/> that contains the secret key</returns>
         /// <exception cref="ArgumentException">Thrown when the <paramref name="secretName"/> is blank.</exception>
+        [Obsolete("Will be removed in v3.0 in favor of using secret result as a return type")]
         public Task<Secret> GetSecretAsync(string secretName)
         {
             Secret secret = GetSecret(secretName);
@@ -41,6 +62,7 @@ namespace Arcus.Security.Providers.CommandLine
         /// <param name="secretName">The name of the secret key</param>
         /// <returns>Returns the secret key.</returns>
         /// <exception cref="ArgumentException">Thrown when the <paramref name="secretName"/> is blank.</exception>
+        [Obsolete("Will be removed in v3.0 as 'raw secrets' support will be removed")]
         public Task<string> GetRawSecretAsync(string secretName)
         {
             string rawSecret = GetRawSecret(secretName);
@@ -54,6 +76,7 @@ namespace Arcus.Security.Providers.CommandLine
         /// <returns>Returns a <see cref="Secret"/> that contains the secret key</returns>
         /// <exception cref="ArgumentException">Thrown when the <paramref name="secretName"/> is blank.</exception>
         /// <exception cref="SecretNotFoundException">Thrown when the secret was not found, using the given name.</exception>
+        [Obsolete("Will be removed in v3.0 in favor of using secret result as a return type")]
         public Secret GetSecret(string secretName)
         {
             string secretValue = GetRawSecret(secretName);
@@ -72,19 +95,11 @@ namespace Arcus.Security.Providers.CommandLine
         /// <returns>Returns the secret key.</returns>
         /// <exception cref="ArgumentException">Thrown when the <paramref name="secretName"/> is blank.</exception>
         /// <exception cref="SecretNotFoundException">Thrown when the secret was not found, using the given name.</exception>
+        [Obsolete("Will be removed in v3.0 as 'raw secrets' support will be removed")]
         public string GetRawSecret(string secretName)
         {
-            if (string.IsNullOrWhiteSpace(secretName))
-            {
-                throw new ArgumentException("Requires a non-blank secret name to look up the command line argument secret", nameof(secretName));
-            }
-
-            if (_configurationProvider.TryGet(secretName, out string secretValue))
-            {
-                return secretValue;
-            }
-
-            return null;
+            SecretResult result = ((ISecretProvider) this).GetSecret(secretName);
+            return result.IsSuccess ? result.Value : null;
         }
     }
 }

--- a/src/Arcus.Security.Providers.CommandLine/CommandLineSecretProvider.cs
+++ b/src/Arcus.Security.Providers.CommandLine/CommandLineSecretProvider.cs
@@ -22,7 +22,8 @@ namespace Arcus.Security.Providers.CommandLine
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="configurationProvider"/> is <c>null</c>.</exception>
         public CommandLineSecretProvider(CommandLineConfigurationProvider configurationProvider)
         {
-            _configurationProvider = configurationProvider ?? throw new ArgumentNullException(nameof(configurationProvider));
+            ArgumentNullException.ThrowIfNull(configurationProvider);
+            _configurationProvider = configurationProvider;
         }
 
         /// <summary>


### PR DESCRIPTION
Internally implement the new `ISecretProvider` interface in the command line provider as preparation for the migration, without too much changes at once.