### PR TITLE
chore(core): make secret result name always available

### DIFF
--- a/src/Arcus.Security.Core/CompositeSecretProvider.cs
+++ b/src/Arcus.Security.Core/CompositeSecretProvider.cs
@@ -155,7 +155,7 @@ namespace Arcus.Security
             if (_registrations.Count is 0)
             {
                 _logger.LogSecretMissingFromStore(secretName);
-                return SecretResult.NotFound(NoProvidersRegistered);
+                return SecretResult.NotFound(secretName, NoProvidersRegistered);
             }
 
             _logger.LogSecretLookup(secretName);
@@ -194,7 +194,7 @@ namespace Arcus.Security
                 }
                 catch (Exception exception)
                 {
-                    failures.Add(SecretResult.Interrupted(ExceptionDuringLookup, exception));
+                    failures.Add(SecretResult.Interrupted(secretName, ExceptionDuringLookup, exception));
                     _logger.LogSecretMissingFromProviderException(exception, secretNameDescription, providerName);
                 }
             }
@@ -211,7 +211,7 @@ namespace Arcus.Security
             if (failureCauses.Length <= 0)
             {
                 _logger.LogSecretMissingFromStore(secretName, failures);
-                return SecretResult.NotFound(failureMessage);
+                return SecretResult.NotFound(secretName, failureMessage);
             }
 
             var failureCause = failureCauses.Length == 1
@@ -221,8 +221,8 @@ namespace Arcus.Security
             _logger.LogSecretMissingFromStore(failureCause, secretName, failures);
 
             return failures.Any(f => f.Failure is SecretFailure.Interrupted)
-                ? SecretResult.Interrupted(failureMessage, failureCause)
-                : SecretResult.NotFound(failureMessage, failureCause);
+                ? SecretResult.Interrupted(secretName, failureMessage, failureCause)
+                : SecretResult.NotFound(secretName, failureMessage, failureCause);
         }
 
         #region Deprecated code

--- a/src/Arcus.Security.Core/Providers/ConfigurationSecretProvider.cs
+++ b/src/Arcus.Security.Core/Providers/ConfigurationSecretProvider.cs
@@ -41,7 +41,7 @@ namespace Arcus.Security.Core.Providers
 
             string secretValue = _configuration[secretName];
             return secretValue is null
-                ? SecretResult.NotFound($"cannot find secret '{secretName}' in application configuration")
+                ? SecretResult.NotFound(secretName, $"cannot find secret '{secretName}' in application configuration")
                 : SecretResult.Success(secretName, secretValue);
         }
 

--- a/src/Arcus.Security.Core/Providers/EnvironmentVariableSecretProvider.cs
+++ b/src/Arcus.Security.Core/Providers/EnvironmentVariableSecretProvider.cs
@@ -93,7 +93,7 @@ namespace Arcus.Security.Core.Providers
 
             string secretValue = Environment.GetEnvironmentVariable(_prefix + secretName, _target);
             return secretValue is null
-                ? SecretResult.NotFound($"cannot find secret '{_prefix}{secretName} in environment variables with target '{_target}'")
+                ? SecretResult.NotFound(secretName, $"cannot find secret '{_prefix}{secretName} in environment variables with target '{_target}'")
                 : SecretResult.Success(secretName, secretValue);
         }
 

--- a/src/Arcus.Security.Core/SecretStoreBuilder.cs
+++ b/src/Arcus.Security.Core/SecretStoreBuilder.cs
@@ -193,7 +193,7 @@ namespace Microsoft.Extensions.Hosting
                 {
                     Secret secret = syncProvider.GetSecret(secretName);
                     return secret is null
-                        ? SecretResult.NotFound($"could not find secret '{secretName}' in provider '{DeprecatedProvider.GetType().Name}'")
+                        ? SecretResult.NotFound(secretName, $"could not find secret '{secretName}' in provider '{DeprecatedProvider.GetType().Name}'")
                         : SecretResult.Success(secretName, secret.Value, secret.Version, secret.Expires ?? default);
                 }
 
@@ -206,7 +206,7 @@ namespace Microsoft.Extensions.Hosting
             {
                 Secret secret = await DeprecatedProvider.GetSecretAsync(secretName);
                 return secret is null
-                    ? SecretResult.NotFound($"could not find secret '{secretName}' in provider '{DeprecatedProvider.GetType().Name}'")
+                    ? SecretResult.NotFound(secretName, $"could not find secret '{secretName}' in provider '{DeprecatedProvider.GetType().Name}'")
                     : SecretResult.Success(secretName, secret.Value, secret.Version, secret.Expires ?? default);
             }
         }

