### PR TITLE
chore(deprecate): use centralized diagnostic id for deprecation messages

### DIFF
--- a/src/Arcus.Security.Core/Arcus.Security.Core.csproj
+++ b/src/Arcus.Security.Core/Arcus.Security.Core.csproj
@@ -20,6 +20,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Include="..\ObsoleteDefaults.cs" Link="ObsoleteDefaults.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
     <None Include="..\..\README.md" Pack="true" PackagePath="\" />
     <None Include="..\..\LICENSE" Pack="true" PackagePath="\" />
     <None Include="..\..\docs\static\img\icon.png" Pack="true" PackagePath="\" />

--- a/src/Arcus.Security.Core/Caching/CachedSecretProvider.cs
+++ b/src/Arcus.Security.Core/Caching/CachedSecretProvider.cs
@@ -11,7 +11,7 @@ namespace Arcus.Security.Core.Caching
     /// <summary>
     /// A <see cref="ISecretProvider"/> that will cache secrets in memory, to improve performance.
     /// </summary>
-    [Obsolete("Will be removed in v3.0 as caching will happen directly on the secret store")]
+    [Obsolete("Will be removed in v3.0 as caching will happen directly on the secret store", DiagnosticId = ObsoleteDefaults.DiagnosticId)]
     public class CachedSecretProvider : ICachedSecretProvider, IVersionedSecretProvider, ISyncSecretProvider
     {
         private readonly ISecretProvider _secretProvider;
@@ -92,7 +92,7 @@ namespace Arcus.Security.Core.Caching
         /// <exception cref="ArgumentException">The name must not be empty</exception>
         /// <exception cref="ArgumentNullException">The name must not be null</exception>
         /// <exception cref="SecretNotFoundException">The secret was not found, using the given name</exception>
-        [Obsolete("Will be removed in v3 in favor of solely using " + nameof(GetSecret) + " instead")]
+        [Obsolete("Will be removed in v3 in favor of solely using " + nameof(GetSecret) + " instead", DiagnosticId = ObsoleteDefaults.DiagnosticId)]
         public Task<string> GetRawSecretAsync(string secretName)
         {
             if (string.IsNullOrWhiteSpace(secretName))
@@ -130,7 +130,7 @@ namespace Arcus.Security.Core.Caching
         /// <exception cref="ArgumentException">The name must not be empty</exception>
         /// <exception cref="ArgumentNullException">The name must not be null</exception>
         /// <exception cref="SecretNotFoundException">The secret was not found, using the given name</exception>
-        [Obsolete("Will be removed in v3 in favor of solely using " + nameof(GetSecret) + " instead")]
+        [Obsolete("Will be removed in v3 in favor of solely using " + nameof(GetSecret) + " instead", DiagnosticId = ObsoleteDefaults.DiagnosticId)]
         public async Task<string> GetRawSecretAsync(string secretName, bool ignoreCache)
         {
             if (string.IsNullOrWhiteSpace(secretName))
@@ -190,7 +190,7 @@ namespace Arcus.Security.Core.Caching
         /// <exception cref="ArgumentException">Thrown when the <paramref name="secretName"/> is blank.</exception>
         /// <exception cref="ArgumentOutOfRangeException">Thrown when the <paramref name="amountOfVersions"/> is less than zero.</exception>
         /// <exception cref="SecretNotFoundException">Thrown when no secret was not found, using the given <paramref name="secretName"/>.</exception>
-        [Obsolete("Will be removed in v3 in favor of solely using " + nameof(GetSecret) + " instead")]
+        [Obsolete("Will be removed in v3 in favor of solely using " + nameof(GetSecret) + " instead", DiagnosticId = ObsoleteDefaults.DiagnosticId)]
         public async Task<IEnumerable<string>> GetRawSecretsAsync(string secretName, int amountOfVersions)
         {
             if (string.IsNullOrWhiteSpace(secretName))

--- a/src/Arcus.Security.Core/Caching/Configuration/CacheConfiguration.cs
+++ b/src/Arcus.Security.Core/Caching/Configuration/CacheConfiguration.cs
@@ -5,7 +5,7 @@ namespace Arcus.Security.Core.Caching.Configuration
     /// <summary>
     /// Default implementation of the collected configuration values to control the caching when interacting with Azure Key Vault.
     /// </summary>
-    [Obsolete("Will be removed in v3.0 as caching will be handled by the secret store itself")]
+    [Obsolete("Will be removed in v3.0 as caching will be handled by the secret store itself", DiagnosticId = ObsoleteDefaults.DiagnosticId)]
     public class CacheConfiguration : ICacheConfiguration
     {
         /// <summary>

--- a/src/Arcus.Security.Core/Caching/Configuration/ICacheConfiguration.cs
+++ b/src/Arcus.Security.Core/Caching/Configuration/ICacheConfiguration.cs
@@ -5,7 +5,7 @@ namespace Arcus.Security.Core.Caching.Configuration
     /// <summary>
     /// Collected configuration values to control the caching when interacting with Azure Key Vault.
     /// </summary>
-    [Obsolete("Will be removed in v3.0 as caching will happen on the secret store itself")]
+    [Obsolete("Will be removed in v3.0 as caching will happen on the secret store itself", DiagnosticId = ObsoleteDefaults.DiagnosticId)]
     public interface ICacheConfiguration
     {
         /// <summary>

--- a/src/Arcus.Security.Core/Caching/ICachedSecretProvider.cs
+++ b/src/Arcus.Security.Core/Caching/ICachedSecretProvider.cs
@@ -7,13 +7,13 @@ namespace Arcus.Security.Core.Caching
     /// <summary>
     /// <see cref="ICachedSecretProvider"/> allows developers to build specific Secret key providers with caching.
     /// </summary>
-    [Obsolete("Will be removed in v3.0 as caching will happen on the secret store itself")]
+    [Obsolete("Will be removed in v3.0 as caching will happen on the secret store itself", DiagnosticId = ObsoleteDefaults.DiagnosticId)]
     public interface ICachedSecretProvider : ISecretProvider
     {
         /// <summary>
         /// Gets the cache-configuration for this instance.
         /// </summary>
-        [Obsolete("Will be removed in v3.0 as caching will happen on the secret store itself")]
+        [Obsolete("Will be removed in v3.0 as caching will happen on the secret store itself", DiagnosticId = ObsoleteDefaults.DiagnosticId)]
         ICacheConfiguration Configuration { get; }
 
         /// <summary>
@@ -25,7 +25,7 @@ namespace Arcus.Security.Core.Caching
         /// <exception cref="ArgumentException">The name must not be empty</exception>
         /// <exception cref="ArgumentNullException">The name must not be null</exception>
         /// <exception cref="SecretNotFoundException">The secret was not found, using the given name</exception>
-        [Obsolete("Will be removed in v3 in favor of solely using " + nameof(GetSecretAsync) + " instead")]
+        [Obsolete("Will be removed in v3 in favor of solely using " + nameof(GetSecretAsync) + " instead", DiagnosticId = ObsoleteDefaults.DiagnosticId)]
         Task<string> GetRawSecretAsync(string secretName, bool ignoreCache);
 
         /// <summary>
@@ -37,7 +37,7 @@ namespace Arcus.Security.Core.Caching
         /// <exception cref="ArgumentException">The name must not be empty</exception>
         /// <exception cref="ArgumentNullException">The name must not be null</exception>
         /// <exception cref="SecretNotFoundException">The secret was not found, using the given name</exception>
-        [Obsolete("Will be removed in v3.0 as caching will happen on the secret store itself")]
+        [Obsolete("Will be removed in v3.0 as caching will happen on the secret store itself", DiagnosticId = ObsoleteDefaults.DiagnosticId)]
         Task<Secret> GetSecretAsync(string secretName, bool ignoreCache);
 
 
@@ -46,7 +46,7 @@ namespace Arcus.Security.Core.Caching
         /// so the next time <see cref="CachedSecretProvider.GetSecretAsync(string)"/> is called, a new version of the secret will be added back to the cache.
         /// </summary>
         /// <param name="secretName">The name of the secret that should be removed from the cache.</param>
-        [Obsolete("Will be removed in v3.0 as caching will happen on the secret store itself")]
+        [Obsolete("Will be removed in v3.0 as caching will happen on the secret store itself", DiagnosticId = ObsoleteDefaults.DiagnosticId)]
         Task InvalidateSecretAsync(string secretName);
     }
 }

--- a/src/Arcus.Security.Core/Caching/SecretProviderCachingExtensions.cs
+++ b/src/Arcus.Security.Core/Caching/SecretProviderCachingExtensions.cs
@@ -18,7 +18,7 @@ namespace Arcus.Security.Core.Caching
         /// <returns>A secret provider that caches values</returns>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="secretProvider"/> or <paramref name="memoryCache"/> is <c>null</c>.</exception>
         /// <exception cref="ArgumentOutOfRangeException">Thrown when the <paramref name="cachingDuration"/> is not a positive time duration.</exception>
-        [Obsolete("Will be removed in v3.0 in favor of placing the secret caching on the secret store itself")]
+        [Obsolete("Will be removed in v3.0 in favor of placing the secret caching on the secret store itself", DiagnosticId = ObsoleteDefaults.DiagnosticId)]
         public static ICachedSecretProvider WithCaching(this ISecretProvider secretProvider, TimeSpan cachingDuration, IMemoryCache memoryCache)
         {
             if (secretProvider is null)
@@ -48,7 +48,7 @@ namespace Arcus.Security.Core.Caching
         /// <returns>A secret provider that caches values</returns>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="secretProvider"/> is <c>null</c>.</exception>
         /// <exception cref="ArgumentOutOfRangeException">Thrown when the <paramref name="cachingDuration"/> is not a positive time duration.</exception>
-        [Obsolete("Will be removed in v3.0 in favor of placing the secret caching on the secret store itself")]
+        [Obsolete("Will be removed in v3.0 in favor of placing the secret caching on the secret store itself", DiagnosticId = ObsoleteDefaults.DiagnosticId)]
         public static ICachedSecretProvider WithCaching(this ISecretProvider secretProvider, TimeSpan cachingDuration)
         {
             if (secretProvider is null)
@@ -71,7 +71,7 @@ namespace Arcus.Security.Core.Caching
         /// <param name="secretProvider">An instantiated <see cref="ISecretProvider" /> that will only be called if the value is not cached</param>
         /// <returns>A secret provider that caches values</returns>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="secretProvider"/> is <c>null</c>.</exception>
-        [Obsolete("Will be removed in v3.0 in favor of placing the secret caching on the secret store itself")]
+        [Obsolete("Will be removed in v3.0 in favor of placing the secret caching on the secret store itself", DiagnosticId = ObsoleteDefaults.DiagnosticId)]
         public static ICachedSecretProvider WithCaching(this ISecretProvider secretProvider)
         {
             if (secretProvider is null)

--- a/src/Arcus.Security.Core/CompositeSecretProvider.cs
+++ b/src/Arcus.Security.Core/CompositeSecretProvider.cs
@@ -237,7 +237,7 @@ namespace Arcus.Security
         /// <exception cref="NotSupportedException">
         ///     Thrown every time because the <see cref="CompositeSecretProvider"/> cannot determine the caching configuration from the different registered <see cref="ICachedSecretProvider"/>s.
         /// </exception>
-        [Obsolete("Will be removed in v3.0 as caching will be handled by the secret store itself")]
+        [Obsolete("Will be removed in v3.0 as caching will be handled by the secret store itself", DiagnosticId = ObsoleteDefaults.DiagnosticId)]
         public ICacheConfiguration Configuration =>
             throw new NotSupportedException(
                 "Getting the cache configuration directly from the secret store is not supported, "
@@ -252,7 +252,7 @@ namespace Arcus.Security
         /// <exception cref="KeyNotFoundException">Thrown when there was no <see cref="ISecretProvider"/> found in the secret store with the given <paramref name="name"/>.</exception>
         /// <exception cref="InvalidCastException">Thrown when the registered <see cref="ISecretProvider"/> cannot be cast to the specific <typeparamref name="TSecretProvider"/>.</exception>
         /// <exception cref="InvalidOperationException">Thrown when multiple <see cref="ISecretProvider"/> were registered with the same name.</exception>
-        [Obsolete("Will be removed in v3.0 in favor of using a new interface")]
+        [Obsolete("Will be removed in v3.0 in favor of using a new interface", DiagnosticId = ObsoleteDefaults.DiagnosticId)]
         public TSecretProvider GetProvider<TSecretProvider>(string name) where TSecretProvider : Core.ISecretProvider
         {
             var provider = ((ISecretStore) this).GetProvider<ISecretProvider>(name);
@@ -280,7 +280,7 @@ namespace Arcus.Security
         /// <param name="name">The name that was used to register the <see cref="ISecretProvider"/> in the secret store.</param>
         /// <exception cref="ArgumentException">Thrown when the <paramref name="name"/> is blank.</exception>
         /// <exception cref="KeyNotFoundException">Thrown when there was no <see cref="ISecretProvider"/> found in the secret store with the given <paramref name="name"/>.</exception>
-        [Obsolete("Will be removed in v3.0 in favor of using a new interface")]
+        [Obsolete("Will be removed in v3.0 in favor of using a new interface", DiagnosticId = ObsoleteDefaults.DiagnosticId)]
         public Core.ISecretProvider GetProvider(string name)
         {
             var provider = ((ISecretStore) this).GetProvider<ISecretProvider>(name);
@@ -314,7 +314,7 @@ namespace Arcus.Security
         /// </exception>
         /// <exception cref="InvalidCastException">Thrown when the registered <see cref="ICachedSecretProvider"/> cannot be cast to the specific <typeparamref name="TCachedSecretProvider"/>.</exception>
         /// <exception cref="InvalidOperationException">Thrown when multiple <see cref="ICachedSecretProvider"/> were registered with the same name.</exception>
-        [Obsolete("Will be removed in v3.0 as caching is handled by the secret store itself")]
+        [Obsolete("Will be removed in v3.0 as caching is handled by the secret store itself", DiagnosticId = ObsoleteDefaults.DiagnosticId)]
         public TCachedSecretProvider GetCachedProvider<TCachedSecretProvider>(string name) where TCachedSecretProvider : ICachedSecretProvider
         {
             var provider = ((ISecretStore) this).GetProvider<ISecretProvider>(name);
@@ -345,7 +345,7 @@ namespace Arcus.Security
         ///     Thrown when their was either none of the registered secret providers are registered as <see cref="ICachedSecretProvider"/> instances
         ///     or there was an <see cref="ISecretProvider"/> registered but not with caching.
         /// </exception>
-        [Obsolete("Will be removed in v3.0 as caching is handled via the secret store itself")]
+        [Obsolete("Will be removed in v3.0 as caching is handled via the secret store itself", DiagnosticId = ObsoleteDefaults.DiagnosticId)]
         public ICachedSecretProvider GetCachedProvider(string name)
         {
             var provider = ((ISecretStore) this).GetProvider<ISecretProvider>(name);
@@ -373,7 +373,7 @@ namespace Arcus.Security
         /// <returns>Returns the secret key.</returns>
         /// <exception cref="ArgumentException">Thrown when the <paramref name="secretName"/> is blank.</exception>
         /// <exception cref="SecretNotFoundException">Thrown when the secret was not found, using the given name.</exception>
-        [Obsolete("Will be removed in v3 in favor of solely using " + nameof(GetSecretAsync) + " instead")]
+        [Obsolete("Will be removed in v3 in favor of solely using " + nameof(GetSecretAsync) + " instead", DiagnosticId = ObsoleteDefaults.DiagnosticId)]
         public string GetRawSecret(string secretName)
         {
             SecretResult result = GetSecret(secretName, configureOptions: null);
@@ -387,7 +387,7 @@ namespace Arcus.Security
         /// <returns>Returns a <see cref="Secret"/> that contains the secret key</returns>
         /// <exception cref="ArgumentException">Thrown when the <paramref name="secretName"/> is blank.</exception>
         /// <exception cref="SecretNotFoundException">Thrown when the secret was not found, using the given name.</exception>
-        [Obsolete("Will be removed in v3.0 in favor of using secret results")]
+        [Obsolete("Will be removed in v3.0 in favor of using secret results", DiagnosticId = ObsoleteDefaults.DiagnosticId)]
         public Secret GetSecret(string secretName)
         {
             SecretResult result = GetSecret(secretName, configureOptions: null);
@@ -441,7 +441,7 @@ namespace Arcus.Security
         /// <param name="secretName">The name of the secret.</param>
         /// <exception cref="ArgumentException">Thrown when the <paramref name="secretName"/> is blank.</exception>
         /// <exception cref="SecretNotFoundException">Thrown when no secret was not found, using the given <paramref name="secretName"/>.</exception>
-        [Obsolete("Will be removed in v3.0 as versioned secrets will be moved to concrete implementations")]
+        [Obsolete("Will be removed in v3.0 as versioned secrets will be moved to concrete implementations", DiagnosticId = ObsoleteDefaults.DiagnosticId)]
         internal Task<IEnumerable<Secret>> GetSecretsAsync(string secretName)
         {
             throw new NotSupportedException(
@@ -455,7 +455,7 @@ namespace Arcus.Security
         /// <param name="secretName">The name of the secret.</param>
         /// <exception cref="ArgumentException">Thrown when the <paramref name="secretName"/> is blank.</exception>
         /// <exception cref="SecretNotFoundException">Thrown when no secret was not found, using the given <paramref name="secretName"/>.</exception>
-        [Obsolete("Will be removed in v3 in favor of solely using " + nameof(GetSecretsAsync) + " instead")]
+        [Obsolete("Will be removed in v3 in favor of solely using " + nameof(GetSecretsAsync) + " instead", DiagnosticId = ObsoleteDefaults.DiagnosticId)]
         internal Task<IEnumerable<string>> GetRawSecretsAsync(string secretName)
         {
             throw new NotSupportedException(
@@ -471,7 +471,7 @@ namespace Arcus.Security
         /// <exception cref="ArgumentException">Thrown when the <paramref name="secretName"/> is blank.</exception>
         /// <exception cref="ArgumentOutOfRangeException">Thrown when the <paramref name="amountOfVersions"/> is less than zero.</exception>
         /// <exception cref="SecretNotFoundException">Thrown when no secret was not found, using the given <paramref name="secretName"/>.</exception>
-        [Obsolete("Will be removed in v3 in favor of solely using " + nameof(GetSecretsAsync) + " instead")]
+        [Obsolete("Will be removed in v3 in favor of solely using " + nameof(GetSecretsAsync) + " instead", DiagnosticId = ObsoleteDefaults.DiagnosticId)]
         public Task<IEnumerable<string>> GetRawSecretsAsync(string secretName, int amountOfVersions)
         {
             throw new NotSupportedException(
@@ -487,7 +487,7 @@ namespace Arcus.Security
         /// <exception cref="ArgumentException">Thrown when the <paramref name="secretName"/> is blank.</exception>
         /// <exception cref="ArgumentOutOfRangeException">Thrown when the <paramref name="amountOfVersions"/> is less than zero.</exception>
         /// <exception cref="SecretNotFoundException">Thrown when no secret was not found, using the given <paramref name="secretName"/>.</exception>
-        [Obsolete("Will be removed in v3.0 as versioned secrets will be moved to concrete implementations")]
+        [Obsolete("Will be removed in v3.0 as versioned secrets will be moved to concrete implementations", DiagnosticId = ObsoleteDefaults.DiagnosticId)]
         public Task<IEnumerable<Secret>> GetSecretsAsync(string secretName, int amountOfVersions)
         {
             throw new NotSupportedException(
@@ -503,7 +503,7 @@ namespace Arcus.Security
         /// <exception cref="System.ArgumentException">The <paramref name="secretName"/> must not be empty</exception>
         /// <exception cref="System.ArgumentNullException">The <paramref name="secretName"/> must not be null</exception>
         /// <exception cref="SecretNotFoundException">The secret was not found, using the given name</exception>
-        [Obsolete("Will be removed in v3 in favor of solely using " + nameof(GetSecretAsync) + " instead")]
+        [Obsolete("Will be removed in v3 in favor of solely using " + nameof(GetSecretAsync) + " instead", DiagnosticId = ObsoleteDefaults.DiagnosticId)]
         public async Task<string> GetRawSecretAsync(string secretName)
         {
             SecretResult result = await GetSecretAsync(secretName, configureOptions: null);
@@ -518,7 +518,7 @@ namespace Arcus.Security
         /// <exception cref="System.ArgumentException">The <paramref name="secretName"/> must not be empty</exception>
         /// <exception cref="System.ArgumentNullException">The <paramref name="secretName"/> must not be null</exception>
         /// <exception cref="SecretNotFoundException">The secret was not found, using the given name</exception>
-        [Obsolete("Will be removed in v3.0 in favor of using secret results")]
+        [Obsolete("Will be removed in v3.0 in favor of using secret results", DiagnosticId = ObsoleteDefaults.DiagnosticId)]
         public async Task<Secret> GetSecretAsync(string secretName)
         {
             SecretResult result = await GetSecretAsync(secretName, configureOptions: null);
@@ -535,7 +535,7 @@ namespace Arcus.Security
         /// <exception cref="ArgumentNullException">The name must not be null</exception>
         /// <exception cref="SecretNotFoundException">The secret was not found, using the given name</exception>
         /// <exception cref="NotSupportedException">Thrown when none of the registered secret providers are registered as <see cref="ICachedSecretProvider"/> instances.</exception>
-        [Obsolete("Will be removed in v3 in favor of solely using " + nameof(GetSecretAsync) + " instead")]
+        [Obsolete("Will be removed in v3 in favor of solely using " + nameof(GetSecretAsync) + " instead", DiagnosticId = ObsoleteDefaults.DiagnosticId)]
         public async Task<string> GetRawSecretAsync(string secretName, bool ignoreCache)
         {
             SecretResult result = await GetSecretAsync(secretName, options => options.UseCache = !ignoreCache);
@@ -552,7 +552,7 @@ namespace Arcus.Security
         /// <exception cref="ArgumentNullException">The name must not be null</exception>
         /// <exception cref="SecretNotFoundException">The secret was not found, using the given name</exception>
         /// <exception cref="NotSupportedException">Thrown when none of the registered secret providers are registered as <see cref="ICachedSecretProvider"/> instances.</exception>
-        [Obsolete("Will be removed in v3.0 in favor of using secret results")]
+        [Obsolete("Will be removed in v3.0 in favor of using secret results", DiagnosticId = ObsoleteDefaults.DiagnosticId)]
         public async Task<Secret> GetSecretAsync(string secretName, bool ignoreCache)
         {
             SecretResult result = await GetSecretAsync(secretName, options => options.UseCache = !ignoreCache);
@@ -564,7 +564,7 @@ namespace Arcus.Security
         /// so the next time <see cref="CachedSecretProvider.GetSecretAsync(string)"/> is called, a new version of the secret will be added back to the cache.
         /// </summary>
         /// <param name="secretName">The name of the secret that should be removed from the cache.</param>
-        [Obsolete("Will be removed in v3.0 as invalidating secrets should happen via the " + nameof(ISecretStoreContext))]
+        [Obsolete("Will be removed in v3.0 as invalidating secrets should happen via the " + nameof(ISecretStoreContext), DiagnosticId = ObsoleteDefaults.DiagnosticId)]
         public async Task InvalidateSecretAsync(string secretName)
         {
             await Cache.InvalidateSecretAsync(secretName);

--- a/src/Arcus.Security.Core/CriticalExceptionFilter.cs
+++ b/src/Arcus.Security.Core/CriticalExceptionFilter.cs
@@ -7,7 +7,7 @@ namespace Arcus.Security.Core
     /// so the <see cref="CompositeSecretProvider"/> is able to collect all the available exception filters
     /// and determine whether or not a critical exception was thrown during interacting with the secret sources.
     /// </summary>
-    [Obsolete("Will be removed in v3.0 in favor of using secret results to determine secret retrieval failures")]
+    [Obsolete("Will be removed in v3.0 in favor of using secret results to determine secret retrieval failures", DiagnosticId = ObsoleteDefaults.DiagnosticId)]
     public class CriticalExceptionFilter
     {
         private readonly Func<Exception, bool> _exceptionFilter;

--- a/src/Arcus.Security.Core/Extensions/ISecretProviderExtensions.Deprecated.cs
+++ b/src/Arcus.Security.Core/Extensions/ISecretProviderExtensions.Deprecated.cs
@@ -25,7 +25,7 @@ namespace Arcus.Security.Core.Extensions
         /// <exception cref="ArgumentException">The <paramref name="secretName"/> must not be empty</exception>
         /// <exception cref="ArgumentNullException">The <paramref name="secretName"/> must not be null</exception>
         /// <exception cref="SecretNotFoundException">The secret was not found, using the given name</exception>
-        [Obsolete("Use the " + nameof(Core.ISecretProviderExtensions.GetRawSecretsAsync) + " extension instead")]
+        [Obsolete("Use the " + nameof(Core.ISecretProviderExtensions.GetRawSecretsAsync) + " extension instead", DiagnosticId = ObsoleteDefaults.DiagnosticId)]
         public static async Task<IEnumerable<string>> GetRawSecretsAsync(this ISecretProvider secretProvider, string secretName)
         {
             ArgumentException.ThrowIfNullOrWhiteSpace(secretName);
@@ -52,7 +52,7 @@ namespace Arcus.Security.Core.Extensions
         /// <exception cref="ArgumentException">The <paramref name="secretName"/> must not be empty</exception>
         /// <exception cref="ArgumentNullException">The <paramref name="secretName"/> must not be null</exception>
         /// <exception cref="SecretNotFoundException">The secret was not found, using the given name</exception>
-        [Obsolete("Use the " + nameof(Core.ISecretProviderExtensions.GetSecretsAsync) + " extension instead")]
+        [Obsolete("Use the " + nameof(Core.ISecretProviderExtensions.GetSecretsAsync) + " extension instead", DiagnosticId = ObsoleteDefaults.DiagnosticId)]
         public static async Task<IEnumerable<Secret>> GetSecretsAsync(this ISecretProvider secretProvider, string secretName)
         {
             ArgumentException.ThrowIfNullOrWhiteSpace(secretName);

--- a/src/Arcus.Security.Core/Extensions/ISecretProviderExtensions.cs
+++ b/src/Arcus.Security.Core/Extensions/ISecretProviderExtensions.cs
@@ -20,7 +20,7 @@ namespace Arcus.Security.Core
         /// <returns>Returns the secret key.</returns>
         /// <exception cref="ArgumentException">Thrown when the <paramref name="secretName"/> is blank.</exception>
         /// <exception cref="SecretNotFoundException">Thrown when the secret was not found, using the given name.</exception>
-        [Obsolete("Will be removed in v3 in favor of solely using " + nameof(Arcus.Security.ISecretProvider.GetSecretAsync) + " instead")]
+        [Obsolete("Will be removed in v3 in favor of solely using " + nameof(Arcus.Security.ISecretProvider.GetSecretAsync) + " instead", DiagnosticId = ObsoleteDefaults.DiagnosticId)]
         public static string GetRawSecret(this ISecretProvider secretProvider, string secretName)
         {
             if (secretProvider is null)
@@ -51,7 +51,7 @@ namespace Arcus.Security.Core
         /// <returns>Returns the secret key.</returns>
         /// <exception cref="ArgumentException">Thrown when the <paramref name="secretName"/> is blank.</exception>
         /// <exception cref="SecretNotFoundException">Thrown when the secret was not found, using the given name.</exception>
-        [Obsolete("Will be removed in v3.0 in favor of using a new secret provider interface 'Arcus.Security.ISecretProvider'")]
+        [Obsolete("Will be removed in v3.0 in favor of using a new secret provider interface 'Arcus.Security.ISecretProvider'", DiagnosticId = ObsoleteDefaults.DiagnosticId)]
         public static Secret GetSecret(this ISecretProvider secretProvider, string secretName)
         {
             if (secretProvider is null)
@@ -86,7 +86,7 @@ namespace Arcus.Security.Core
         /// <exception cref="ArgumentException">The <paramref name="secretName"/> must not be empty</exception>
         /// <exception cref="ArgumentNullException">The <paramref name="secretName"/> must not be null</exception>
         /// <exception cref="SecretNotFoundException">The secret was not found, using the given name</exception>
-        [Obsolete("Will be removed in v3 in favor of solely using " + nameof(GetSecretsAsync) + " instead")]
+        [Obsolete("Will be removed in v3 in favor of solely using " + nameof(GetSecretsAsync) + " instead", DiagnosticId = ObsoleteDefaults.DiagnosticId)]
         public static async Task<IEnumerable<string>> GetRawSecretsAsync(this ISecretProvider secretProvider, string secretName)
         {
             if (string.IsNullOrWhiteSpace(secretName))
@@ -116,7 +116,7 @@ namespace Arcus.Security.Core
         /// <exception cref="ArgumentException">The <paramref name="secretName"/> must not be empty</exception>
         /// <exception cref="ArgumentNullException">The <paramref name="secretName"/> must not be null</exception>
         /// <exception cref="SecretNotFoundException">The secret was not found, using the given name</exception>
-        [Obsolete("Will be removed in v3 in favor of solely using " + nameof(GetSecretsAsync) + " instead")]
+        [Obsolete("Will be removed in v3 in favor of solely using " + nameof(GetSecretsAsync) + " instead", DiagnosticId = ObsoleteDefaults.DiagnosticId)]
         public static async Task<IEnumerable<string>> GetRawSecretsAsync(this Security.ISecretProvider secretProvider, string secretName)
         {
             if (string.IsNullOrWhiteSpace(secretName))
@@ -146,7 +146,7 @@ namespace Arcus.Security.Core
         /// <exception cref="ArgumentException">The <paramref name="secretName"/> must not be empty</exception>
         /// <exception cref="ArgumentNullException">The <paramref name="secretName"/> must not be null</exception>
         /// <exception cref="SecretNotFoundException">The secret was not found, using the given name</exception>
-        [Obsolete("Will be removed in v3.0 as versioned secrets will be handled on the concrete secret providers themselves")]
+        [Obsolete("Will be removed in v3.0 as versioned secrets will be handled on the concrete secret providers themselves", DiagnosticId = ObsoleteDefaults.DiagnosticId)]
         public static async Task<IEnumerable<Secret>> GetSecretsAsync(this ISecretProvider secretProvider, string secretName)
         {
             if (string.IsNullOrWhiteSpace(secretName))
@@ -177,7 +177,7 @@ namespace Arcus.Security.Core
         /// <exception cref="ArgumentException">The <paramref name="secretName"/> must not be empty</exception>
         /// <exception cref="ArgumentNullException">The <paramref name="secretName"/> must not be null</exception>
         /// <exception cref="SecretNotFoundException">The secret was not found, using the given name</exception>
-        [Obsolete("Will be removed in v3.0 as versioned secrets will be handled on the concrete secret providers themselves")]
+        [Obsolete("Will be removed in v3.0 as versioned secrets will be handled on the concrete secret providers themselves", DiagnosticId = ObsoleteDefaults.DiagnosticId)]
         public static async Task<IEnumerable<Secret>> GetSecretsAsync(this Security.ISecretProvider secretProvider, string secretName)
         {
             if (string.IsNullOrWhiteSpace(secretName))

--- a/src/Arcus.Security.Core/Extensions/SecretStoreBuilderExtensions.cs
+++ b/src/Arcus.Security.Core/Extensions/SecretStoreBuilderExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Arcus.Security;
 using Arcus.Security.Core.Providers;
 using Microsoft.Extensions.Configuration;
 
@@ -74,7 +75,7 @@ namespace Microsoft.Extensions.Hosting
         /// <param name="mutateSecretName">The optional function to mutate the secret name before looking it up.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="builder"/> is <c>null</c>.</exception>
         /// <exception cref="ArgumentException">Thrown when the <paramref name="target"/> is outside the bounds of the enumeration.</exception>
-        [Obsolete("Will be removed in v3.0 in favor of configuring the secret provider registration with options")]
+        [Obsolete("Will be removed in v3.0 in favor of configuring the secret provider registration with options", DiagnosticId = ObsoleteDefaults.DiagnosticId)]
         public static SecretStoreBuilder AddEnvironmentVariables(
             this SecretStoreBuilder builder,
             EnvironmentVariableTarget target = EnvironmentVariableSecretProvider.DefaultTarget,
@@ -95,7 +96,7 @@ namespace Microsoft.Extensions.Hosting
         /// <param name="mutateSecretName">The optional function to mutate the secret name before looking it up.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="builder"/> is <c>null</c>.</exception>
         /// <exception cref="ArgumentException">Thrown when the <paramref name="target"/> is outside the bounds of the enumeration.</exception>
-        [Obsolete("Will be removed in v3.0 in favor of configuring the secret provider registration with options")]
+        [Obsolete("Will be removed in v3.0 in favor of configuring the secret provider registration with options", DiagnosticId = ObsoleteDefaults.DiagnosticId)]
         public static SecretStoreBuilder AddEnvironmentVariables(
             this SecretStoreBuilder builder,
             EnvironmentVariableTarget target,
@@ -135,7 +136,7 @@ namespace Microsoft.Extensions.Hosting
         /// <param name="configuration">The configuration of the application, containing secrets.</param>
         /// <param name="mutateSecretName">The function to mutate the secret name before looking it up.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="builder"/> is <c>null</c>.</exception>
-        [Obsolete("Will be removed in v3.0 in favor of configuring the secret provider registration with options")]
+        [Obsolete("Will be removed in v3.0 in favor of configuring the secret provider registration with options", DiagnosticId = ObsoleteDefaults.DiagnosticId)]
         public static SecretStoreBuilder AddConfiguration(
             this SecretStoreBuilder builder,
             IConfiguration configuration,
@@ -153,7 +154,7 @@ namespace Microsoft.Extensions.Hosting
         /// <param name="name">The unique name to register this Configuration provider in the secret store.</param>
         /// <param name="mutateSecretName">The optional function to mutate the secret name before looking it up.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="builder"/> is <c>null</c>.</exception>
-        [Obsolete("Will be removed in v3.0 in favor of configuring the secret provider registration with options")]
+        [Obsolete("Will be removed in v3.0 in favor of configuring the secret provider registration with options", DiagnosticId = ObsoleteDefaults.DiagnosticId)]
         public static SecretStoreBuilder AddConfiguration(
             this SecretStoreBuilder builder,
             IConfiguration configuration,

--- a/src/Arcus.Security.Core/ISecretProvider.cs
+++ b/src/Arcus.Security.Core/ISecretProvider.cs
@@ -11,7 +11,7 @@ namespace Arcus.Security.Core
     /// <summary>
     /// <see cref="ISecretProvider"/> allows developers to build specific Secret key providers.
     /// </summary>
-    [Obsolete("Will be removed in v3.0 in favor a new interface 'Arcus.Security.ISecretProvider'")]
+    [Obsolete("Will be removed in v3.0 in favor a new interface 'Arcus.Security.ISecretProvider'", DiagnosticId = ObsoleteDefaults.DiagnosticId)]
     public interface ISecretProvider
     {
         /// <summary>
@@ -22,7 +22,7 @@ namespace Arcus.Security.Core
         /// <exception cref="ArgumentException">The <paramref name="secretName"/> must not be empty</exception>
         /// <exception cref="ArgumentNullException">The <paramref name="secretName"/> must not be null</exception>
         /// <exception cref="SecretNotFoundException">The secret was not found, using the given name</exception>
-        [Obsolete("Will be removed in v3 in favor of solely using " + nameof(GetSecretAsync) + " instead")]
+        [Obsolete("Will be removed in v3 in favor of solely using " + nameof(GetSecretAsync) + " instead", DiagnosticId = ObsoleteDefaults.DiagnosticId)]
         Task<string> GetRawSecretAsync(string secretName);
 
         /// <summary>
@@ -84,7 +84,7 @@ namespace Arcus.Security
         /// <exception cref="ArgumentException">The <paramref name="secretName"/> must not be empty</exception>
         /// <exception cref="ArgumentNullException">The <paramref name="secretName"/> must not be null</exception>
         /// <exception cref="SecretNotFoundException">The secret was not found, using the given name</exception>
-        [Obsolete("Will be removed in v3.0, please use the new " + nameof(ISecretProvider.GetSecretAsync) + " overloads with secret results")]
+        [Obsolete("Will be removed in v3.0, please use the new " + nameof(ISecretProvider.GetSecretAsync) + " overloads with secret results", DiagnosticId = ObsoleteDefaults.DiagnosticId)]
         public static async Task<Secret> GetSecretAsync(this ISecretProvider provider, string secretName)
         {
             return await provider.GetSecretAsync(secretName);
@@ -99,7 +99,7 @@ namespace Arcus.Security
         /// <exception cref="ArgumentException">The <paramref name="secretName"/> must not be empty</exception>
         /// <exception cref="ArgumentNullException">The <paramref name="secretName"/> must not be null</exception>
         /// <exception cref="SecretNotFoundException">The secret was not found, using the given name</exception>
-        [Obsolete("Will be removed in v3.0, please use the new " + nameof(ISecretProvider.GetSecret) + " overloads with secret results")]
+        [Obsolete("Will be removed in v3.0, please use the new " + nameof(ISecretProvider.GetSecret) + " overloads with secret results", DiagnosticId = ObsoleteDefaults.DiagnosticId)]
         public static Secret GetSecret(this ISecretProvider provider, string secretName)
         {
             return provider.GetSecret(secretName);
@@ -114,7 +114,7 @@ namespace Arcus.Security
         /// <exception cref="ArgumentException">The <paramref name="secretName"/> must not be empty</exception>
         /// <exception cref="ArgumentNullException">The <paramref name="secretName"/> must not be null</exception>
         /// <exception cref="SecretNotFoundException">The secret was not found, using the given name</exception>
-        [Obsolete("Will be removed in v3.0, please use the new " + nameof(ISecretProvider.GetSecretAsync) + " overloads with secret results")]
+        [Obsolete("Will be removed in v3.0, please use the new " + nameof(ISecretProvider.GetSecretAsync) + " overloads with secret results", DiagnosticId = ObsoleteDefaults.DiagnosticId)]
         public static async Task<string> GetRawSecretAsync(this ISecretProvider provider, string secretName)
         {
             Secret secret = await GetSecretAsync(provider, secretName);
@@ -130,7 +130,7 @@ namespace Arcus.Security
         /// <exception cref="ArgumentException">The <paramref name="secretName"/> must not be empty</exception>
         /// <exception cref="ArgumentNullException">The <paramref name="secretName"/> must not be null</exception>
         /// <exception cref="SecretNotFoundException">The secret was not found, using the given name</exception>
-        [Obsolete("Will be removed in v3.0, please use the new " + nameof(ISecretProvider.GetSecret) + " overloads with secret results")]
+        [Obsolete("Will be removed in v3.0, please use the new " + nameof(ISecretProvider.GetSecret) + " overloads with secret results", DiagnosticId = ObsoleteDefaults.DiagnosticId)]
         public static string GetRawSecret(this ISecretProvider provider, string secretName)
         {
             Secret secret = GetSecret(provider, secretName);
@@ -340,7 +340,7 @@ namespace Arcus.Security
         /// <summary>
         /// Converts the <see cref="SecretResult"/> to its deprecated previous implementation.
         /// </summary>
-        [Obsolete("Will be removed in v3.0 in favor of using secret results")]
+        [Obsolete("Will be removed in v3.0 in favor of using secret results", DiagnosticId = ObsoleteDefaults.DiagnosticId)]
 #pragma warning disable CS0618
         public static implicit operator Secret(SecretResult result)
 #pragma warning restore

--- a/src/Arcus.Security.Core/ISecretStore.cs
+++ b/src/Arcus.Security.Core/ISecretStore.cs
@@ -12,7 +12,7 @@ namespace Arcus.Security.Core
     /// <summary>
     /// Represents the exposed functionality of the secret store.
     /// </summary>
-    [Obsolete("Will be removed in v3.0 in favor of a new " + nameof(Security.ISecretStore) + " interface in the 'Arcus.Security' namespace")]
+    [Obsolete("Will be removed in v3.0 in favor of a new " + nameof(Security.ISecretStore) + " interface in the 'Arcus.Security' namespace", DiagnosticId = ObsoleteDefaults.DiagnosticId)]
     public interface ISecretStore
     {
         /// <summary>
@@ -149,7 +149,7 @@ namespace Arcus.Security
         /// <exception cref="KeyNotFoundException">Thrown when there was no <see cref="ISecretProvider"/> found in the secret store with the given <paramref name="name"/>.</exception>
         /// <exception cref="InvalidCastException">Thrown when the registered <see cref="ISecretProvider"/> cannot be cast to the specific <typeparamref name="TSecretProvider"/>.</exception>
         /// <exception cref="InvalidOperationException">Thrown when multiple <see cref="ISecretProvider"/> were registered with the same name.</exception>
-        [Obsolete("Will be removed in v3.0 in favor of a new interface 'Arcus.Security.ISecretProvider'")]
+        [Obsolete("Will be removed in v3.0 in favor of a new interface 'Arcus.Security.ISecretProvider'", DiagnosticId = ObsoleteDefaults.DiagnosticId)]
         public static TSecretProvider GetProvider<TSecretProvider>(this ISecretStore store, string name) where TSecretProvider : Core.ISecretProvider
         {
             var provider = store.GetProvider<ISecretProvider>(name);
@@ -172,7 +172,7 @@ namespace Arcus.Security
         ///     Thrown when their was either none of the registered secret providers are registered as <see cref="ICachedSecretProvider"/> instances
         ///     or there was an <see cref="ISecretProvider"/> registered but not with caching.
         /// </exception>
-        [Obsolete("Will be removed in v3.0 as secret caching will happen on the secret store itself")]
+        [Obsolete("Will be removed in v3.0 as secret caching will happen on the secret store itself", DiagnosticId = ObsoleteDefaults.DiagnosticId)]
         public static ICachedSecretProvider GetCachedProvider(this ISecretStore store, string name)
         {
             var provider = store.GetProvider<ISecretProvider>(name);
@@ -198,7 +198,7 @@ namespace Arcus.Security
         /// </exception>
         /// <exception cref="InvalidCastException">Thrown when the registered <see cref="ICachedSecretProvider"/> cannot be cast to the specific <typeparamref name="TCachedSecretProvider"/>.</exception>
         /// <exception cref="InvalidOperationException">Thrown when multiple <see cref="ICachedSecretProvider"/> were registered with the same name.</exception>
-        [Obsolete("Will be removed in v3.0 as secret caching will happen on the secret store itself")]
+        [Obsolete("Will be removed in v3.0 as secret caching will happen on the secret store itself", DiagnosticId = ObsoleteDefaults.DiagnosticId)]
         public static TCachedSecretProvider GetCachedProvider<TCachedSecretProvider>(this ISecretStore store, string name) where TCachedSecretProvider : ICachedSecretProvider
         {
             var provider = store.GetProvider<ISecretProvider>(name);

--- a/src/Arcus.Security.Core/ISyncSecretProvider.cs
+++ b/src/Arcus.Security.Core/ISyncSecretProvider.cs
@@ -5,7 +5,7 @@ namespace Arcus.Security.Core
     /// <summary>
     /// Represents an additional synchronous implementation on top of the <see cref="ISecretProvider"/>.
     /// </summary>
-    [Obsolete("Will be removed in v3.0 in favor of using the new secret provider interface which has already a synchronous variant of secret retrieval")]
+    [Obsolete("Will be removed in v3.0 in favor of using the new secret provider interface which has already a synchronous variant of secret retrieval", DiagnosticId = ObsoleteDefaults.DiagnosticId)]
     public interface ISyncSecretProvider : ISecretProvider
     {
         /// <summary>
@@ -15,7 +15,7 @@ namespace Arcus.Security.Core
         /// <returns>Returns the secret key.</returns>
         /// <exception cref="ArgumentException">Thrown when the <paramref name="secretName"/> is blank.</exception>
         /// <exception cref="SecretNotFoundException">Thrown when the secret was not found, using the given name.</exception>
-        [Obsolete("Will be removed in v3 in favor of solely using " + nameof(GetSecret) + " instead")]
+        [Obsolete("Will be removed in v3 in favor of solely using " + nameof(GetSecret) + " instead", DiagnosticId = ObsoleteDefaults.DiagnosticId)]
         string GetRawSecret(string secretName);
 
         /// <summary>

--- a/src/Arcus.Security.Core/IVersionedSecretProvider.cs
+++ b/src/Arcus.Security.Core/IVersionedSecretProvider.cs
@@ -7,7 +7,7 @@ namespace Arcus.Security.Core
     /// <summary>
     /// Represents an <see cref="ISecretProvider"/> implementation that supports multiple versions of a secret.
     /// </summary>
-    [Obsolete("Will be removed in v3.0 in favor of accessing versioned secrets on the concrete secret provider implementations")]
+    [Obsolete("Will be removed in v3.0 in favor of accessing versioned secrets on the concrete secret provider implementations", DiagnosticId = ObsoleteDefaults.DiagnosticId)]
     public interface IVersionedSecretProvider : ISecretProvider
     {
         /// <summary>

--- a/src/Arcus.Security.Core/Providers/ConfigurationSecretProvider.cs
+++ b/src/Arcus.Security.Core/Providers/ConfigurationSecretProvider.cs
@@ -53,7 +53,7 @@ namespace Arcus.Security.Core.Providers
         /// <exception cref="T:System.ArgumentException">The <paramref name="secretName" /> must not be empty</exception>
         /// <exception cref="T:System.ArgumentNullException">The <paramref name="secretName" /> must not be null</exception>
         /// <exception cref="T:Arcus.Security.Core.SecretNotFoundException">The secret was not found, using the given name</exception>
-        [Obsolete("Will be removed in v3.0 in favor of using secret results")]
+        [Obsolete("Will be removed in v3.0 in favor of using secret results", DiagnosticId = ObsoleteDefaults.DiagnosticId)]
         public Task<Secret> GetSecretAsync(string secretName)
         {
             Secret secret = GetSecret(secretName);
@@ -66,7 +66,7 @@ namespace Arcus.Security.Core.Providers
         /// <exception cref="T:System.ArgumentException">The <paramref name="secretName" /> must not be empty</exception>
         /// <exception cref="T:System.ArgumentNullException">The <paramref name="secretName" /> must not be null</exception>
         /// <exception cref="T:Arcus.Security.Core.SecretNotFoundException">The secret was not found, using the given name</exception>
-        [Obsolete("Will be removed in v3 in favor of solely using " + nameof(GetSecretAsync) + " instead")]
+        [Obsolete("Will be removed in v3 in favor of solely using " + nameof(GetSecretAsync) + " instead", DiagnosticId = ObsoleteDefaults.DiagnosticId)]
         public Task<string> GetRawSecretAsync(string secretName)
         {
             string secretValue = GetRawSecret(secretName);
@@ -80,7 +80,7 @@ namespace Arcus.Security.Core.Providers
         /// <returns>Returns a <see cref="Secret"/> that contains the secret key</returns>
         /// <exception cref="ArgumentException">Thrown when the <paramref name="secretName"/> is blank.</exception>
         /// <exception cref="SecretNotFoundException">Thrown when the secret was not found, using the given name.</exception>
-        [Obsolete("Will be removed in v3.0 in favor of using secret results")]
+        [Obsolete("Will be removed in v3.0 in favor of using secret results", DiagnosticId = ObsoleteDefaults.DiagnosticId)]
         public Secret GetSecret(string secretName)
         {
             SecretResult result = ((Security.ISecretProvider) this).GetSecret(secretName);
@@ -94,7 +94,7 @@ namespace Arcus.Security.Core.Providers
         /// <returns>Returns the secret key.</returns>
         /// <exception cref="ArgumentException">Thrown when the <paramref name="secretName"/> is blank.</exception>
         /// <exception cref="SecretNotFoundException">Thrown when the secret was not found, using the given name.</exception>
-        [Obsolete("Will be removed in v3 in favor of solely using " + nameof(GetSecret) + " instead")]
+        [Obsolete("Will be removed in v3 in favor of solely using " + nameof(GetSecret) + " instead", DiagnosticId = ObsoleteDefaults.DiagnosticId)]
         public string GetRawSecret(string secretName)
         {
             return GetSecret(secretName)?.Value;

--- a/src/Arcus.Security.Core/Providers/EnvironmentVariableSecretProvider.cs
+++ b/src/Arcus.Security.Core/Providers/EnvironmentVariableSecretProvider.cs
@@ -60,7 +60,7 @@ namespace Arcus.Security.Core.Providers
         /// <param name="target">The target on which the environment variables should be retrieved.</param>
         /// <param name="prefix">The optional prefix which will be prepended to the secret name when retrieving environment variables.</param>
         /// <exception cref="ArgumentException">Thrown when the <paramref name="target"/> is outside the bounds of the enumeration.</exception>
-        [Obsolete("Will be removed in v3.0 in favor of internal constructor")]
+        [Obsolete("Will be removed in v3.0 in favor of internal constructor", DiagnosticId = ObsoleteDefaults.DiagnosticId)]
         public EnvironmentVariableSecretProvider(EnvironmentVariableTarget target = DefaultTarget, string prefix = null)
         {
             if (!Enum.IsDefined(typeof(EnvironmentVariableTarget), target))
@@ -107,7 +107,7 @@ namespace Arcus.Security.Core.Providers
         /// <exception cref="T:System.ArgumentException">The <paramref name="secretName" /> must not be empty</exception>
         /// <exception cref="T:System.ArgumentNullException">The <paramref name="secretName" /> must not be null</exception>
         /// <exception cref="T:Arcus.Security.Core.SecretNotFoundException">The secret was not found, using the given name</exception>
-        [Obsolete("Will be removed in v3.0 in favor of using secret results")]
+        [Obsolete("Will be removed in v3.0 in favor of using secret results", DiagnosticId = ObsoleteDefaults.DiagnosticId)]
         public Task<Secret> GetSecretAsync(string secretName)
         {
             Secret secret = GetSecret(secretName);
@@ -122,7 +122,7 @@ namespace Arcus.Security.Core.Providers
         /// <exception cref="T:System.ArgumentException">The <paramref name="secretName" /> must not be empty</exception>
         /// <exception cref="T:System.ArgumentNullException">The <paramref name="secretName" /> must not be null</exception>
         /// <exception cref="T:Arcus.Security.Core.SecretNotFoundException">The secret was not found, using the given name</exception>
-        [Obsolete("Will be removed in v3 in favor of solely using " + nameof(GetSecretAsync) + " instead")]
+        [Obsolete("Will be removed in v3 in favor of solely using " + nameof(GetSecretAsync) + " instead", DiagnosticId = ObsoleteDefaults.DiagnosticId)]
         public Task<string> GetRawSecretAsync(string secretName)
         {
             string secretValue = GetRawSecret(secretName);
@@ -136,7 +136,7 @@ namespace Arcus.Security.Core.Providers
         /// <returns>Returns a <see cref="Secret"/> that contains the secret key</returns>
         /// <exception cref="ArgumentException">Thrown when the <paramref name="secretName"/> is blank.</exception>
         /// <exception cref="SecretNotFoundException">Thrown when the secret was not found, using the given name.</exception>
-        [Obsolete("Will be removed in v3.0 in favor of using secret results")]
+        [Obsolete("Will be removed in v3.0 in favor of using secret results", DiagnosticId = ObsoleteDefaults.DiagnosticId)]
         public Secret GetSecret(string secretName)
         {
             SecretResult result = ((Security.ISecretProvider) this).GetSecret(secretName);
@@ -150,7 +150,7 @@ namespace Arcus.Security.Core.Providers
         /// <returns>Returns the secret key.</returns>
         /// <exception cref="ArgumentException">Thrown when the <paramref name="secretName"/> is blank.</exception>
         /// <exception cref="SecretNotFoundException">Thrown when the secret was not found, using the given name.</exception>
-        [Obsolete("Will be removed in v3 in favor of solely using " + nameof(GetSecret) + " instead")]
+        [Obsolete("Will be removed in v3 in favor of solely using " + nameof(GetSecret) + " instead", DiagnosticId = ObsoleteDefaults.DiagnosticId)]
         public string GetRawSecret(string secretName)
         {
             return GetSecret(secretName)?.Value;

--- a/src/Arcus.Security.Core/Providers/MutatedSecretNameCachedSecretProvider.cs
+++ b/src/Arcus.Security.Core/Providers/MutatedSecretNameCachedSecretProvider.cs
@@ -9,7 +9,7 @@ namespace Arcus.Security.Core.Providers
     /// <summary>
     /// Represents an <see cref="ICachedSecretProvider"/> that can mutate the secret name provided before looking up the secret.
     /// </summary>
-    [Obsolete("Will be removed in v3.0 in favor of moving secret name mutation solely in secret provider registration options")]
+    [Obsolete("Will be removed in v3.0 in favor of moving secret name mutation solely in secret provider registration options", DiagnosticId = ObsoleteDefaults.DiagnosticId)]
     public class MutatedSecretNameCachedSecretProvider : MutatedSecretNameSecretProvider, ICachedSecretProvider
     {
         private readonly ICachedSecretProvider _implementation;
@@ -51,7 +51,7 @@ namespace Arcus.Security.Core.Providers
         /// <exception cref="ArgumentException">The name must not be empty</exception>
         /// <exception cref="ArgumentNullException">The name must not be null</exception>
         /// <exception cref="SecretNotFoundException">The secret was not found, using the given name</exception>
-        [Obsolete("Will be removed in v3 in favor of solely using " + nameof(GetSecretAsync) + " instead")]
+        [Obsolete("Will be removed in v3 in favor of solely using " + nameof(GetSecretAsync) + " instead", DiagnosticId = ObsoleteDefaults.DiagnosticId)]
         public async Task<string> GetRawSecretAsync(string secretName, bool ignoreCache)
         {
             if (string.IsNullOrWhiteSpace(secretName))

--- a/src/Arcus.Security.Core/Providers/MutatedSecretNameSecretProvider.cs
+++ b/src/Arcus.Security.Core/Providers/MutatedSecretNameSecretProvider.cs
@@ -8,7 +8,7 @@ namespace Arcus.Security.Core.Providers
     /// <summary>
     /// Represents an <see cref="ISecretProvider"/> that can mutate the secret name provided before looking up the secret.
     /// </summary>
-    [Obsolete("Will be removed in v3.0 in favor of moving secret name mutation solely in secret provider registration options")]
+    [Obsolete("Will be removed in v3.0 in favor of moving secret name mutation solely in secret provider registration options", DiagnosticId = ObsoleteDefaults.DiagnosticId)]
     public class MutatedSecretNameSecretProvider : ISyncSecretProvider
     {
         private readonly Func<string, string> _mutateSecretName;
@@ -54,7 +54,7 @@ namespace Arcus.Security.Core.Providers
         /// <exception cref="ArgumentException">The <paramref name="secretName"/> must not be empty</exception>
         /// <exception cref="ArgumentNullException">The <paramref name="secretName"/> must not be null</exception>
         /// <exception cref="SecretNotFoundException">The secret was not found, using the given name</exception>
-        [Obsolete("Will be removed in v3 in favor of solely using " + nameof(GetSecretAsync) + " instead")]
+        [Obsolete("Will be removed in v3 in favor of solely using " + nameof(GetSecretAsync) + " instead", DiagnosticId = ObsoleteDefaults.DiagnosticId)]
         public async Task<string> GetRawSecretAsync(string secretName)
         {
             if (string.IsNullOrWhiteSpace(secretName))
@@ -100,7 +100,7 @@ namespace Arcus.Security.Core.Providers
         /// <returns>Returns the secret key.</returns>
         /// <exception cref="ArgumentException">Thrown when the <paramref name="secretName"/> is blank.</exception>
         /// <exception cref="SecretNotFoundException">Thrown when the secret was not found, using the given name.</exception>
-        [Obsolete("Will be removed in v3 in favor of solely using " + nameof(GetSecretAsync) + " instead")]
+        [Obsolete("Will be removed in v3 in favor of solely using " + nameof(GetSecretAsync) + " instead", DiagnosticId = ObsoleteDefaults.DiagnosticId)]
         public string GetRawSecret(string secretName)
         {
             if (string.IsNullOrWhiteSpace(secretName))

--- a/src/Arcus.Security.Core/Secret.cs
+++ b/src/Arcus.Security.Core/Secret.cs
@@ -5,7 +5,7 @@ namespace Arcus.Security.Core
     /// <summary>
     /// Represents the secret returned from the <see cref="ISecretProvider"/> implementation.
     /// </summary>
-    [Obsolete("Will be removed in v3.0 in favor of using secret results")]
+    [Obsolete("Will be removed in v3.0 in favor of using secret results", DiagnosticId = ObsoleteDefaults.DiagnosticId)]
     public class Secret
     {
         /// <summary>

--- a/src/Arcus.Security.Core/SecretNotFoundException.cs
+++ b/src/Arcus.Security.Core/SecretNotFoundException.cs
@@ -5,7 +5,7 @@ namespace Arcus.Security.Core
     /// <summary>
     /// Exception, thrown when no secret was found, using the given name.
     /// </summary>
-    [Obsolete("Will be removed in v3.0 in favor of using secret results")]
+    [Obsolete("Will be removed in v3.0 in favor of using secret results", DiagnosticId = ObsoleteDefaults.DiagnosticId)]
     public class SecretNotFoundException : Exception
     {
         /// <summary>

--- a/src/Arcus.Security.Core/SecretProviderOptions.cs
+++ b/src/Arcus.Security.Core/SecretProviderOptions.cs
@@ -7,7 +7,7 @@ namespace Arcus.Security.Core
     /// <summary>
     /// Represents the additional options to register an <see cref="ISecretProvider"/> implementation to the secret store.
     /// </summary>
-    [Obsolete("Will be removed in v3.0 in favor of a new " + nameof(SecretProviderRegistrationOptions) + " model")]
+    [Obsolete("Will be removed in v3.0 in favor of a new " + nameof(SecretProviderRegistrationOptions) + " model", DiagnosticId = ObsoleteDefaults.DiagnosticId)]
     public class SecretProviderOptions
     {
         private readonly IDictionary<string, int> _versionedSecretNames = new Dictionary<string, int>();

--- a/src/Arcus.Security.Core/SecretStoreAuditingOptions.cs
+++ b/src/Arcus.Security.Core/SecretStoreAuditingOptions.cs
@@ -5,7 +5,7 @@ namespace Arcus.Security.Core
     /// <summary>
     /// Represents configurable options related to auditing during the lifetime of the secret store.
     /// </summary>
-    [Obsolete("Will be removed in v3.0 as the hard-link to Arcus.Observability will be removed")]
+    [Obsolete("Will be removed in v3.0 as the hard-link to Arcus.Observability will be removed", DiagnosticId = ObsoleteDefaults.DiagnosticId)]
     public class SecretStoreAuditingOptions
     {
         /// <summary>

--- a/src/Arcus.Security.Core/SecretStoreBuilder.cs
+++ b/src/Arcus.Security.Core/SecretStoreBuilder.cs
@@ -51,7 +51,7 @@ namespace Microsoft.Extensions.Hosting
         ///     The series of secret stores is directly publicly available, including the operations so future (consumer) extensions can easily low-level manipulate this series during build-up.
         ///     Though, for almost all use-cases, the <see cref="AddProvider(ISecretProvider)"/> and the <see cref="AddProvider(Func{IServiceProvider,ISecretProvider},Action{SecretProviderOptions})"/> should be sufficient.
         /// </remarks>
-        [Obsolete("Will be removed in v3.0 as secret providers are registered internally")]
+        [Obsolete("Will be removed in v3.0 as secret providers are registered internally", DiagnosticId = ObsoleteDefaults.DiagnosticId)]
         public IList<SecretStoreSource> SecretStoreSources { get; } = new List<SecretStoreSource>();
 
         /// <summary>
@@ -62,7 +62,7 @@ namespace Microsoft.Extensions.Hosting
         ///     The series of exception filters is directly publicly available including the operations so future (consumer) extensions can easily low-level manipulate this series during build-up.
         ///     Though, for almost all use-cases, the <see cref="AddCriticalException{TException}()"/> and <see cref="AddCriticalException{TException}(Func{TException,bool})"/> should be sufficient.
         /// </remarks>
-        [Obsolete("Will be removed in v3.0 as secret results are capturing failures")]
+        [Obsolete("Will be removed in v3.0 as secret results are capturing failures", DiagnosticId = ObsoleteDefaults.DiagnosticId)]
         public IList<CriticalExceptionFilter> CriticalExceptionFilters { get; } = new List<CriticalExceptionFilter>();
 
         /// <summary>
@@ -73,7 +73,7 @@ namespace Microsoft.Extensions.Hosting
         ///     The extended secret store with the given <paramref name="secretProvider"/>.
         /// </returns>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="secretProvider"/> is <c>null</c>.</exception>
-        [Obsolete("Will be removed in v3.0 in favor of using a new interface 'Arcus.Security.ISecretProvider'")]
+        [Obsolete("Will be removed in v3.0 in favor of using a new interface 'Arcus.Security.ISecretProvider'", DiagnosticId = ObsoleteDefaults.DiagnosticId)]
         public SecretStoreBuilder AddProvider(ISecretProvider secretProvider)
         {
             return AddProvider(secretProvider ?? throw new ArgumentNullException(nameof(secretProvider)), configureOptions: null);
@@ -88,7 +88,7 @@ namespace Microsoft.Extensions.Hosting
         ///     The extended secret store with the given <paramref name="secretProvider"/>.
         /// </returns>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="secretProvider"/> is <c>null</c>.</exception>
-        [Obsolete("Will be removed in v3.0 in favor of using a new interface 'Arcus.Security.ISecretProvider'")]
+        [Obsolete("Will be removed in v3.0 in favor of using a new interface 'Arcus.Security.ISecretProvider'", DiagnosticId = ObsoleteDefaults.DiagnosticId)]
         public SecretStoreBuilder AddProvider(
             ISecretProvider secretProvider,
             Action<SecretProviderOptions> configureOptions)
@@ -127,7 +127,7 @@ namespace Microsoft.Extensions.Hosting
         ///     The extended secret store with the given <paramref name="createSecretProvider"/> as lazy initialization.
         /// </returns>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="createSecretProvider"/> is <c>null</c>.</exception>
-        [Obsolete("Will be removed in v3.0, please use the new " + nameof(ISecretProvider) + " in the 'Arcus.Security' namespace")]
+        [Obsolete("Will be removed in v3.0, please use the new " + nameof(ISecretProvider) + " in the 'Arcus.Security' namespace", DiagnosticId = ObsoleteDefaults.DiagnosticId)]
         public SecretStoreBuilder AddProvider(Func<IServiceProvider, ISecretProvider> createSecretProvider)
         {
             return AddProvider(createSecretProvider, configureOptions: null);
@@ -142,7 +142,7 @@ namespace Microsoft.Extensions.Hosting
         ///     The extended secret store with the given <paramref name="createSecretProvider"/> as lazy initialization.
         /// </returns>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="createSecretProvider"/> is <c>null</c>.</exception>
-        [Obsolete("Will be removed in v3.0 in favor of using a new interface 'Arcus.Security.ISecretProvider'")]
+        [Obsolete("Will be removed in v3.0 in favor of using a new interface 'Arcus.Security.ISecretProvider'", DiagnosticId = ObsoleteDefaults.DiagnosticId)]
         public SecretStoreBuilder AddProvider(
             Func<IServiceProvider, ISecretProvider> createSecretProvider,
             Action<SecretProviderOptions> configureOptions)
@@ -304,7 +304,7 @@ namespace Microsoft.Extensions.Hosting
         /// which makes sure that the secret store handles all exceptions of type <typeparamref name="TException"/> differently.
         /// </summary>
         /// <typeparam name="TException">The type of the <see cref="Exception"/> to add as critical exception.</typeparam>
-        [Obsolete("Will be removed in v3.0 in favor of using secret results")]
+        [Obsolete("Will be removed in v3.0 in favor of using secret results", DiagnosticId = ObsoleteDefaults.DiagnosticId)]
         public SecretStoreBuilder AddCriticalException<TException>() where TException : Exception
         {
             CriticalExceptionFilters.Add(new CriticalExceptionFilter(typeof(TException), exception => exception is TException));
@@ -318,7 +318,7 @@ namespace Microsoft.Extensions.Hosting
         /// <typeparam name="TException">The type of the <see cref="Exception"/> to add as critical exception.</typeparam>
         /// <param name="exceptionFilter">The filter that makes sure that only specific <typeparamref name="TException"/>'s are considered critical exceptions.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="exceptionFilter"/> is <c>null</c>.</exception>
-        [Obsolete("Will be removed in v3.0 in favor of using secret results")]
+        [Obsolete("Will be removed in v3.0 in favor of using secret results", DiagnosticId = ObsoleteDefaults.DiagnosticId)]
         public SecretStoreBuilder AddCriticalException<TException>(Func<TException, bool> exceptionFilter) where TException : Exception
         {
             if (exceptionFilter is null)
@@ -344,7 +344,7 @@ namespace Microsoft.Extensions.Hosting
         /// </summary>
         /// <param name="configureOptions">The function to customize the auditing options of the secret store.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="configureOptions"/> is <c>null</c>.</exception>
-        [Obsolete("Will be removed in v3.0 as the hard-link to Arcus.Observability will be removed")]
+        [Obsolete("Will be removed in v3.0 as the hard-link to Arcus.Observability will be removed", DiagnosticId = ObsoleteDefaults.DiagnosticId)]
         public SecretStoreBuilder WithAuditing(Action<SecretStoreAuditingOptions> configureOptions)
         {
             _configureAuditingOptions.Add(configureOptions ?? throw new ArgumentNullException(nameof(configureOptions)));

--- a/src/Arcus.Security.Core/SecretStoreSource.cs
+++ b/src/Arcus.Security.Core/SecretStoreSource.cs
@@ -10,7 +10,7 @@ namespace Arcus.Security.Core
     /// <summary>
     /// Represents an entry for an <see cref="ISecretProvider"/> implementation.
     /// </summary>
-    [Obsolete("Will be removed in v3.0 in favor of internal secret provider registration")]
+    [Obsolete("Will be removed in v3.0 in favor of internal secret provider registration", DiagnosticId = ObsoleteDefaults.DiagnosticId)]
     public class SecretStoreSource
     {
         private readonly Func<IServiceProvider, ISecretProvider> _createSecretProvider;

--- a/src/Arcus.Security.sln
+++ b/src/Arcus.Security.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 17
-VisualStudioVersion = 17.0.32126.317
+# Visual Studio Version 18
+VisualStudioVersion = 18.2.11430.68 d18.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Arcus.Security.Tests.Unit", "Arcus.Security.Tests.Unit\Arcus.Security.Tests.Unit.csproj", "{DACBC3C6-2894-4961-B327-746BC29229CC}"
 EndProject
@@ -28,6 +28,7 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{8EC462FD-D22E-90A8-E5CE-7E832BA40C5D}"
 	ProjectSection(SolutionItems) = preProject
 		.editorconfig = .editorconfig
+		ObsoleteDefaults.cs = ObsoleteDefaults.cs
 	EndProjectSection
 EndProject
 Global

--- a/src/ObsoleteDefaults.cs
+++ b/src/ObsoleteDefaults.cs
@@ -1,0 +1,13 @@
+﻿namespace Arcus.Security
+{
+    /// <summary>
+    /// Represents the deprecation defaults used throughout deprecated Arcus functionality.
+    /// </summary>
+    internal static class ObsoleteDefaults
+    {
+        /// <summary>
+        /// Gets the diagnostic identifier to group Arcus deprecated functionality.
+        /// </summary>
+        internal const string DiagnosticId = "ARCUS";
+    }
+}


### PR DESCRIPTION
Use a centralized diagnostic ID for all the deprecation messages, making intent and source more clear.

