### PR TITLE
feat(secret): add support for fine-grained secret caching

### DIFF
--- a/docs/preview/03-Features/secret-store/index.mdx
+++ b/docs/preview/03-Features/secret-store/index.mdx
@@ -131,7 +131,6 @@ public class MySqlService
 <summary><h3 style={{ margin:0 }}>⚡ Secret caching</h3></summary>
 
 To limit possible throttling during external secrets retrieval, the secret store can be customized to cache secrets for a period of time.
-
 ```csharp
 builder.ConfigureServices(services =>
 {
@@ -142,14 +141,18 @@ builder.ConfigureServices(services =>
 });
 ```
 
-All secrets are cached by default, but this can be ignored on a by-secret basis.
+All secrets are cached by default upon registering the cache duration, but this can be ignored on a by-secret basis.
 ```csharp
 using Arcus.Security;
 
 ISecretStore store = ...
 SecretResult result = store.GetSecret("Contoso_Sql_ConnectionString", options => 
 {
-    options.UseCache = false;
+    // Prevent secret caching on this secret retrieval.
+    options.DisableCaching();
+
+    // Overwrite (if already registered)/Enable (if not already registered) secret caching duration on this secret retrieval.
+    options.EnableCaching(TimeSpan.FromMinutes(2));
 });
 ```
 

--- a/src/Arcus.Security.Core/CompositeSecretProvider.cs
+++ b/src/Arcus.Security.Core/CompositeSecretProvider.cs
@@ -538,7 +538,14 @@ namespace Arcus.Security
         [Obsolete("Will be removed in v3 in favor of solely using " + nameof(GetSecretAsync) + " instead")]
         public async Task<string> GetRawSecretAsync(string secretName, bool ignoreCache)
         {
-            SecretResult result = await GetSecretAsync(secretName, options => options.UseCache = !ignoreCache);
+            SecretResult result = await GetSecretAsync(secretName, options =>
+            {
+                if (ignoreCache)
+                {
+                    options.DisableCaching();
+                }
+            });
+
             return result.IsSuccess ? result.Value : throw NotFoundOrCritical(secretName, result);
         }
 
@@ -555,7 +562,14 @@ namespace Arcus.Security
         [Obsolete("Will be removed in v3.0 in favor of using secret results")]
         public async Task<Secret> GetSecretAsync(string secretName, bool ignoreCache)
         {
-            SecretResult result = await GetSecretAsync(secretName, options => options.UseCache = !ignoreCache);
+            SecretResult result = await GetSecretAsync(secretName, options =>
+            {
+                if (ignoreCache)
+                {
+                    options.DisableCaching();
+                }
+            });
+
             return result.IsSuccess ? new Secret(result.Value, result.Version, result.Expiration) : throw NotFoundOrCritical(secretName, result);
         }
 
@@ -592,8 +606,8 @@ namespace Arcus.Security
         [LoggerMessage(LogLevel.Information, "Secret store found secret '{SecretName}' in provider '{ProviderName}' | skipped by {SkippedProvidersDescription}")]
         internal static partial void LogSecretFoundInStore(this ILogger logger, string secretName, string providerName, string skippedProvidersDescription);
 
-        [LoggerMessage(LogLevel.Information, "Secret store found secret '{SecretName}' in cache (sliding expiration={CacheDuration:t}) | skipped all providers")]
-        internal static partial void LogSecretFoundInCache(this ILogger logger, string secretName, TimeSpan? cacheDuration);
+        [LoggerMessage(LogLevel.Information, "Secret store found secret '{SecretName}' in cache | skipped all providers")]
+        internal static partial void LogSecretFoundInCache(this ILogger logger, string secretName);
 
         [LoggerMessage(LogLevel.Debug, "Secret {SecretName} [Found in] '{ProviderName}'")]
         internal static partial void LogSecretFoundInProvider(this ILogger logger, string secretName, string providerName);
@@ -638,8 +652,8 @@ namespace Arcus.Security
         [LoggerMessage(LogLevel.Trace, "[Secret store] looking up secret '{SecretName}' in registered providers")]
         internal static partial void LogSecretLookup(this ILogger logger, string secretName);
 
-        [LoggerMessage(LogLevel.Trace, "[Secret store] refresh secret '{SecretName}' in cache (sliding expiration={CacheDuration:t})")]
-        internal static partial void LogSecretRefreshInCache(this ILogger logger, string secretName, TimeSpan? cacheDuration);
+        [LoggerMessage(LogLevel.Trace, "[Secret store] refresh secret '{SecretName}' in cache")]
+        internal static partial void LogSecretRefreshInCache(this ILogger logger, string secretName);
 
         [LoggerMessage(LogLevel.Trace, "[Secret store] invalidate secret '{SecretName}' in cache")]
         internal static partial void LogSecretInvalidateInCache(this ILogger logger, string secretName);