--- a/src/Arcus.Security.Providers.AzureKeyVault/KeyVaultSecretProvider.cs
+++ b/src/Arcus.Security.Providers.AzureKeyVault/KeyVaultSecretProvider.cs
@@ -146,8 +146,8 @@ namespace Arcus.Security.Providers.AzureKeyVault
         private static SecretResult SuccessOrNotFoundVersions(string secretName, RequestFailedException failureOnVersions)
         {
             return failureOnVersions?.Status is (int) HttpStatusCode.NotFound
-                ? SecretResult.NotFound($"no enabled secret versions found for '{secretName}'", failureOnVersions)
-                : SecretResult.Interrupted($"enabled secret versions cannot be retrieved for '{secretName}'", failureOnVersions);
+                ? SecretResult.NotFound(secretName, $"no enabled secret versions found for '{secretName}'", failureOnVersions)
+                : SecretResult.Interrupted(secretName, $"enabled secret versions cannot be retrieved for '{secretName}'", failureOnVersions);
         }
 
         private async Task<(string[], RequestFailedException)> DetermineEnabledVersionsAsync(string secretName)
@@ -203,7 +203,7 @@ namespace Arcus.Security.Providers.AzureKeyVault
             }
             catch (RequestFailedException ex) when (ex.Status is (int) HttpStatusCode.NotFound)
             {
-                return SecretResult.NotFound($"cannot find secret '{secretName}' in Azure Key Vault secrets", ex);
+                return SecretResult.NotFound(secretName, $"cannot find secret '{secretName}' in Azure Key Vault secrets", ex);
             }
         }
 

--- a/src/Arcus.Security.Providers.CommandLine/CommandLineSecretProvider.cs
+++ b/src/Arcus.Security.Providers.CommandLine/CommandLineSecretProvider.cs
@@ -49,7 +49,7 @@ namespace Arcus.Security.Providers.CommandLine
 
             return _configurationProvider.TryGet(secretName, out string secretValue)
                 ? SecretResult.Success(secretName, secretValue)
-                : SecretResult.NotFound($"no secret '{secretName}' found in command line arguments");
+                : SecretResult.NotFound(secretName, $"no secret '{secretName}' found in command line arguments");
         }
 
         /// <summary>

--- a/src/Arcus.Security.Providers.DockerSecrets/DockerSecretsSecretProvider.cs
+++ b/src/Arcus.Security.Providers.DockerSecrets/DockerSecretsSecretProvider.cs
@@ -100,7 +100,7 @@ namespace Arcus.Security.Providers.DockerSecrets
 
             return _provider.TryGet(secretName, out string secretValue)
                 ? SecretResult.Success(secretName, secretValue)
-                : SecretResult.NotFound($"cannot found secret '{secretName}' in Docker Secrets");
+                : SecretResult.NotFound(secretName, $"cannot found secret '{secretName}' in Docker Secrets");
         }
 
         /// <summary>

--- a/src/Arcus.Security.Providers.HashiCorp/HashiCorpSecretProvider.cs
+++ b/src/Arcus.Security.Providers.HashiCorp/HashiCorpSecretProvider.cs
@@ -113,7 +113,7 @@ namespace Arcus.Security.Providers.HashiCorp
                 return SecretResult.Success(secretName, value.ToString(), version, default);
             }
 
-            return SecretResult.NotFound($"cannot find secret '{secretName}' in HashiCorp Vault");
+            return SecretResult.NotFound(secretName, $"cannot find secret '{secretName}' in HashiCorp Vault");
         }
 
         /// <summary>

--- a/src/Arcus.Security.Providers.UserSecrets/UserSecretsSecretProvider.cs
+++ b/src/Arcus.Security.Providers.UserSecrets/UserSecretsSecretProvider.cs
@@ -85,7 +85,7 @@ namespace Arcus.Security.Providers.UserSecrets
 
             return _jsonProvider.TryGet(secretName, out string secretValue)
                 ? SecretResult.Success(secretName, secretValue)
-                : SecretResult.NotFound($"cannot found '{secretName}' in User Secrets");
+                : SecretResult.NotFound(secretName, $"cannot found '{secretName}' in User Secrets");
         }
 
         /// <summary>


### PR DESCRIPTION
Make sure that all failed versions of the `SecretResult` model also includes the secret name for better tracability/defect localization. It also makes more sense that this information is always available.

Follow-up on #460 