### PR TITLE
chore(core): deprecate remaining core functionality

### DIFF
--- a/src/Arcus.Security.Core/Caching/CachedSecretProvider.cs
+++ b/src/Arcus.Security.Core/Caching/CachedSecretProvider.cs
@@ -11,6 +11,7 @@ namespace Arcus.Security.Core.Caching
     /// <summary>
     /// A <see cref="ISecretProvider"/> that will cache secrets in memory, to improve performance.
     /// </summary>
+    [Obsolete("Will be removed in v3.0 as caching will happen directly on the secret store")]
     public class CachedSecretProvider : ICachedSecretProvider, IVersionedSecretProvider, ISyncSecretProvider
     {
         private readonly ISecretProvider _secretProvider;

--- a/src/Arcus.Security.Core/Caching/Configuration/ICacheConfiguration.cs
+++ b/src/Arcus.Security.Core/Caching/Configuration/ICacheConfiguration.cs
@@ -5,6 +5,7 @@ namespace Arcus.Security.Core.Caching.Configuration
     /// <summary>
     /// Collected configuration values to control the caching when interacting with Azure Key Vault.
     /// </summary>
+    [Obsolete("Will be removed in v3.0 as caching will happen on the secret store itself")]
     public interface ICacheConfiguration
     {
         /// <summary>

--- a/src/Arcus.Security.Core/Caching/ICachedSecretProvider.cs
+++ b/src/Arcus.Security.Core/Caching/ICachedSecretProvider.cs
@@ -7,11 +7,13 @@ namespace Arcus.Security.Core.Caching
     /// <summary>
     /// <see cref="ICachedSecretProvider"/> allows developers to build specific Secret key providers with caching.
     /// </summary>
+    [Obsolete("Will be removed in v3.0 as caching will happen on the secret store itself")]
     public interface ICachedSecretProvider : ISecretProvider
     {
         /// <summary>
         /// Gets the cache-configuration for this instance.
         /// </summary>
+        [Obsolete("Will be removed in v3.0 as caching will happen on the secret store itself")]
         ICacheConfiguration Configuration { get; }
 
         /// <summary>
@@ -35,6 +37,7 @@ namespace Arcus.Security.Core.Caching
         /// <exception cref="ArgumentException">The name must not be empty</exception>
         /// <exception cref="ArgumentNullException">The name must not be null</exception>
         /// <exception cref="SecretNotFoundException">The secret was not found, using the given name</exception>
+        [Obsolete("Will be removed in v3.0 as caching will happen on the secret store itself")]
         Task<Secret> GetSecretAsync(string secretName, bool ignoreCache);
 
 
@@ -43,6 +46,7 @@ namespace Arcus.Security.Core.Caching
         /// so the next time <see cref="CachedSecretProvider.GetSecretAsync(string)"/> is called, a new version of the secret will be added back to the cache.
         /// </summary>
         /// <param name="secretName">The name of the secret that should be removed from the cache.</param>
+        [Obsolete("Will be removed in v3.0 as caching will happen on the secret store itself")]
         Task InvalidateSecretAsync(string secretName);
     }
 }

--- a/src/Arcus.Security.Core/Extensions/ISecretProviderExtensions.cs
+++ b/src/Arcus.Security.Core/Extensions/ISecretProviderExtensions.cs
@@ -20,7 +20,7 @@ namespace Arcus.Security.Core
         /// <returns>Returns the secret key.</returns>
         /// <exception cref="ArgumentException">Thrown when the <paramref name="secretName"/> is blank.</exception>
         /// <exception cref="SecretNotFoundException">Thrown when the secret was not found, using the given name.</exception>
-        [Obsolete("Will be removed in v3 in favor of solely using " + nameof(ISecretProvider.GetSecretAsync) + " instead")]
+        [Obsolete("Will be removed in v3 in favor of solely using " + nameof(Arcus.Security.ISecretProvider.GetSecretAsync) + " instead")]
         public static string GetRawSecret(this ISecretProvider secretProvider, string secretName)
         {
             if (secretProvider is null)
@@ -51,6 +51,7 @@ namespace Arcus.Security.Core
         /// <returns>Returns the secret key.</returns>
         /// <exception cref="ArgumentException">Thrown when the <paramref name="secretName"/> is blank.</exception>
         /// <exception cref="SecretNotFoundException">Thrown when the secret was not found, using the given name.</exception>
+        [Obsolete("Will be removed in v3.0 in favor of using a new secret provider interface 'Arcus.Security.ISecretProvider'")]
         public static Secret GetSecret(this ISecretProvider secretProvider, string secretName)
         {
             if (secretProvider is null)

--- a/src/Arcus.Security.Core/ISecretProvider.cs
+++ b/src/Arcus.Security.Core/ISecretProvider.cs
@@ -16,6 +16,7 @@ namespace Arcus.Security.Core
     /// <summary>
     /// <see cref="ISecretProvider"/> allows developers to build specific Secret key providers.
     /// </summary>
+    [Obsolete("Will be removed in v3.0 in favor a new interface 'Arcus.Security.ISecretProvider'")]
     public interface ISecretProvider
     {
         /// <summary>

--- a/src/Arcus.Security.Core/ISyncSecretProvider.cs
+++ b/src/Arcus.Security.Core/ISyncSecretProvider.cs
@@ -5,6 +5,7 @@ namespace Arcus.Security.Core
     /// <summary>
     /// Represents an additional synchronous implementation on top of the <see cref="ISecretProvider"/>.
     /// </summary>
+    [Obsolete("Will be removed in v3.0 in favor of using the new secret provider interface which has already a synchronous variant of secret retrieval")]
     public interface ISyncSecretProvider : ISecretProvider
     {
         /// <summary>

--- a/src/Arcus.Security.Core/IVersionedSecretProvider.cs
+++ b/src/Arcus.Security.Core/IVersionedSecretProvider.cs
@@ -7,6 +7,7 @@ namespace Arcus.Security.Core
     /// <summary>
     /// Represents an <see cref="ISecretProvider"/> implementation that supports multiple versions of a secret.
     /// </summary>
+    [Obsolete("Will be removed in v3.0 in favor of accessing versioned secrets on the concrete secret provider implementations")]
     public interface IVersionedSecretProvider : ISecretProvider
     {
         /// <summary>

--- a/src/Arcus.Security.Core/Providers/ConfigurationSecretProvider.cs
+++ b/src/Arcus.Security.Core/Providers/ConfigurationSecretProvider.cs
@@ -9,7 +9,9 @@ namespace Arcus.Security.Core.Providers
     /// </summary>
     public class ConfigurationSecretProvider :
 #pragma warning disable CS0612 // Type or member is obsolete
+#pragma warning disable CS0618 // Type or member is obsolete
         ISyncSecretProvider,
+#pragma warning restore CS0618 // Type or member is obsolete
 #pragma warning restore CS0612 // Type or member is obsolete
         Security.ISecretProvider
     {

--- a/src/Arcus.Security.Core/Providers/EnvironmentVariableSecretProvider.cs
+++ b/src/Arcus.Security.Core/Providers/EnvironmentVariableSecretProvider.cs
@@ -43,7 +43,9 @@ namespace Arcus.Security.Core.Providers
     /// </summary>
     public class EnvironmentVariableSecretProvider :
 #pragma warning disable CS0612 // Type or member is obsolete
+#pragma warning disable CS0618 // Type or member is obsolete
         ISyncSecretProvider,
+#pragma warning restore CS0618 // Type or member is obsolete
 #pragma warning restore CS0612 // Type or member is obsolete
         Security.ISecretProvider
     {

--- a/src/Arcus.Security.Core/Secret.cs
+++ b/src/Arcus.Security.Core/Secret.cs
@@ -5,6 +5,7 @@ namespace Arcus.Security.Core
     /// <summary>
     /// Represents the secret returned from the <see cref="ISecretProvider"/> implementation.
     /// </summary>
+    [Obsolete("Will be removed in v3.0 in favor of using secret results")]
     public class Secret
     {
         /// <summary>
@@ -24,7 +25,7 @@ namespace Arcus.Security.Core
         /// <summary>
         /// Gets the secret value.
         /// </summary>
-        public string Value { get;}
+        public string Value { get; }
 
         /// <summary>
         /// Gets the optional version of the secret.

--- a/src/Arcus.Security.Core/SecretNotFoundException.cs
+++ b/src/Arcus.Security.Core/SecretNotFoundException.cs
@@ -5,6 +5,7 @@ namespace Arcus.Security.Core
     /// <summary>
     /// Exception, thrown when no secret was found, using the given name.
     /// </summary>
+    [Obsolete("Will be removed in v3.0 in favor of using secret results")]
     public class SecretNotFoundException : Exception
     {
         /// <summary>
@@ -13,7 +14,7 @@ namespace Arcus.Security.Core
         public SecretNotFoundException() : base("The secret was not found.")
         {
         }
-        
+
         /// <summary>
         /// Creates <see cref="SecretNotFoundException"/> , using the given name
         /// </summary>

--- a/src/Arcus.Security.Core/SecretProviderOptions.cs
+++ b/src/Arcus.Security.Core/SecretProviderOptions.cs
@@ -1,11 +1,13 @@
 ﻿using System;
 using System.Collections.Generic;
+using Microsoft.Extensions.Hosting;
 
 namespace Arcus.Security.Core
 {
     /// <summary>
     /// Represents the additional options to register an <see cref="ISecretProvider"/> implementation to the secret store.
     /// </summary>
+    [Obsolete("Will be removed in v3.0 in favor of a new " + nameof(SecretProviderRegistrationOptions) + " model")]
     public class SecretProviderOptions
     {
         private readonly IDictionary<string, int> _versionedSecretNames = new Dictionary<string, int>();
@@ -21,8 +23,8 @@ namespace Arcus.Security.Core
         /// Gets or sets the name of the <see cref="ISecretProvider"/> to be registered in the secret store.
         /// </summary>
         /// <exception cref="ArgumentException">Thrown when the <paramref name="value"/> is blank.</exception>
-        public string Name 
-        {  
+        public string Name
+        {
             get => _name;
             set
             {

--- a/src/Arcus.Security.Core/SecretStoreBuilder.cs
+++ b/src/Arcus.Security.Core/SecretStoreBuilder.cs
@@ -301,6 +301,7 @@ namespace Microsoft.Extensions.Hosting
         /// which makes sure that the secret store handles all exceptions of type <typeparamref name="TException"/> differently.
         /// </summary>
         /// <typeparam name="TException">The type of the <see cref="Exception"/> to add as critical exception.</typeparam>
+        [Obsolete("Will be removed in v3.0 in favor of using secret results")]
         public SecretStoreBuilder AddCriticalException<TException>() where TException : Exception
         {
             CriticalExceptionFilters.Add(new CriticalExceptionFilter(typeof(TException), exception => exception is TException));
@@ -314,6 +315,7 @@ namespace Microsoft.Extensions.Hosting
         /// <typeparam name="TException">The type of the <see cref="Exception"/> to add as critical exception.</typeparam>
         /// <param name="exceptionFilter">The filter that makes sure that only specific <typeparamref name="TException"/>'s are considered critical exceptions.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="exceptionFilter"/> is <c>null</c>.</exception>
+        [Obsolete("Will be removed in v3.0 in favor of using secret results")]
         public SecretStoreBuilder AddCriticalException<TException>(Func<TException, bool> exceptionFilter) where TException : Exception
         {
             if (exceptionFilter is null)

--- a/src/Arcus.Security.Core/SecretStoreBuilder.cs
+++ b/src/Arcus.Security.Core/SecretStoreBuilder.cs
@@ -73,6 +73,7 @@ namespace Microsoft.Extensions.Hosting
         ///     The extended secret store with the given <paramref name="secretProvider"/>.
         /// </returns>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="secretProvider"/> is <c>null</c>.</exception>
+        [Obsolete("Will be removed in v3.0 in favor of using a new interface 'Arcus.Security.ISecretProvider'")]
         public SecretStoreBuilder AddProvider(ISecretProvider secretProvider)
         {
             return AddProvider(secretProvider ?? throw new ArgumentNullException(nameof(secretProvider)), configureOptions: null);
@@ -87,6 +88,7 @@ namespace Microsoft.Extensions.Hosting
         ///     The extended secret store with the given <paramref name="secretProvider"/>.
         /// </returns>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="secretProvider"/> is <c>null</c>.</exception>
+        [Obsolete("Will be removed in v3.0 in favor of using a new interface 'Arcus.Security.ISecretProvider'")]
         public SecretStoreBuilder AddProvider(
             ISecretProvider secretProvider,
             Action<SecretProviderOptions> configureOptions)
@@ -140,6 +142,7 @@ namespace Microsoft.Extensions.Hosting
         ///     The extended secret store with the given <paramref name="createSecretProvider"/> as lazy initialization.
         /// </returns>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="createSecretProvider"/> is <c>null</c>.</exception>
+        [Obsolete("Will be removed in v3.0 in favor of using a new interface 'Arcus.Security.ISecretProvider'")]
         public SecretStoreBuilder AddProvider(
             Func<IServiceProvider, ISecretProvider> createSecretProvider,
             Action<SecretProviderOptions> configureOptions)

--- a/src/Arcus.Security.Providers.AzureKeyVault/KeyVaultSecretProvider.cs
+++ b/src/Arcus.Security.Providers.AzureKeyVault/KeyVaultSecretProvider.cs
@@ -21,12 +21,16 @@ namespace Arcus.Security.Providers.AzureKeyVault
     /// <summary>
     ///     Secret key provider that connects to Azure Key Vault
     /// </summary>
-    public class KeyVaultSecretProvider : IVersionedSecretProvider, ISyncSecretProvider, ISecretProvider
+    public class KeyVaultSecretProvider :
+#pragma warning disable CS0618 // Type or member is obsolete
+        IVersionedSecretProvider, ISyncSecretProvider,
+#pragma warning restore CS0618 // Type or member is obsolete
+        ISecretProvider
     {
         private readonly SecretClient _secretClient;
         private readonly ILogger _logger;
 
-        [Obsolete] private readonly KeyVaultOptions _options = new();
+        [Obsolete("Will be removed in v3.0")] private readonly KeyVaultOptions _options = new();
 
         internal KeyVaultSecretProvider(SecretClient secretClient, ILogger<KeyVaultSecretProvider> logger)
         {
@@ -341,6 +345,7 @@ namespace Arcus.Security.Providers.AzureKeyVault
             throw result.FailureCause ?? new SecretNotFoundException(secretName);
         }
 
+        [Obsolete("Will be removed in v3.0")]
         private static Exception DetermineFinalException(string secretName, SecretResult result)
         {
             if (result.FailureCause is null or RequestFailedException { Status: (int) HttpStatusCode.NotFound })

--- a/src/Arcus.Security.Providers.CommandLine/CommandLineSecretProvider.cs
+++ b/src/Arcus.Security.Providers.CommandLine/CommandLineSecretProvider.cs
@@ -11,7 +11,11 @@ namespace Arcus.Security.Providers.CommandLine
     /// <summary>
     /// Represents an <see cref="ISecretProvider"/> implementation that provides the command line arguments as secrets to the secret store.
     /// </summary>
-    public class CommandLineSecretProvider : ISyncSecretProvider, ISecretProvider
+    public class CommandLineSecretProvider :
+#pragma warning disable CS0618 // Type or member is obsolete
+        ISyncSecretProvider,
+#pragma warning restore CS0618 // Type or member is obsolete
+        ISecretProvider
     {
         private readonly CommandLineConfigurationProvider _configurationProvider;
 

--- a/src/Arcus.Security.Providers.DockerSecrets/DockerSecretsSecretProvider.cs
+++ b/src/Arcus.Security.Providers.DockerSecrets/DockerSecretsSecretProvider.cs
@@ -13,7 +13,9 @@ namespace Arcus.Security.Providers.DockerSecrets
     /// </summary>
 #pragma warning disable S3881 // Constructor will be solely internal in v3.0.
 #pragma warning disable CS0612 // Type or member is obsolete: synchronous secret provider interface will be removed in v3.0.
+#pragma warning disable CS0618 // Type or member is obsolete
     public class DockerSecretsSecretProvider : ISyncSecretProvider, ISecretProvider, IDisposable
+#pragma warning restore CS0618 // Type or member is obsolete
 #pragma warning restore CS0612 // Type or member is obsolete
 #pragma warning restore S3881
     {

--- a/src/Arcus.Security.Providers.HashiCorp/Extensions/SecretStoreBuilderExtensions.cs
+++ b/src/Arcus.Security.Providers.HashiCorp/Extensions/SecretStoreBuilderExtensions.cs
@@ -449,11 +449,13 @@ namespace Arcus.Security.Providers.HashiCorp.Extensions
         private static void AddHashiCorpCriticalExceptions(SecretStoreBuilder builder)
         {
             // Thrown when the HashiCorp Vault's authentication and/or authorization fails.
+#pragma warning disable CS0618 // Type or member is obsolete
             builder.AddCriticalException<VaultApiException>(exception =>
             {
                 return exception.HttpStatusCode == HttpStatusCode.BadRequest
                        || exception.HttpStatusCode == HttpStatusCode.Forbidden;
             });
+#pragma warning restore CS0618 // Type or member is obsolete
         }
     }
 }

--- a/src/Arcus.Security.Providers.HashiCorp/HashiCorpSecretProvider.cs
+++ b/src/Arcus.Security.Providers.HashiCorp/HashiCorpSecretProvider.cs
@@ -21,7 +21,9 @@ namespace Arcus.Security.Providers.HashiCorp
     /// </summary>
     public class HashiCorpSecretProvider :
 #pragma warning disable CS0612
+#pragma warning disable CS0618 // Type or member is obsolete
         Core.ISecretProvider,
+#pragma warning restore CS0618 // Type or member is obsolete
 #pragma warning restore CS0612
         ISecretProvider
     {

--- a/src/Arcus.Security.Providers.UserSecrets/UserSecretsSecretProvider.cs
+++ b/src/Arcus.Security.Providers.UserSecrets/UserSecretsSecretProvider.cs
@@ -13,7 +13,9 @@ namespace Arcus.Security.Providers.UserSecrets
     /// </summary>
 #pragma warning disable S3881 // Constructor will be solely internal in v3.0.
 #pragma warning disable CS0612 // Type or member is obsolete: synchronous secret provider interface will be removed in v3.0.
+#pragma warning disable CS0618 // Type or member is obsolete
     public class UserSecretsSecretProvider : ISyncSecretProvider, ISecretProvider, IDisposable
+#pragma warning restore CS0618 // Type or member is obsolete
 #pragma warning restore CS0612 // Type or member is obsolete
 #pragma warning restore S3881
     {


### PR DESCRIPTION
Now that all the implementations have updated their deprecated/new extensions, we can safely deprecate the abstractions itself in the core package.

Relates to #438 