--- a/src/Arcus.Security.Core/ISecretStore.cs
+++ b/src/Arcus.Security.Core/ISecretStore.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using Arcus.Security.Core.Caching;
 using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Primitives;
@@ -221,7 +222,36 @@ namespace Arcus.Security
         /// if <c>false</c>, the secret provider will always retrieve the fresh secret from the underlying store.
         /// (Default: <c>true</c>)
         /// </summary>
+        [Obsolete("Will be removed in v3, use the " + nameof(EnableCaching) + " for fine-grained cache duration control and " + nameof(DisableCaching) + " to ignore the cache during this secret retrieval all together")]
         public bool UseCache { get; set; } = true;
+
+        internal bool CachingAllowed { get; set; } = true;
+        internal TimeSpan? CachingDuration { get; set; }
+
+        /// <summary>
+        /// Configures the secret retrieval to ignore the cache on the secret store and always retrieve a fresh secret.
+        /// </summary>
+        public void DisableCaching()
+        {
+            CachingAllowed = false;
+        }
+
+        /// <summary>
+        /// Configures the secret retrieval to use the cache on the secret store.
+        /// </summary>
+        /// <remarks>
+        ///     If the secret store was registered with a different caching duration via <see cref="SecretStoreBuilder.UseCaching"/>,
+        ///     then the provided <paramref name="duration"/> will overwrite this.
+        /// </remarks>
+        /// <param name="duration">The specific cache duration used solely for this secret retrieval.</param>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown when the <paramref name="duration"/> is less than or equal to <see cref="TimeSpan.Zero"/>.</exception>
+        public void EnableCaching(TimeSpan duration)
+        {
+            ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(duration, TimeSpan.Zero);
+
+            CachingAllowed = true;
+            CachingDuration = duration;
+        }
     }
 
     /// <summary>
@@ -280,9 +310,9 @@ namespace Arcus.Security
 
         internal bool TryGetCachedSecret(string secretName, SecretOptions secretOptions, ILogger logger, out SecretResult secret)
         {
-            if (secretOptions.UseCache && _cache.TryGetValue(secretName, out secret))
+            if (secretOptions.CachingAllowed && _cache.TryGetValue(secretName, out secret))
             {
-                logger.LogSecretFoundInCache(secretName, _cacheEntry.SlidingExpiration);
+                logger.LogSecretFoundInCache(secretName);
                 return true;
             }
 
@@ -290,16 +320,20 @@ namespace Arcus.Security
             return false;
         }
 
-        internal void UpdateSecretInCache(string secretName, SecretResult result, SecretOptions options = null)
+        internal void UpdateSecretInCache(string secretName, SecretResult result, SecretOptions options)
         {
-            if (result.IsSuccess && (options is null || options.UseCache))
+            if (result.IsSuccess && options.CachingAllowed)
             {
                 if (_cache is not NullMemoryCache)
                 {
-                    _logger.LogSecretRefreshInCache(secretName, _cacheEntry.SlidingExpiration);
+                    _logger.LogSecretRefreshInCache(secretName);
                 }
 
-                _cache.Set(secretName, result, _cacheEntry);
+                var entry = options.CachingDuration.HasValue
+                    ? new MemoryCacheEntryOptions().SetSlidingExpiration(options.CachingDuration.Value)
+                    : _cacheEntry;
+
+                _cache.Set(secretName, result, entry);
             }
         }
 

--- a/src/Arcus.Security.Tests.Integration/Fixture/SecretStoreTestContext.cs
+++ b/src/Arcus.Security.Tests.Integration/Fixture/SecretStoreTestContext.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.Threading.Tasks;
 using Arcus.Testing;
 using Bogus;
@@ -16,6 +18,7 @@ namespace Arcus.Security.Tests.Integration.Fixture
     public class SecretStoreTestContext : IAsyncDisposable
     {
         private readonly string _providerName;
+        private readonly Collection<Action<SecretOptions>> _configuresSecretOptions = [];
         private readonly IHostBuilder _builder;
         private readonly ILogger _logger;
         private IHost _host;
@@ -101,6 +104,18 @@ namespace Arcus.Security.Tests.Integration.Fixture
             _builder.ConfigureSecretStore(configureSecretStore);
         }
 
