### PR TITLE
chore(core): make new interfaces public

### DIFF
--- a/src/Arcus.Security.Core/Extensions/ISecretProviderExtensions.cs
+++ b/src/Arcus.Security.Core/Extensions/ISecretProviderExtensions.cs
@@ -115,8 +115,69 @@ namespace Arcus.Security.Core
         /// <exception cref="ArgumentException">The <paramref name="secretName"/> must not be empty</exception>
         /// <exception cref="ArgumentNullException">The <paramref name="secretName"/> must not be null</exception>
         /// <exception cref="SecretNotFoundException">The secret was not found, using the given name</exception>
+        [Obsolete("Will be removed in v3 in favor of solely using " + nameof(GetSecretsAsync) + " instead")]
+        public static async Task<IEnumerable<string>> GetRawSecretsAsync(this Security.ISecretProvider secretProvider, string secretName)
+        {
+            if (string.IsNullOrWhiteSpace(secretName))
+            {
+                throw new ArgumentException("Requires a non-blank secret name to look up the secret", nameof(secretName));
+            }
+
+            if (secretProvider is CompositeSecretProvider composite)
+            {
+                IEnumerable<string> secretValues = await composite.GetRawSecretsAsync(secretName);
+                return secretValues.ToArray();
+            }
+
+            string secretValue = await secretProvider.GetRawSecretAsync(secretName);
+            return new[] { secretValue };
+        }
+
+        /// <summary>
+        /// Retrieves all the allowed versions of a secret value, based on the given <paramref name="secretName"/>.
+        /// </summary>
+        /// <remarks>
+        ///     This extension is made for easy access to the versions of a secret, and is expected to be used on the <paramref name="secretProvider"/> secret store implementation,
+        ///     any other uses will fallback on the general secret retrieval. In that case, the resulting sequence will contain a single secret value.
+        /// </remarks>
+        /// <param name="secretProvider">The secret store composite secret provider.</param>
+        /// <param name="secretName">The name of the secret that was made versioned with <see cref="SecretProviderOptions.AddVersionedSecret"/>.</param>
+        /// <exception cref="ArgumentException">The <paramref name="secretName"/> must not be empty</exception>
+        /// <exception cref="ArgumentNullException">The <paramref name="secretName"/> must not be null</exception>
+        /// <exception cref="SecretNotFoundException">The secret was not found, using the given name</exception>
         [Obsolete("Will be removed in v3.0 as versioned secrets will be handled on the concrete secret providers themselves")]
         public static async Task<IEnumerable<Secret>> GetSecretsAsync(this ISecretProvider secretProvider, string secretName)
