### PR TITLE
chore(deps): use package ranges for user secrets provider

### DIFF
--- a/src/Arcus.Security.Providers.UserSecrets/Arcus.Security.Providers.UserSecrets.csproj
+++ b/src/Arcus.Security.Providers.UserSecrets/Arcus.Security.Providers.UserSecrets.csproj
@@ -25,7 +25,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="[8.*,10.0.0)" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
There is a security vulnerability on the 6.* version of the Microsoft UserSecrets package. Also, we should use package ranges for maximum stable support.
This PR provides a package range for this package, going from 8.* to (and limited to) 10.0.0.