+        /// <summary>
+        /// Configures the secret options during the secret retrieval on the registered secret store.
+        /// </summary>
+        public void WhenSecretOptions(Action<SecretOptions> configureOptions)
+        {
+            ArgumentNullException.ThrowIfNull(configureOptions);
+            _configuresSecretOptions.Add(configureOptions);
+        }
+
+        /// <summary>
+        /// Verifies if a secret with a given <paramref name="secretName"/> and <paramref name="secretValue"/> is located in the registered secret store.
+        /// </summary>
         public async Task<SecretResult> ShouldFindSecretAsync(string secretName, string secretValue)
         {
             SecretResult result = await ShouldFindSecretAsync(secretName);
@@ -121,7 +136,13 @@ namespace Arcus.Security.Tests.Integration.Fixture
                 using (_logger.BeginScope("synchronous secrets"))
                 {
 #pragma warning disable S6966 // Should call synchronous method here to verify if both synchronous and asynchronous methods return the same result.
-                    SecretResult syncResult = store.GetSecret(secretName);
+                    SecretResult syncResult =
+                        _configuresSecretOptions.Count is 0
+                            // ReSharper disable MethodHasAsyncOverload
+                            ? store.GetSecret(secretName)
+                            : store.GetSecret(secretName, AggregateSecretOptions(_configuresSecretOptions));
+                    // ReSharper restore MethodHasAsyncOverload
+
                     Assert.True(syncResult.IsSuccess, $"synchronously retrieving secret '{secretName}' from secret store should result in a successful result, but wasn't: {syncResult}");
 #pragma warning restore S6966
                 }
@@ -130,17 +151,29 @@ namespace Arcus.Security.Tests.Integration.Fixture
             SecretResult asyncResult;
             using (_logger.BeginScope("asynchronous secrets"))
             {
-                asyncResult = await store.GetSecretAsync(secretName);
+                asyncResult = _configuresSecretOptions.Count is 0
+                    ? await store.GetSecretAsync(secretName)
+                    : await store.GetSecretAsync(secretName, AggregateSecretOptions(_configuresSecretOptions));
+
                 Assert.True(asyncResult.IsSuccess, $"asynchronously retrieving secret '{secretName}' from secret store should result in a successful result, but wasn't: {asyncResult}");
             }
 
+            await VerifyStoreInfrastructureAsync(store);
+            return asyncResult;
+        }
+
+        private async Task VerifyStoreInfrastructureAsync(ISecretStore store)
+        {
             _logger.LogDebug("-----------------------------------------------------------------------------------------------------------------------------------");
             _logger.LogDebug("[Test] verifying secret store infrastructure");
+
             if (SupportSynchronous && Bogus.Random.Bool())
             {
 #pragma warning disable S6966 // Should call synchronous method here to verify if both synchronous and asynchronous methods return the same result.
+                // ReSharper disable once MethodHasAsyncOverload
                 SecretResult syncNotFoundResult = store.GetSecret("always-not-found-sync-secret" + Guid.NewGuid());
 #pragma warning restore S6966
+
                 Assert.False(syncNotFoundResult.IsSuccess, $"synchronously retrieving a secret that is not available in the secret store should return a failed result, but wasn't: {syncNotFoundResult}");
             }
             else
@@ -148,10 +181,16 @@ namespace Arcus.Security.Tests.Integration.Fixture
                 SecretResult asyncNotFoundResult = await store.GetSecretAsync("always-not-found-async-secret" + Guid.NewGuid());
                 Assert.False(asyncNotFoundResult.IsSuccess, $"asynchronously retrieving a secret that is not available in the secret store should return a failed result, but wasn't: {asyncNotFoundResult}");
             }
-
-            return asyncResult;
         }
 
