### PR TITLE
chore(hashicorp.vault): deprecate diff auth mechainsm in favor of future considelation

### DIFF
--- a/src/Arcus.Security.Providers.HashiCorp/Configuration/HashiCorpVaultKubernetesOptions.cs
+++ b/src/Arcus.Security.Providers.HashiCorp/Configuration/HashiCorpVaultKubernetesOptions.cs
@@ -6,6 +6,9 @@ namespace Arcus.Security.Providers.HashiCorp.Configuration
     /// <summary>
     /// Represents the available options to configure the <see cref="HashiCorpSecretProvider"/> when using the Kubernetes authentication.
     /// </summary>
+#pragma warning disable S1133
+    [Obsolete("Will be removed in v3.0 in favor of consolidating HashiCorp Vault authentication mechanisms")]
+#pragma warning restore S1133
     public class HashiCorpVaultKubernetesOptions : HashiCorpVaultOptions
     {
         private string _kubernetesMountPoint = AuthMethodDefaultPaths.Kubernetes;
@@ -21,7 +24,7 @@ namespace Arcus.Security.Providers.HashiCorp.Configuration
             {
                 if (string.IsNullOrWhiteSpace(value))
                 {
-                    throw new ArgumentException("Requires a non-blank mount point for the Kubernetes authentication", nameof(value)); 
+                    throw new ArgumentException("Requires a non-blank mount point for the Kubernetes authentication", nameof(value));
                 }
 
                 _kubernetesMountPoint = value;

--- a/src/Arcus.Security.Providers.HashiCorp/Configuration/HashiCorpVaultOptions.cs
+++ b/src/Arcus.Security.Providers.HashiCorp/Configuration/HashiCorpVaultOptions.cs
@@ -22,7 +22,7 @@ namespace Arcus.Security.Providers.HashiCorp.Configuration
             {
                 if (string.IsNullOrWhiteSpace(value))
                 {
-                    throw new ArgumentException("Requires a non-blank point where the KeyVault secret engine is mounted", nameof(value)); 
+                    throw new ArgumentException("Requires a non-blank point where the KeyVault secret engine is mounted", nameof(value));
                 }
 
                 _keyValueMountPoint = value;
@@ -50,6 +50,9 @@ namespace Arcus.Security.Providers.HashiCorp.Configuration
         /// <summary>
         /// Gets or sets the flag indicating whether or not to track the HashiCorp Vault dependency.
         /// </summary>
+#pragma warning disable S1133
+        [Obsolete("Will be removed in v3.0 as the hard-link with Arcus.Observability will be removed")]
+#pragma warning restore S1133
         public bool TrackDependency { get; set; }
     }
 }

--- a/src/Arcus.Security.Providers.HashiCorp/Configuration/HashiCorpVaultUserPassOptions.cs
+++ b/src/Arcus.Security.Providers.HashiCorp/Configuration/HashiCorpVaultUserPassOptions.cs
@@ -6,6 +6,9 @@ namespace Arcus.Security.Providers.HashiCorp.Configuration
     /// <summary>
     /// Represents the available options to configure the <see cref="HashiCorpSecretProvider"/> when using the UserPass authentication.
     /// </summary>
+#pragma warning disable S1133
+    [Obsolete("Will be removed in v3.0 in favor of consolidating HashiCorp Vault authentication mechanisms")]
+#pragma warning restore S1133
     public class HashiCorpVaultUserPassOptions : HashiCorpVaultOptions
     {
         private string _userPassMountPoint = AuthMethodDefaultPaths.UserPass;

--- a/src/Arcus.Security.Providers.HashiCorp/Extensions/SecretStoreBuilderExtensions.cs
+++ b/src/Arcus.Security.Providers.HashiCorp/Extensions/SecretStoreBuilderExtensions.cs
@@ -37,6 +37,9 @@ namespace Arcus.Security.Providers.HashiCorp.Extensions
         ///     or the <paramref name="username"/> or <paramref name="password"/> is blank,
         ///     or the <paramref name="secretPath"/> is blank.
         /// </exception>
+#pragma warning disable S1133
+        [Obsolete("Will be removed in v3.0 in favor of consolidating HashiCorp Vault authentication mechanisms")]
+#pragma warning restore S1133
         public static SecretStoreBuilder AddHashiCorpVaultWithUserPass(
             this SecretStoreBuilder builder,
             string vaultServerUriWithPort,
@@ -67,6 +70,9 @@ namespace Arcus.Security.Providers.HashiCorp.Extensions
         ///     or the <paramref name="username"/> or <paramref name="password"/> is blank,
         ///     or the <paramref name="secretPath"/> is blank.
         /// </exception>
+#pragma warning disable S1133
+        [Obsolete("Will be removed in v3.0 in favor of consolidating HashiCorp Vault authentication mechanisms")]
+#pragma warning restore S1133
         public static SecretStoreBuilder AddHashiCorpVaultWithUserPass(
             this SecretStoreBuilder builder,
             string vaultServerUriWithPort,
@@ -100,6 +106,9 @@ namespace Arcus.Security.Providers.HashiCorp.Extensions
         ///     or the <paramref name="username"/> or <paramref name="password"/> is blank,
         ///     or the <paramref name="secretPath"/> is blank.
         /// </exception>
+#pragma warning disable S1133
+        [Obsolete("Will be removed in v3.0 in favor of consolidating HashiCorp Vault authentication mechanisms")]
+#pragma warning restore S1133
         public static SecretStoreBuilder AddHashiCorpVaultWithUserPass(
             this SecretStoreBuilder builder,
             string vaultServerUriWithPort,
@@ -171,6 +180,9 @@ namespace Arcus.Security.Providers.HashiCorp.Extensions
         ///     or the <paramref name="jsonWebToken"/> is blank,
         ///     or the <paramref name="secretPath"/> is blank.
         /// </exception>
+#pragma warning disable S1133
+        [Obsolete("Will be removed in v3.0 in favor of consolidating HashiCorp Vault authentication mechanisms")]
+#pragma warning restore S1133
         public static SecretStoreBuilder AddHashiCorpVaultWithKubernetes(
             this SecretStoreBuilder builder,
             string vaultServerUriWithPort,
@@ -207,6 +219,9 @@ namespace Arcus.Security.Providers.HashiCorp.Extensions
         ///     or the <paramref name="jsonWebToken"/> is blank,
         ///     or the <paramref name="secretPath"/> is blank.
         /// </exception>
+#pragma warning disable S1133
+        [Obsolete("Will be removed in v3.0 in favor of consolidating HashiCorp Vault authentication mechanisms")]
+#pragma warning restore S1133
         public static SecretStoreBuilder AddHashiCorpVaultWithKubernetes(
             this SecretStoreBuilder builder,
             string vaultServerUriWithPort,
@@ -231,7 +246,7 @@ namespace Arcus.Security.Providers.HashiCorp.Extensions
             {
                 throw new ArgumentException("Requires a path where the HashiCorp Vault secrets are stored", nameof(secretPath));
             }
-            
+
             if (!Uri.IsWellFormedUriString(vaultServerUriWithPort, UriKind.RelativeOrAbsolute))
             {
                 throw new ArgumentException("Requires a HashiCorp Vault server URI with HTTP port", nameof(vaultServerUriWithPort));
@@ -268,6 +283,9 @@ namespace Arcus.Security.Providers.HashiCorp.Extensions
         ///     Thrown when the <paramref name="settings"/> doesn't have a valid Vault server URI or a missing authentication method,
         ///     or the <paramref name="secretPath"/> is blank.
         /// </exception>
+#pragma warning disable S1133
+        [Obsolete("Will be removed in v3.0 in favor of consolidating HashiCorp Vault authentication mechanisms")]
+#pragma warning restore S1133
         public static SecretStoreBuilder AddHashiCorpVault(
             this SecretStoreBuilder builder,
             VaultClientSettings settings,
@@ -297,6 +315,9 @@ namespace Arcus.Security.Providers.HashiCorp.Extensions
         ///     Thrown when the <paramref name="settings"/> doesn't have a valid Vault server URI or a missing authentication method,
         ///     or the <paramref name="secretPath"/> is blank.
         /// </exception>
+#pragma warning disable S1133
+        [Obsolete("Will be removed in v3.0 in favor of using new secret provider options")]
+#pragma warning restore S1133
         public static SecretStoreBuilder AddHashiCorpVault(
             this SecretStoreBuilder builder,
             VaultClientSettings settings,
@@ -314,7 +335,7 @@ namespace Arcus.Security.Providers.HashiCorp.Extensions
                 secretProviderOptions.MutateSecretName = mutateSecretName;
             });
         }
-        
+
         /// <summary>
         /// <para>
         ///     Adds the secrets of a HashiCorp Vault KeyValue engine to the secret store.
@@ -327,8 +348,11 @@ namespace Arcus.Security.Providers.HashiCorp.Extensions
         /// <param name="builder">The builder to add the HashiCorp secrets from the KeyValue Vault to.</param>
         /// <param name="implementationFactory">The factory function to create an implementation of the <see cref="HashiCorpSecretProvider"/>.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="builder"/> or the <paramref name="implementationFactory"/> is <c>null</c>.</exception>
+#pragma warning disable S1133
+        [Obsolete("Will be removed in v3.0 as inheriting secret providers will be removed as extension")]
+#pragma warning restore S1133
         public static SecretStoreBuilder AddHashiCorpVault<TSecretProvider>(
-            this SecretStoreBuilder builder, 
+            this SecretStoreBuilder builder,
             Func<IServiceProvider, TSecretProvider> implementationFactory)
             where TSecretProvider : HashiCorpSecretProvider
         {
@@ -349,8 +373,11 @@ namespace Arcus.Security.Providers.HashiCorp.Extensions
         /// <param name="name">The unique name to register this HashiCorp provider in the secret store.</param>
         /// <param name="mutateSecretName">The optional function to mutate the secret name before looking it up.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="builder"/> or the <paramref name="implementationFactory"/> is <c>null</c>.</exception>
+#pragma warning disable S1133
+        [Obsolete("Will be removed in v3.0 as inheriting secret providers will be removed as extension")]
+#pragma warning restore S1133
         public static SecretStoreBuilder AddHashiCorpVault<TSecretProvider>(
-            this SecretStoreBuilder builder, 
+            this SecretStoreBuilder builder,
             Func<IServiceProvider, TSecretProvider> implementationFactory,
             string name,
             Func<string, string> mutateSecretName)
@@ -403,7 +430,7 @@ namespace Arcus.Security.Providers.HashiCorp.Extensions
             {
                 var logger = serviceProvider.GetService<ILogger<HashiCorpSecretProvider>>();
                 var provider = new HashiCorpSecretProvider(settings, secretPath, options, logger);
-                
+
                 return provider;
             }, configureSecretProviderOptions);
         }

--- a/src/Arcus.Security.Providers.HashiCorp/HashiCorpSecretProvider.cs
+++ b/src/Arcus.Security.Providers.HashiCorp/HashiCorpSecretProvider.cs
@@ -75,22 +75,22 @@ namespace Arcus.Security.Providers.HashiCorp
             VaultClient = new VaultClient(settings);
             Logger = logger ?? NullLogger<HashiCorpSecretProvider>.Instance;
         }
-        
+
         /// <summary>
         /// Gets the user-configurable options to configure and change the behavior of the HashiCorp KeyValue Vault.
         /// </summary>
         protected HashiCorpVaultOptions Options { get; }
-        
+
         /// <summary>
         /// Gets the HashiCorp secret path available in the KeyValue engine where this secret provider should look for secrets.
         /// </summary>
         protected string SecretPath { get; }
-        
+
         /// <summary>
         /// Gets the client to interact with the HashiCorp KeyValue Vault, based on the user-provided <see cref="VaultClientSettings"/>.
         /// </summary>
         protected IVaultClient VaultClient { get; }
-        
+
         /// <summary>
         /// Gets the logger instance to write diagnostic messages and track HashiCorp Vault dependencies.
         /// </summary>
@@ -160,22 +160,24 @@ namespace Arcus.Security.Providers.HashiCorp
                     Logger.LogTrace("Getting a secret {SecretName} from HashiCorp Vault {VaultUri}...", secretName, VaultClient.Settings.VaultServerUriWithPort);
                     SecretData result = await ReadSecretDataAsync();
                     Logger.LogTrace("Secret '{SecretName}' was successfully retrieved from HashiCorp Vault {VaultUri}", secretName, VaultClient.Settings.VaultServerUriWithPort);
-                    
+
                     isSuccessful = true;
                     return result;
                 }
                 catch (Exception exception)
                 {
-                    Logger.LogError(exception, "Secret '{SecretName}' was not successfully retrieved from HashiCorp Vault {VaultUri}, cause: {Message}", 
+                    Logger.LogError(exception, "Secret '{SecretName}' was not successfully retrieved from HashiCorp Vault {VaultUri}, cause: {Message}",
                         secretName, VaultClient.Settings.VaultServerUriWithPort, exception.Message);
 
                     throw;
                 }
                 finally
                 {
+#pragma warning disable CS0618 // Type or member is obsolete
                     if (Options.TrackDependency)
+#pragma warning restore CS0618 // Type or member is obsolete
                     {
-                        Logger.LogDependency(DependencyName, secretName, VaultClient.Settings.VaultServerUriWithPort, isSuccessful, measurement, context); 
+                        Logger.LogDependency(DependencyName, secretName, VaultClient.Settings.VaultServerUriWithPort, isSuccessful, measurement, context);
                     }
                 }
             }
@@ -192,15 +194,15 @@ namespace Arcus.Security.Providers.HashiCorp
             switch (Options.KeyValueVersion)
             {
                 case VaultKeyValueSecretEngineVersion.V1:
-                    Secret<Dictionary<string, object>> secretV1 = 
+                    Secret<Dictionary<string, object>> secretV1 =
                         await VaultClient.V1.Secrets.KeyValue.V1.ReadSecretAsync(SecretPath, mountPoint: Options.KeyValueMountPoint);
                     return new SecretData { Data = secretV1.Data };
-                
+
                 case VaultKeyValueSecretEngineVersion.V2:
-                    Secret<SecretData> secretV2 = 
+                    Secret<SecretData> secretV2 =
                         await VaultClient.V1.Secrets.KeyValue.V2.ReadSecretAsync(SecretPath, mountPoint: Options.KeyValueMountPoint);
                     return secretV2.Data;
-                
+
                 default:
                     throw new ArgumentOutOfRangeException(nameof(Options), Options.KeyValueVersion, "Unknown HashiCorp Vault KeyValue secret engine version");
             }


### PR DESCRIPTION
Related to #438 , some extensions with different authentication mechanisms (like with Azure Key Vault and HashiCorp Vault), will be consolidated to limit maintainence cost and improve usability. This PR deprecates the functionality in HashiCorp Vault that will be removed in v3.0.