+        {
+            if (string.IsNullOrWhiteSpace(secretName))
+            {
+                throw new ArgumentException("Requires a non-blank secret name to look up the secret", nameof(secretName));
+            }
+
+            if (secretProvider is CompositeSecretProvider composite)
+            {
+                IEnumerable<Secret> secrets = await composite.GetSecretsAsync(secretName);
+                return secrets.ToArray();
+            }
+
+            Secret secret = await secretProvider.GetSecretAsync(secretName);
+            return new[] { secret };
+        }
+
+
+        /// <summary>
+        /// Retrieves all the allowed versions of a secret value, based on the given <paramref name="secretName"/>.
+        /// </summary>
+        /// <remarks>
+        ///     This extension is made for easy access to the versions of a secret, and is expected to be used on the <paramref name="secretProvider"/> secret store implementation,
+        ///     any other uses will fallback on the general secret retrieval. In that case, the resulting sequence will contain a single secret value.
+        /// </remarks>
+        /// <param name="secretProvider">The secret store composite secret provider.</param>
+        /// <param name="secretName">The name of the secret that was made versioned with <see cref="SecretProviderOptions.AddVersionedSecret"/>.</param>
+        /// <exception cref="ArgumentException">The <paramref name="secretName"/> must not be empty</exception>
+        /// <exception cref="ArgumentNullException">The <paramref name="secretName"/> must not be null</exception>
+        /// <exception cref="SecretNotFoundException">The secret was not found, using the given name</exception>
+        [Obsolete("Will be removed in v3.0 as versioned secrets will be handled on the concrete secret providers themselves")]
+        public static async Task<IEnumerable<Secret>> GetSecretsAsync(this Security.ISecretProvider secretProvider, string secretName)
         {
             if (string.IsNullOrWhiteSpace(secretName))
             {

--- a/src/Arcus.Security.Core/ISecretProvider.cs
+++ b/src/Arcus.Security.Core/ISecretProvider.cs
@@ -2,14 +2,8 @@
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
-using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
-
-[assembly: InternalsVisibleTo("Arcus.Security.Providers.HashiCorp")]
-[assembly: InternalsVisibleTo("Arcus.Security.Providers.UserSecrets")]
-[assembly: InternalsVisibleTo("Arcus.Security.Providers.DockerSecrets")]
-[assembly: InternalsVisibleTo("Arcus.Security.Providers.CommandLine")]
-[assembly: InternalsVisibleTo("Arcus.Security.Providers.AzureKeyVault")]
+using Arcus.Security.Core;
 
 namespace Arcus.Security.Core
 {
@@ -46,7 +40,7 @@ namespace Arcus.Security
     /// <summary>
     /// Represents a provider that can retrieve secrets based on a given name.
     /// </summary>
-    internal interface ISecretProvider
+    public interface ISecretProvider
     {
         /// <summary>
         /// Gets the secret by its name from the registered provider.
@@ -72,6 +66,76 @@ namespace Arcus.Security
         /// </returns>
         /// <exception cref="ArgumentException">Thrown when the <paramref name="secretName"/> is blank.</exception>
         SecretResult GetSecret(string secretName);
+    }
+
+    /// <summary>
+    /// Extensions on the <see cref="ISecretProvider"/> to ease the migration to the new secret retrieval operations.
+    /// </summary>
+    public static class DeprecatedSecretProviderExtensions
+    {
+        /// <summary>
+        /// Retrieves the secret value, based on the given name
+        /// </summary>
+        /// <param name="provider"></param>
+        /// <param name="secretName">The name of the secret key</param>
+        /// <returns>Returns a <see cref="Secret"/> that contains the secret key</returns>
+        /// <exception cref="ArgumentException">The <paramref name="secretName"/> must not be empty</exception>
+        /// <exception cref="ArgumentNullException">The <paramref name="secretName"/> must not be null</exception>
+        /// <exception cref="SecretNotFoundException">The secret was not found, using the given name</exception>
+        [Obsolete("Will be removed in v3.0, please use the new " + nameof(ISecretProvider.GetSecretAsync) + " overloads with secret results")]
+        public static async Task<Secret> GetSecretAsync(this ISecretProvider provider, string secretName)
+        {
+            SecretResult result = await provider.GetSecretAsync(secretName);
+            return result.IsSuccess ? new Secret(result.Value, result.Version, result.Expiration) : throw new SecretNotFoundException(secretName);
+        }
+
+        /// <summary>
+        /// Retrieves the secret value, based on the given name
+        /// </summary>
+        /// <param name="provider"></param>
+        /// <param name="secretName">The name of the secret key</param>
+        /// <returns>Returns a <see cref="Secret"/> that contains the secret key</returns>
+        /// <exception cref="ArgumentException">The <paramref name="secretName"/> must not be empty</exception>
+        /// <exception cref="ArgumentNullException">The <paramref name="secretName"/> must not be null</exception>
+        /// <exception cref="SecretNotFoundException">The secret was not found, using the given name</exception>
+        [Obsolete("Will be removed in v3.0, please use the new " + nameof(ISecretProvider.GetSecret) + " overloads with secret results")]
+        public static Secret GetSecret(this ISecretProvider provider, string secretName)
+        {
+            SecretResult result = provider.GetSecret(secretName);
+            return result.IsSuccess ? new Secret(result.Value, result.Version, result.Expiration) : throw new SecretNotFoundException(secretName);
+        }
+
+        /// <summary>
+        /// Retrieves the secret value, based on the given name
+        /// </summary>
+        /// <param name="provider"></param>
+        /// <param name="secretName">The name of the secret key</param>
+        /// <returns>Returns the secret key.</returns>
+        /// <exception cref="ArgumentException">The <paramref name="secretName"/> must not be empty</exception>
+        /// <exception cref="ArgumentNullException">The <paramref name="secretName"/> must not be null</exception>
+        /// <exception cref="SecretNotFoundException">The secret was not found, using the given name</exception>
+        [Obsolete("Will be removed in v3.0, please use the new " + nameof(ISecretProvider.GetSecretAsync) + " overloads with secret results")]
+        public static async Task<string> GetRawSecretAsync(this ISecretProvider provider, string secretName)
+        {
+            Secret secret = await GetSecretAsync(provider, secretName);
+            return secret.Value;
+        }
+
+        /// <summary>
+        /// Retrieves the secret value, based on the given name
+        /// </summary>
+        /// <param name="provider"></param>
+        /// <param name="secretName">The name of the secret key</param>
+        /// <returns>Returns the secret key.</returns>
+        /// <exception cref="ArgumentException">The <paramref name="secretName"/> must not be empty</exception>
+        /// <exception cref="ArgumentNullException">The <paramref name="secretName"/> must not be null</exception>
+        /// <exception cref="SecretNotFoundException">The secret was not found, using the given name</exception>
+        [Obsolete("Will be removed in v3.0, please use the new " + nameof(ISecretProvider.GetSecret) + " overloads with secret results")]
+        public static string GetRawSecret(this ISecretProvider provider, string secretName)
+        {
+            Secret secret = GetSecret(provider, secretName);
+            return secret.Value;
+        }
     }
 
     /// <summary>
@@ -237,6 +301,15 @@ namespace Arcus.Security
         public static implicit operator string(SecretResult result)
         {
             return result?.Value;
+        }
+
+        /// <summary>
+        /// Converts the <see cref="SecretResult"/> to its deprecated previous implementation.
+        /// </summary>
+        [Obsolete("Will be removed in v3.0 in favor of using secret results")]
+        public static implicit operator Secret(SecretResult result)
+        {
+            return result.IsSuccess ? new Secret(result.Value, result.Version, result._expirationDate) : null;
         }
 
         /// <summary>

--- a/src/Arcus.Security.Core/ISecretStore.cs
+++ b/src/Arcus.Security.Core/ISecretStore.cs
@@ -67,7 +67,7 @@ namespace Arcus.Security
     /// <summary>
     /// Represents the central point of contact to retrieve secrets from registered <see cref="ISecretProvider"/>s in the user application.
     /// </summary>
-    internal interface ISecretStore : ISecretProvider, ISecretStoreContext
+    public interface ISecretStore : ISecretProvider, ISecretStoreContext
     {
         /// <summary>
         /// Gets the registered named <see cref="ISecretProvider"/> from the secret store.
@@ -75,7 +75,7 @@ namespace Arcus.Security
         /// <typeparam name="TProvider">The concrete type of the secret provider implementation.</typeparam>
         /// <param name="providerName">
         ///     The name of the concrete secret provider implementation;
-        ///     uses the FQN (fully-qualified name) of the type in case none is provided.
+        ///     uses the type name of the type in case none is provided.
         /// </param>
         /// <exception cref="ArgumentException">Thrown when the <paramref name="providerName"/> is blank.</exception>
         /// <exception cref="KeyNotFoundException">Thrown when no secret provider(s) was found with the provided <paramref name="providerName"/>.</exception>
@@ -105,6 +105,97 @@ namespace Arcus.Security
         /// </returns>
         /// <exception cref="ArgumentException">Thrown when the <paramref name="secretName"/> is blank.</exception>
         SecretResult GetSecret(string secretName, Action<SecretOptions> configureOptions);
+    }
+
+    /// <summary>
+    /// Extensions on the <see cref="ISecretStore"/> to ease the migration process.
+    /// </summary>
+    public static class SecretStoreExtensions
+    {
+        /// <summary>
+        /// Gets the registered named <see cref="ISecretProvider"/> from the secret store.
+        /// </summary>
+        /// <param name="store">The registered secret store to retrieve a single/subset secret provider from.</param>
+        /// <param name="providerName">
+        ///     The name of the concrete secret provider implementation;
+        ///     uses the type name of the type in case none is provided.
+        /// </param>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="providerName"/> is blank.</exception>
+        /// <exception cref="KeyNotFoundException">Thrown when no secret provider(s) was found with the provided <paramref name="providerName"/>.</exception>
+        public static ISecretProvider GetProvider(this ISecretStore store, string providerName)
+        {
+            return store.GetProvider<ISecretProvider>(providerName);
+        }
+
+        /// <summary>
+        /// Gets the registered named <see cref="ISecretProvider"/> from the secret store.
+        /// </summary>
+        /// <param name="store"></param>
+        /// <param name="name">The name that was used to register the <see cref="ISecretProvider"/> in the secret store.</param>
+        /// <typeparam name="TSecretProvider">The concrete <see cref="ISecretProvider"/> type.</typeparam>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="name"/> is blank.</exception>
+        /// <exception cref="KeyNotFoundException">Thrown when there was no <see cref="ISecretProvider"/> found in the secret store with the given <paramref name="name"/>.</exception>
+        /// <exception cref="InvalidCastException">Thrown when the registered <see cref="ISecretProvider"/> cannot be cast to the specific <typeparamref name="TSecretProvider"/>.</exception>
+        /// <exception cref="InvalidOperationException">Thrown when multiple <see cref="ISecretProvider"/> were registered with the same name.</exception>
+        [Obsolete("Will be removed in v3.0 in favor of a new interface 'Arcus.Security.ISecretProvider'")]
+        public static TSecretProvider GetProvider<TSecretProvider>(this ISecretStore store, string name) where TSecretProvider : Core.ISecretProvider
+        {
+            var provider = store.GetProvider<ISecretProvider>(name);
+            if (provider is not TSecretProvider concrete)
+            {
+                throw new InvalidCastException($"Cannot cast the registered '{name}' secret provider to a '{nameof(TSecretProvider)}' implementation");
+            }
+
+            return concrete;
+        }
+
+        /// <summary>
+        /// Gets the registered named <see cref="ICachedSecretProvider"/> from the secret store.
+        /// </summary>
+        /// <param name="store"></param>
+        /// <param name="name">The name that was used to register the <see cref="ICachedSecretProvider"/> in the secret store.</param>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="name"/> is blank.</exception>
+        /// <exception cref="KeyNotFoundException">Thrown when there was no <see cref="ICachedSecretProvider"/> found in the secret store with the given <paramref name="name"/>.</exception>
+        /// <exception cref="NotSupportedException">
+        ///     Thrown when their was either none of the registered secret providers are registered as <see cref="ICachedSecretProvider"/> instances
+        ///     or there was an <see cref="ISecretProvider"/> registered but not with caching.
+        /// </exception>
+        [Obsolete("Will be removed in v3.0 as secret caching will happen on the secret store itself")]
+        public static ICachedSecretProvider GetCachedProvider(this ISecretStore store, string name)
+        {
+            var provider = store.GetProvider<ISecretProvider>(name);
+            if (provider is not ICachedSecretProvider cached)
+            {
+                throw new InvalidCastException($"Cannot cast the registered '{name}' secret provider to a '{nameof(ICachedSecretProvider)}' implementation");
+            }
+
+            return cached;
+        }
+
+        /// <summary>
+        /// Gets the registered named <see cref="ICachedSecretProvider"/> from the secret store.
+        /// </summary>
+        /// <param name="store"></param>
+        /// <param name="name">The name that was used to register the <see cref="ICachedSecretProvider"/> in the secret store.</param>
+        /// <typeparam name="TCachedSecretProvider">The concrete <see cref="ICachedSecretProvider"/> type.</typeparam>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="name"/> is blank.</exception>
+        /// <exception cref="KeyNotFoundException">Thrown when there was no <see cref="ICachedSecretProvider"/> found in the secret store with the given <paramref name="name"/>.</exception>
+        /// <exception cref="NotSupportedException">
+        ///     Thrown when none of the registered secret providers are registered as <see cref="ICachedSecretProvider"/> instances
+        ///     or there was an <see cref="ISecretProvider"/> registered but not with caching.
+        /// </exception>
+        /// <exception cref="InvalidCastException">Thrown when the registered <see cref="ICachedSecretProvider"/> cannot be cast to the specific <typeparamref name="TCachedSecretProvider"/>.</exception>
+        /// <exception cref="InvalidOperationException">Thrown when multiple <see cref="ICachedSecretProvider"/> were registered with the same name.</exception>
+        public static TCachedSecretProvider GetCachedProvider<TCachedSecretProvider>(this ISecretStore store, string name) where TCachedSecretProvider : ICachedSecretProvider
+        {
+            var provider = store.GetProvider<ISecretProvider>(name);
+            if (provider is not TCachedSecretProvider cached)
+            {
+                throw new InvalidCastException($"Cannot cast the registered '{name}' secret provider to a '{nameof(TCachedSecretProvider)}' implementation");
+            }
+
+            return cached;
+        }
     }
 
     /// <summary>

--- a/src/Arcus.Security.Core/SecretStoreBuilder.cs
+++ b/src/Arcus.Security.Core/SecretStoreBuilder.cs
@@ -221,7 +221,7 @@ namespace Microsoft.Extensions.Hosting
         ///     The extended secret store with the given <paramref name="secretProvider"/>.
         /// </returns>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="secretProvider"/> is <c>null</c>.</exception>
-        internal SecretStoreBuilder AddProvider<TProvider>(TProvider secretProvider, Action<SecretProviderRegistrationOptions> configureOptions)
+        public SecretStoreBuilder AddProvider<TProvider>(TProvider secretProvider, Action<SecretProviderRegistrationOptions> configureOptions)
             where TProvider : Arcus.Security.ISecretProvider
         {
             ArgumentNullException.ThrowIfNull(secretProvider);
@@ -239,7 +239,7 @@ namespace Microsoft.Extensions.Hosting
         ///     The extended secret store with the given <paramref name="implementationFactory"/> as lazy initialization.
         /// </returns>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="implementationFactory"/> is <c>null</c>.</exception>
-        internal SecretStoreBuilder AddProvider<TProvider>(
+        public SecretStoreBuilder AddProvider<TProvider>(
             Func<IServiceProvider, ISecretStoreContext, TProvider> implementationFactory,
             Action<SecretProviderRegistrationOptions> configureOptions)
             where TProvider : Arcus.Security.ISecretProvider
@@ -268,7 +268,7 @@ namespace Microsoft.Extensions.Hosting
         ///     The extended secret store with the given <paramref name="implementationFactory"/> as lazy initialization.
         /// </returns>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="implementationFactory"/> is <c>null</c>.</exception>
-        internal SecretStoreBuilder AddProvider<TProvider, TOptions>(
+        public SecretStoreBuilder AddProvider<TProvider, TOptions>(
             Func<IServiceProvider, ISecretStoreContext, TOptions, TProvider> implementationFactory,
             Action<TOptions> configureOptions)
             where TProvider : Arcus.Security.ISecretProvider

--- a/src/Arcus.Security.Tests.Unit/Core/Stubs/AsyncStaticSecretProvider.cs
+++ b/src/Arcus.Security.Tests.Unit/Core/Stubs/AsyncStaticSecretProvider.cs
@@ -1,13 +1,9 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 using Arcus.Security.Core;
 
 namespace Arcus.Security.Tests.Unit.Core.Stubs
 {
-    internal class AsyncStaticSecretProvider : ISecretProvider
+    internal class AsyncStaticSecretProvider : ISecretProvider, Security.Core.ISecretProvider
     {
         private readonly string _secretValue;
 
@@ -17,6 +13,11 @@ namespace Arcus.Security.Tests.Unit.Core.Stubs
         public AsyncStaticSecretProvider(string secretValue)
         {
             _secretValue = secretValue;
+        }
+
+        public SecretResult GetSecret(string secretName)
+        {
+            return SecretResult.Success(secretName, _secretValue);
         }
 
         public Task<string> GetRawSecretAsync(string secretName)


### PR DESCRIPTION
Make the new interfaces `ISecretProvider`/`ISecretStore` public with the necessary deprecation extensions to smooth the migration process.

Relates to #448 , #438 