+        private Action<SecretOptions> AggregateSecretOptions(IEnumerable<Action<SecretOptions>> configuresSecretOptions)
+        {
+            return options => Assert.All(configuresSecretOptions, configure => configure(options));
+        }
+
+        /// <summary>
+        /// Verifies if a secret provider is available in the registered secret store.
+        /// </summary>
         public TProvider ShouldFindProvider<TProvider>(string providerName = null) where TProvider : ISecretProvider
         {
             var store = GetStore();

--- a/src/Arcus.Security.Tests.Integration/KeyVault/Fixture/TemporaryKeyVaultSecret.cs
+++ b/src/Arcus.Security.Tests.Integration/KeyVault/Fixture/TemporaryKeyVaultSecret.cs
@@ -43,13 +43,30 @@ namespace Arcus.Security.Tests.Integration.KeyVault.Fixture
             TokenCredential credential = config.GetServicePrincipal().GetCredential();
             SecretClient client = config.GetKeyVault().GetClient();
 
-            string truncated = secretValue[..5] + "...";
+            string truncated = TruncatedSecretValue(secretValue);
             logger.LogDebug("[Test:Setup] add Azure Key Vault secret '{SecretName}' with '{SecretValue}' to vault '{VaultUri}'", secretName, truncated, client.VaultUri);
             await client.SetSecretAsync(secretName, secretValue);
 
             await Poll.UntilAvailableAsync(() => client.GetSecretAsync(secretName));
 
             return new TemporaryKeyVaultSecret(secretName, secretValue, client, credential, logger);
+        }
+
+        /// <summary>
+        /// Sets a new version of the Azure Key Vault secret value.
+        /// </summary>
+        public async Task RefreshSecretAsync(string newSecretValue)
+        {
+            ArgumentException.ThrowIfNullOrWhiteSpace(newSecretValue);
+
+            string truncated = TruncatedSecretValue(newSecretValue);
+            _logger.LogDebug("[Test] refresh Azure Key Vault secret '{SecretName}' with new value '{SecretValue}' in vault '{VaultUri}'", SecretName, truncated, Client.VaultUri);
+            await Client.SetSecretAsync(SecretName, newSecretValue);
+        }
+
+        private static string TruncatedSecretValue(string secretValue)
+        {
+            return secretValue[..5] + "...";
         }
 
         /// <summary>

--- a/src/Arcus.Security.Tests.Integration/KeyVault/KeyVaultSecretProviderTests.cs
+++ b/src/Arcus.Security.Tests.Integration/KeyVault/KeyVaultSecretProviderTests.cs
@@ -1,8 +1,10 @@
 ﻿using System;
 using System.Threading.Tasks;
 using Arcus.Security.Providers.AzureKeyVault;
+using Arcus.Security.Tests.Integration.Fixture;
 using Arcus.Security.Tests.Integration.KeyVault.Fixture;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
 using Xunit;
 
 namespace Arcus.Security.Tests.Integration.KeyVault
@@ -40,14 +42,35 @@ namespace Arcus.Security.Tests.Integration.KeyVault
             await using var store = GivenSecretStore(store =>
             {
                 WhenAzureKeyVaultFor(store, secret);
-                WhenCaching(store);
             });
+            WhenCaching(store);
 
             var provider = store.ShouldFindProvider<KeyVaultSecretProvider>();
             string newSecretValue = $"new{Bogus.Random.Guid():N}";
 
             // Act
             await provider.SetSecretAsync(secret.SecretName, newSecretValue);
+
+            // Assert
+            await store.ShouldFindSecretAsync(secret.SecretName, newSecretValue);
+        }
+
+        [Fact]
+        public async Task GetCachedSecret_WithDisabledCaching_RetrievesFreshSecret()
+        {
+            // Arrange
+            await using var secret = await GivenNewKeyVaultSecretAsync();
+            await using var store = GivenSecretStore(store =>
+            {
+                WhenAzureKeyVaultFor(store, secret);
+                WhenCaching(store);
+            });
+
+            string newSecretValue = $"new{Bogus.Random.Guid():N}";
+            await secret.RefreshSecretAsync(newSecretValue);
+
+            // Act
+            store.WhenSecretOptions(options => options.DisableCaching());
 
             // Assert
             await store.ShouldFindSecretAsync(secret.SecretName, newSecretValue);
@@ -72,7 +95,25 @@ namespace Arcus.Security.Tests.Integration.KeyVault
             }
         }
 
-        private void WhenCaching(SecretStoreBuilder store)
+        private void WhenCaching(SecretStoreTestContext context)
+        {
+            if (Bogus.Random.Bool())
+            {
+                WhenCaching(context);
+                Logger.LogDebug("[Test:Setup] use secret caching duration at secret store level");
+
+                context.WhenSecretStore(WhenCaching);
+            }
+            else
+            {
+                TimeSpan duration = TimeSpan.FromHours(1);
+
+                Logger.LogDebug("[Test:Setup] use secret caching duration at secret options level");
+                context.WhenSecretOptions(options => options.EnableCaching(duration));
+            }
+        }
+
+        private static void WhenCaching(SecretStoreBuilder store)
         {
             store.UseCaching(TimeSpan.FromHours(1));
         }


### PR DESCRIPTION
Provide the possibility to enable/overwrite the secret cache duration on a by-secret level, making the cache duration option much more fine grained.

Closes #489

